### PR TITLE
#119 - Response status code 413 when Content-Length is above limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.8.3</version>
+      <version>0.8.7</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/ContentLengthRestriction.java
+++ b/src/main/java/com/artipie/ContentLengthRestriction.java
@@ -72,7 +72,7 @@ public final class ContentLengthRestriction implements Slice {
         if (new RqHeaders(headers, "Content-Length").stream().allMatch(this::withinLimit)) {
             response = this.delegate.response(line, headers, body);
         } else {
-            response = new RsWithStatus(RsStatus.BAD_REQUEST);
+            response = new RsWithStatus(RsStatus.PAYLOAD_TOO_LARGE);
         }
         return response;
     }

--- a/src/test/java/com/artipie/ContentLengthRestrictionTest.java
+++ b/src/test/java/com/artipie/ContentLengthRestrictionTest.java
@@ -51,7 +51,7 @@ class ContentLengthRestrictionTest {
             limit
         );
         final Response response = slice.response("", this.headers("11"), Flowable.empty());
-        MatcherAssert.assertThat(response, new RsHasStatus(RsStatus.BAD_REQUEST));
+        MatcherAssert.assertThat(response, new RsHasStatus(RsStatus.PAYLOAD_TOO_LARGE));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Part of #119 
Response status code 413 when Content-Length is above limit instead of 400