### PR TITLE
implement job to start benchmarks on release

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,27 @@
+name: Artipie Benchmarks
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+      - name: Run benchmarks
+        uses: artipie/benchmarks@master
+        with:
+          aws-access-key: '${{ secrets.PERF_AWS_ACCESS_KEY }}'
+          aws-secret-key: '${{ secrets.PERF_AWS_SECRET_KEY }}'
+          adapter: 'files'
+          scenario: 'upload-files.jmx'
+          version: '${{ github.event.release.tag_name }}'
+      - name: Publish reports
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: report
+          TARGET_FOLDER: benchmarks/${{ github.event.release.tag_name }}/files/upload


### PR DESCRIPTION
For https://github.com/artipie/benchmarks/issues/12.

Firstly, this PR is required to be merged:
https://github.com/artipie/benchmarks/pull/15

Then 2 secrets must be created in the artipie repo:
PERF_AWS_ACCESS_KEY 
PERF_AWS_SECRET_KEY
It's AWS credentials to create performance tests environment.

Then current PR can be merged