### PR TITLE
Logging improvements

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
-log4j.rootLogger=DEBUG, CONSOLE
+log4j.rootLogger=INFO, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=APP %t %c: %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %d %t %c - %m%n
 


### PR DESCRIPTION
For now, when artipie is started, a huge amount of mess is thrown into a console:
```
$ docker run -v /tmp/artipie:/var/artipie -p80:80 artipie:local
APP main io.netty.util.internal.logging.InternalLoggerFactory: Using SLF4J as the default logging framework
APP main io.netty.util.ResourceLeakDetector: -Dio.netty.leakDetection.level: simple
APP main io.netty.util.ResourceLeakDetector: -Dio.netty.leakDetection.targetRecords: 4
APP main io.netty.util.internal.InternalThreadLocalMap: -Dio.netty.threadLocalMap.stringBuilder.initialSize: 1024
APP main io.netty.util.internal.InternalThreadLocalMap: -Dio.netty.threadLocalMap.stringBuilder.maxSize: 4096
APP main io.netty.channel.MultithreadEventLoopGroup: -Dio.netty.eventLoopThreads: 16
APP main io.netty.channel.nio.NioEventLoop: -Dio.netty.noKeySetOptimization: false
APP main io.netty.channel.nio.NioEventLoop: -Dio.netty.selectorAutoRebuildThreshold: 512
APP main io.netty.util.internal.PlatformDependent0: -Dio.netty.noUnsafe: false
APP main io.netty.util.internal.PlatformDependent0: Java version: 13
APP main io.netty.util.internal.PlatformDependent0: sun.misc.Unsafe.theUnsafe: available
APP main io.netty.util.internal.PlatformDependent0: sun.misc.Unsafe.copyMemory: available
APP main io.netty.util.internal.PlatformDependent0: java.nio.Buffer.address: available
APP main io.netty.util.internal.PlatformDependent0: direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
	at io.netty.util.internal.ReflectionUtil.trySetAccessible(ReflectionUtil.java:31)
	at io.netty.util.internal.PlatformDependent0$4.run(PlatformDependent0.java:224)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:218)
	at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:272)
	at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:92)
	at io.netty.channel.nio.NioEventLoop.newTaskQueue0(NioEventLoop.java:285)
	at io.netty.channel.nio.NioEventLoop.newTaskQueue(NioEventLoop.java:156)
	at io.netty.channel.nio.NioEventLoop.<init>(NioEventLoop.java:138)
	at io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:138)
	at io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:37)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:58)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:47)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:78)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:73)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:60)
	at io.vertx.core.net.impl.transport.Transport.eventLoopGroup(Transport.java:153)
	at io.vertx.core.impl.VertxImpl.<init>(VertxImpl.java:143)
	at io.vertx.core.impl.VertxImpl.vertx(VertxImpl.java:92)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:40)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:32)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:27)
	at io.vertx.core.Vertx.vertx(Vertx.java:75)
	at io.vertx.reactivex.core.Vertx.vertx(Vertx.java:118)
	at com.artipie.vertx.VertxSliceServer.<init>(VertxSliceServer.java:93)
	at com.artipie.VertxMain.run(VertxMain.java:68)
	at com.artipie.VertxMain.main(VertxMain.java:117)
APP main io.netty.util.internal.PlatformDependent0: java.nio.Bits.unaligned: available, true
APP main io.netty.util.internal.PlatformDependent0: jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable
java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @1f28c152
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Unknown Source)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at io.netty.util.internal.PlatformDependent0$6.run(PlatformDependent0.java:334)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at io.netty.util.internal.PlatformDependent0.<clinit>(PlatformDependent0.java:325)
	at io.netty.util.internal.PlatformDependent.isAndroid(PlatformDependent.java:272)
	at io.netty.util.internal.PlatformDependent.<clinit>(PlatformDependent.java:92)
	at io.netty.channel.nio.NioEventLoop.newTaskQueue0(NioEventLoop.java:285)
	at io.netty.channel.nio.NioEventLoop.newTaskQueue(NioEventLoop.java:156)
	at io.netty.channel.nio.NioEventLoop.<init>(NioEventLoop.java:138)
	at io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:138)
	at io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:37)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:58)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:47)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:78)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:73)
	at io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:60)
	at io.vertx.core.net.impl.transport.Transport.eventLoopGroup(Transport.java:153)
	at io.vertx.core.impl.VertxImpl.<init>(VertxImpl.java:143)
	at io.vertx.core.impl.VertxImpl.vertx(VertxImpl.java:92)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:40)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:32)
	at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:27)
	at io.vertx.core.Vertx.vertx(Vertx.java:75)
	at io.vertx.reactivex.core.Vertx.vertx(Vertx.java:118)
	at com.artipie.vertx.VertxSliceServer.<init>(VertxSliceServer.java:93)
	at com.artipie.VertxMain.run(VertxMain.java:68)
	at com.artipie.VertxMain.main(VertxMain.java:117)
APP main io.netty.util.internal.PlatformDependent0: java.nio.DirectByteBuffer.<init>(long, int): unavailable
APP main io.netty.util.internal.PlatformDependent: sun.misc.Unsafe: available
APP main io.netty.util.internal.PlatformDependent: maxDirectMemory: 522190848 bytes (maybe)
APP main io.netty.util.internal.PlatformDependent: -Dio.netty.tmpdir: /tmp (java.io.tmpdir)
APP main io.netty.util.internal.PlatformDependent: -Dio.netty.bitMode: 64 (sun.arch.data.model)
APP main io.netty.util.internal.PlatformDependent: -Dio.netty.maxDirectMemory: -1 bytes
APP main io.netty.util.internal.PlatformDependent: -Dio.netty.uninitializedArrayAllocationThreshold: -1
APP main io.netty.util.internal.CleanerJava9: java.nio.ByteBuffer.cleaner(): available
APP main io.netty.util.internal.PlatformDependent: -Dio.netty.noPreferDirect: false
APP main io.netty.util.internal.PlatformDependent: org.jctools-core.MpscChunkedArrayQueue: available
APP main io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider: Default DNS servers: [/192.168.65.1:53] (sun.net.dns.ResolverConfiguration)
APP main io.netty.util.NetUtil: -Djava.net.preferIPv4Stack: false
APP main io.netty.util.NetUtil: -Djava.net.preferIPv6Addresses: false
APP main io.netty.util.NetUtil: Loopback interface: lo (lo, 127.0.0.1)
APP main io.netty.util.NetUtil: /proc/sys/net/core/somaxconn: 128
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.numHeapArenas: 5
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.numDirectArenas: 5
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.pageSize: 8192
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.maxOrder: 11
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.chunkSize: 16777216
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.tinyCacheSize: 512
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.smallCacheSize: 256
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.normalCacheSize: 64
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.maxCachedBufferCapacity: 32768
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.cacheTrimInterval: 8192
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.cacheTrimIntervalMillis: 0
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.useCacheForAllThreads: true
APP main io.netty.buffer.PooledByteBufAllocator: -Dio.netty.allocator.maxCachedByteBuffersPerChunk: 1023
APP main io.netty.channel.DefaultChannelId: -Dio.netty.processId: 1 (auto-detected)
APP main io.netty.channel.DefaultChannelId: -Dio.netty.machineId: 02:42:ac:ff:fe:11:00:02 (auto-detected)
APP main io.netty.buffer.ByteBufUtil: -Dio.netty.allocator.type: pooled
APP main io.netty.buffer.ByteBufUtil: -Dio.netty.threadLocalDirectBufferSize: 0
APP main io.netty.buffer.ByteBufUtil: -Dio.netty.maxThreadLocalCharBufferSize: 16384
APP vert.x-eventloop-thread-1 io.netty.util.Recycler: -Dio.netty.recycler.maxCapacityPerThread: 4096
APP vert.x-eventloop-thread-1 io.netty.util.Recycler: -Dio.netty.recycler.maxSharedCapacityFactor: 2
APP vert.x-eventloop-thread-1 io.netty.util.Recycler: -Dio.netty.recycler.linkCapacity: 16
APP vert.x-eventloop-thread-1 io.netty.util.Recycler: -Dio.netty.recycler.ratio: 8
APP vert.x-eventloop-thread-1 io.netty.buffer.AbstractByteBuf: -Dio.netty.buffer.checkAccessible: true
APP vert.x-eventloop-thread-1 io.netty.buffer.AbstractByteBuf: -Dio.netty.buffer.checkBounds: true
APP vert.x-eventloop-thread-1 io.netty.util.ResourceLeakDetectorFactory: Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@734cc2e2
```
The Pull Request fixes the problem and improves logging layout, by printing log priority and date