### PR TITLE
Support hierarchical paths for repos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ meta:
     path: /var/artipie/repo
   credentials:
     type: env
+  layout: flat

--- a/src/main/java/com/artipie/Pie.java
+++ b/src/main/java/com/artipie/Pie.java
@@ -24,23 +24,19 @@
 
 package com.artipie;
 
-import com.artipie.asto.Key;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
-import com.artipie.http.async.AsyncSlice;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
-import com.artipie.http.slice.SliceSimple;
 import com.jcabi.log.Logger;
 import io.vertx.reactivex.core.Vertx;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import org.cactoos.scalar.Unchecked;
 import org.reactivestreams.Publisher;
 
 /**
@@ -85,42 +81,17 @@ public final class Pie implements Slice {
         if (path.equals("/") || parts.length == 0) {
             return new RsWithStatus(RsStatus.NO_CONTENT);
         }
-        final String repo = parts[0];
-        Logger.debug(this, "Slice repo=%s", repo);
-        final Key.From key = new Key.From(String.format("%s.yaml", repo));
-        return new AsyncSlice(
-            CompletableFuture.supplyAsync(
-                () -> new Unchecked<>(this.settings::storage).value()
-            ).thenCompose(
-                storage -> storage.exists(key).thenApply(
-                    exist -> {
-                        final Slice slice;
-                        if (exist) {
-                            slice = new AsyncSlice(
-                                storage.value(key).thenCombine(
-                                    new Unchecked<>(this.settings::auth).value(),
-                                    (content, auth) -> new SliceFromConfig(
-                                        new RepoConfig(repo, content),
-                                        this.vertx,
-                                        auth
-                                    )
-                                )
-                            );
-                        } else {
-                            slice = new SliceSimple(
-                                new RsWithStatus(
-                                    new RsWithBody(
-                                        String.format("Repository '%s' was not found", repo),
-                                        StandardCharsets.UTF_8
-                                    ),
-                                    RsStatus.NOT_FOUND
-                                )
-                            );
-                        }
-                        return slice;
-                    }
-                )
-            )
-        ).response(line, headers, body);
+        try {
+            return this.settings.layout(this.vertx).resolve(path).response(line, headers, body);
+        } catch (final IOException err) {
+            Logger.error(this, "Failed to read settings layout: %[exception]s", err);
+            return new RsWithStatus(
+                new RsWithBody(
+                    String.format("Failed to read Artipie settings: %s", err.getMessage()),
+                    StandardCharsets.UTF_8
+                ),
+                RsStatus.INTERNAL_ERROR
+            );
+        }
     }
 }

--- a/src/main/java/com/artipie/RepoConfig.java
+++ b/src/main/java/com/artipie/RepoConfig.java
@@ -50,9 +50,9 @@ import org.reactivestreams.Publisher;
 public final class RepoConfig {
 
     /**
-     * Repo name.
+     * Storage prefix.
      */
-    private final String repo;
+    private final Key prefix;
 
     /**
      * Source yaml future.
@@ -61,11 +61,11 @@ public final class RepoConfig {
 
     /**
      * Ctor.
-     * @param repo Repository name
+     * @param prefix Storage prefix
      * @param content Flow content
      */
-    public RepoConfig(final String repo, final Publisher<ByteBuffer> content) {
-        this.repo = repo;
+    public RepoConfig(final Key prefix, final Publisher<ByteBuffer> content) {
+        this.prefix = prefix;
         this.yaml = RepoConfig.yamlFromPublisher(content);
     }
 
@@ -123,7 +123,7 @@ public final class RepoConfig {
             .thenApply(map -> map.yamlMapping("storage"))
             .thenApply(YamlStorageSettings::new)
             .thenApply(YamlStorageSettings::storage)
-            .thenApply(storage -> new SubStorage(new Key.From(this.repo), storage));
+            .thenApply(storage -> new SubStorage(this.prefix, storage));
     }
 
     /**

--- a/src/main/java/com/artipie/Settings.java
+++ b/src/main/java/com/artipie/Settings.java
@@ -26,6 +26,9 @@ package com.artipie;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.auth.Authentication;
+import com.artipie.repo.FlatLayout;
+import com.artipie.repo.RepoLayout;
+import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
 
@@ -35,6 +38,7 @@ import java.util.concurrent.CompletionStage;
  * @since 0.1
  */
 public interface Settings {
+
     /**
      * Provides a storage.
      *
@@ -50,6 +54,14 @@ public interface Settings {
      * @throws IOException On Error
      */
     CompletionStage<Authentication> auth() throws IOException;
+
+    /**
+     * Repository layout.
+     * @param vertx Vertx instance
+     * @return Repository layout
+     * @throws IOException If failet to parse settings
+     */
+    RepoLayout layout(Vertx vertx) throws IOException;
 
     /**
      * Fake {@link Settings} using a file storage.
@@ -80,13 +92,18 @@ public interface Settings {
         }
 
         @Override
-        public Storage storage() throws IOException {
+        public Storage storage() {
             return this.storage;
         }
 
         @Override
-        public CompletionStage<Authentication> auth() throws IOException {
+        public CompletionStage<Authentication> auth() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RepoLayout layout(final Vertx vertx) {
+            return new FlatLayout(this, vertx);
         }
     }
 }

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -56,24 +56,21 @@ import org.cactoos.map.MapOf;
  * @since 0.1.4
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ParameterNameCheck (500 lines)
+ * @checkstyle ParameterNumberCheck (500 lines)
  */
 public final class SliceFromConfig extends Slice.Wrap {
-
-    /**
-     * Repository path prefix.
-     */
-    private static final Pattern REPO_PREF = Pattern.compile("/(?:[a-zA-Z0-9]+)(/.*)");
 
     /**
      * Ctor.
      * @param config Repo config
      * @param vertx Vertx instance
      * @param auth Authentication
+     * @param prefix Path prefix
      */
     public SliceFromConfig(final RepoConfig config, final Vertx vertx,
-        final Authentication auth) {
+        final Authentication auth, final Pattern prefix) {
         super(
-            new AsyncSlice(SliceFromConfig.build(config, vertx, auth))
+            new AsyncSlice(SliceFromConfig.build(config, vertx, auth, prefix))
         );
     }
 
@@ -82,6 +79,7 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @param cfg Repository config
      * @param vertx Vertx instance
      * @param auth Authentication implementation
+     * @param prefix Path prefix pattern
      * @return Slice completionStage
      * @todo #90:30min This method still needs more refactoring.
      *  We should test if the type exist in the constructed map. If the type does not exist,
@@ -89,7 +87,7 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @checkstyle LineLengthCheck (100 lines)
      */
     static CompletionStage<Slice> build(final RepoConfig cfg, final Vertx vertx,
-        final Authentication auth) {
+        final Authentication auth, final Pattern prefix) {
         return cfg.type().thenCompose(
             type -> cfg.storage().thenCombine(
                 cfg.permissions(),
@@ -99,7 +97,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                         config -> CompletableFuture.completedStage(
                             new TrimPathSlice(
                                 new FilesSlice(storage, permissions, auth),
-                                SliceFromConfig.REPO_PREF
+                                prefix
                             )
                         )
                     ),
@@ -124,7 +122,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                         "rpm",
                         config -> CompletableFuture.completedStage(
                             new TrimPathSlice(
-                                new RpmSlice(storage), SliceFromConfig.REPO_PREF
+                                new RpmSlice(storage), prefix
                             )
                         )
                     ),
@@ -141,7 +139,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                         config -> CompletableFuture.completedStage(
                             new TrimPathSlice(
                                 new MavenSlice(storage, permissions, auth),
-                                SliceFromConfig.REPO_PREF
+                                prefix
                             )
                         )
                     ),

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -31,9 +31,13 @@ import com.artipie.auth.AuthFromEnv;
 import com.artipie.auth.AuthFromYaml;
 import com.artipie.http.auth.Authentication;
 import com.artipie.http.slice.KeyFromPath;
+import com.artipie.repo.FlatLayout;
+import com.artipie.repo.OrgLayout;
+import com.artipie.repo.RepoLayout;
 import com.jcabi.log.Logger;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
+import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -108,6 +112,23 @@ public final class YamlSettings implements Settings {
             );
         } else {
             res = CompletableFuture.completedStage(new AuthFromEnv());
+        }
+        return res;
+    }
+
+    @Override
+    public RepoLayout layout(final Vertx vertx) throws IOException {
+        final String layout = Yaml.createYamlInput(this.content)
+            .readYamlMapping()
+            .yamlMapping(YamlSettings.META)
+            .string("layout");
+        final RepoLayout res;
+        if (layout == null || "flat".equals(layout)) {
+            res = new FlatLayout(this, vertx);
+        } else if ("org".equals(layout)) {
+            res = new OrgLayout(this, vertx);
+        } else {
+            throw new IOException(String.format("Unsupported layout kind: %s", layout));
         }
         return res;
     }

--- a/src/main/java/com/artipie/repo/FlatLayout.java
+++ b/src/main/java/com/artipie/repo/FlatLayout.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.repo;
+
+import com.artipie.RepoConfig;
+import com.artipie.Settings;
+import com.artipie.SliceFromConfig;
+import com.artipie.asto.Key;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncSlice;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.SliceSimple;
+import com.jcabi.log.Logger;
+import io.vertx.reactivex.core.Vertx;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Flat repositories layout.
+ * @see RepoLayout
+ * @since 0.4
+ * @checkstyle ReturnCountCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class FlatLayout implements RepoLayout {
+
+    /**
+     * Repository path prefix.
+     */
+    private static final Pattern REPO_PREF = Pattern.compile("/(?:[a-zA-Z0-9]+)(/.*)");
+
+    /**
+     * Artipie settings.
+     */
+    private final Settings settings;
+
+    /**
+     * Vertx instance.
+     */
+    private final Vertx vertx;
+
+    /**
+     * New flat layout.
+     * @param settings Artipie settings
+     * @param vertx Vertx
+     */
+    public FlatLayout(final Settings settings, final Vertx vertx) {
+        this.settings = settings;
+        this.vertx = vertx;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    public Slice resolve(final String path) {
+        final String[] parts = path.replaceAll("^/+", "").split("/");
+        if (parts.length < 1) {
+            return new SliceSimple(
+                new RsWithStatus(
+                    new RsWithBody(String.format("Bad request: %s", path), StandardCharsets.UTF_8),
+                    RsStatus.BAD_REQUEST
+                )
+            );
+        }
+        final String repo = parts[0];
+        Logger.debug(this, "Slice repo=%s", repo);
+        final Key.From key = new Key.From(String.format("%s.yaml", repo));
+        return new AsyncSlice(
+            CompletableFuture.supplyAsync(
+                () -> new Unchecked<>(this.settings::storage).value()
+            ).thenCompose(
+                storage -> storage.exists(key).thenApply(
+                    exist -> {
+                        final Slice slice;
+                        if (exist) {
+                            slice = new AsyncSlice(
+                                storage.value(key).thenCombine(
+                                    new Unchecked<>(this.settings::auth).value(),
+                                    (content, auth) -> new SliceFromConfig(
+                                        new RepoConfig(new Key.From(repo), content),
+                                        this.vertx,
+                                        auth,
+                                        FlatLayout.REPO_PREF
+                                    )
+                                )
+                            );
+                        } else {
+                            slice = new SliceSimple(
+                                new RsWithStatus(
+                                    new RsWithBody(
+                                        String.format("Repository '%s' was not found", repo),
+                                        StandardCharsets.UTF_8
+                                    ),
+                                    RsStatus.NOT_FOUND
+                                )
+                            );
+                        }
+                        return slice;
+                    }
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/com/artipie/repo/FlatLayout.java
+++ b/src/main/java/com/artipie/repo/FlatLayout.java
@@ -42,6 +42,11 @@ import org.cactoos.scalar.Unchecked;
 
 /**
  * Flat repositories layout.
+ * <p>
+ * Artipie doesn't use any structural layout, all repositories
+ * are located at the root of base path, e.g. URI {@code https://central.artipie.com/maven}
+ * accesses {@code maven} repository.
+ * </p>
  * @see RepoLayout
  * @since 0.4
  * @checkstyle ReturnCountCheck (500 lines)
@@ -52,7 +57,7 @@ public final class FlatLayout implements RepoLayout {
     /**
      * Repository path prefix.
      */
-    private static final Pattern REPO_PREF = Pattern.compile("/(?:[a-zA-Z0-9]+)(/.*)");
+    private static final Pattern REPO_PREF = Pattern.compile("/(?:[a-zA-Z0-9_]+)(/.*)");
 
     /**
      * Artipie settings.

--- a/src/main/java/com/artipie/repo/FlatLayout.java
+++ b/src/main/java/com/artipie/repo/FlatLayout.java
@@ -57,7 +57,7 @@ public final class FlatLayout implements RepoLayout {
     /**
      * Repository path prefix.
      */
-    private static final Pattern REPO_PREF = Pattern.compile("/(?:[a-zA-Z0-9_]+)(/.*)");
+    private static final Pattern REPO_PREF = Pattern.compile("/(?:[^/.]+)(/.*)");
 
     /**
      * Artipie settings.

--- a/src/main/java/com/artipie/repo/OrgLayout.java
+++ b/src/main/java/com/artipie/repo/OrgLayout.java
@@ -41,7 +41,13 @@ import java.util.regex.Pattern;
 import org.cactoos.scalar.Unchecked;
 
 /**
- * Flat repositories layout.
+ * Hierarchical repositories layout.
+ * <p>
+ * Artipie installation has multiple namespaces/organizations/users,
+ * so first part of the request is a namespace name, second part is a repository name,
+ * e.g. URI {@code https://central.artipie.com/public/maven} accesses {@code maven}
+ * repository under {@code public} namespace.
+ * </p>
  * @see RepoLayout
  * @since 0.4
  * @checkstyle ReturnCountCheck (500 lines)
@@ -53,7 +59,7 @@ public final class OrgLayout implements RepoLayout {
      * Repository path prefix.
      */
     private static final Pattern REPO_PREF =
-        Pattern.compile("/(?:[a-zA-Z0-9]+)/(?:[a-zA-Z0-9]+)(/.*)");
+        Pattern.compile("/(?:[a-zA-Z0-9_]+)/(?:[a-zA-Z0-9_]+)(/.*)");
 
     /**
      * Artipie settings.

--- a/src/main/java/com/artipie/repo/OrgLayout.java
+++ b/src/main/java/com/artipie/repo/OrgLayout.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.repo;
+
+import com.artipie.RepoConfig;
+import com.artipie.Settings;
+import com.artipie.SliceFromConfig;
+import com.artipie.asto.Key;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncSlice;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.SliceSimple;
+import com.jcabi.log.Logger;
+import io.vertx.reactivex.core.Vertx;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Flat repositories layout.
+ * @see RepoLayout
+ * @since 0.4
+ * @checkstyle ReturnCountCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class OrgLayout implements RepoLayout {
+
+    /**
+     * Repository path prefix.
+     */
+    private static final Pattern REPO_PREF =
+        Pattern.compile("/(?:[a-zA-Z0-9]+)/(?:[a-zA-Z0-9]+)(/.*)");
+
+    /**
+     * Artipie settings.
+     */
+    private final Settings settings;
+
+    /**
+     * Vertx instance.
+     */
+    private final Vertx vertx;
+
+    /**
+     * New org layout.
+     * @param settings Artipie settings
+     * @param vertx Vertx
+     */
+    public OrgLayout(final Settings settings, final Vertx vertx) {
+        this.settings = settings;
+        this.vertx = vertx;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    public Slice resolve(final String path) {
+        final String[] parts = path.replaceAll("^/+", "").split("/");
+        if (parts.length < 2) {
+            return new SliceSimple(
+                new RsWithStatus(
+                    new RsWithBody(String.format("Bad request: %s", path), StandardCharsets.UTF_8),
+                    RsStatus.BAD_REQUEST
+                )
+            );
+        }
+        final String namespace = parts[0];
+        final String repo = parts[1];
+        Logger.debug(this, "Slice repo=%s", repo);
+        final Key.From key = new Key.From(namespace, String.format("%s.yaml", repo));
+        return new AsyncSlice(
+            CompletableFuture.supplyAsync(
+                () -> new Unchecked<>(this.settings::storage).value()
+            ).thenCompose(
+                storage -> storage.exists(key).thenApply(
+                    exist -> {
+                        final Slice slice;
+                        if (exist) {
+                            slice = new AsyncSlice(
+                                storage.value(key).thenCombine(
+                                    new Unchecked<>(this.settings::auth).value(),
+                                    (content, auth) -> new SliceFromConfig(
+                                        new RepoConfig(new Key.From(namespace, repo), content),
+                                        this.vertx,
+                                        auth,
+                                        OrgLayout.REPO_PREF
+                                    )
+                                )
+                            );
+                        } else {
+                            slice = new SliceSimple(
+                                new RsWithStatus(
+                                    new RsWithBody(
+                                        String.format("Repository '%s' was not found", repo),
+                                        StandardCharsets.UTF_8
+                                    ),
+                                    RsStatus.NOT_FOUND
+                                )
+                            );
+                        }
+                        return slice;
+                    }
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/com/artipie/repo/OrgLayout.java
+++ b/src/main/java/com/artipie/repo/OrgLayout.java
@@ -59,7 +59,7 @@ public final class OrgLayout implements RepoLayout {
      * Repository path prefix.
      */
     private static final Pattern REPO_PREF =
-        Pattern.compile("/(?:[a-zA-Z0-9_]+)/(?:[a-zA-Z0-9_]+)(/.*)");
+        Pattern.compile("/(?:[^/.]+)/(?:[^/.]+)(/.*)");
 
     /**
      * Artipie settings.

--- a/src/main/java/com/artipie/repo/RepoLayout.java
+++ b/src/main/java/com/artipie/repo/RepoLayout.java
@@ -21,10 +21,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package com.artipie.repo;
+
+import com.artipie.http.Slice;
 
 /**
- * Artipie authentication providers.
- *
- * @since 0.3
+ * Repositories layout.
+ * <p>
+ * This object resolves repository HTTP endpoints for specified URL.
+ * Artipie supports two primary layout configurations:
+ * <ul>
+ *     <li>Flat layout - Artipie doesn't use any structural layout, all repositories
+ *     are located at the root of base path, e.g. URI {@code https://central.artipie.com/maven}
+ *     accesses {@code maven} repository.</li>
+ *     <li>User based - Artipie installation has multiple namespaces/organizations/users,
+ *     so first part of the request is a namespace name, second part is a repository name,
+ *     e.g. URI {@code https://central.artipie.com/public/maven} accesses {@code maven}
+ *     repository under {@code public} namespace.</li>
+ * </ul>
+ * </p>
+ * @see FlatLayout
+ * @see OrgLayout
+ * @since 0.4
  */
-package com.artipie.auth;
+public interface RepoLayout {
+
+    /**
+     * Resolve slice based on URI path.
+     * @param path URI path
+     * @return Repository API
+     */
+    Slice resolve(String path);
+}

--- a/src/main/java/com/artipie/repo/RepoLayout.java
+++ b/src/main/java/com/artipie/repo/RepoLayout.java
@@ -34,7 +34,7 @@ import com.artipie.http.Slice;
  *     <li>Flat layout - Artipie doesn't use any structural layout, all repositories
  *     are located at the root of base path, e.g. URI {@code https://central.artipie.com/maven}
  *     accesses {@code maven} repository.</li>
- *     <li>User based - Artipie installation has multiple namespaces/organizations/users,
+ *     <li>Hierarchical layout - Artipie installation has multiple namespaces/organizations/users,
  *     so first part of the request is a namespace name, second part is a repository name,
  *     e.g. URI {@code https://central.artipie.com/public/maven} accesses {@code maven}
  *     repository under {@code public} namespace.</li>

--- a/src/main/java/com/artipie/repo/package-info.java
+++ b/src/main/java/com/artipie/repo/package-info.java
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 /**
- * Artipie authentication providers.
+ * Artipie repositories.
  *
- * @since 0.3
+ * @since 0.4
  */
-package com.artipie.auth;
+package com.artipie.repo;

--- a/src/test/java/com/artipie/RepoConfigTest.java
+++ b/src/test/java/com/artipie/RepoConfigTest.java
@@ -24,6 +24,7 @@
 package com.artipie;
 
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Key;
 import com.artipie.asto.fs.RxFile;
 import io.vertx.reactivex.core.Vertx;
 import java.net.URISyntaxException;
@@ -115,6 +116,6 @@ public final class RepoConfigTest {
                     .toURI()
             )
         );
-        return new RepoConfig(name, file.flow());
+        return new RepoConfig(new Key.From(name), file.flow());
     }
 }

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  *
  * @since 0.1
  * @checkstyle MethodNameCheck (500 lines)
+ * @todo #187:30min Add a test for layout structure, it can be either `flat` or `org`. If it's
+ *  omitted, it should treated as a `flat` layout. See RepoLayout javadocs for more details.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class YamlSettingsTest {


### PR DESCRIPTION
#178 - support two different repository layout formats:
 - `flat` - no repository hierarchy
 - `org` - two level hierarchy: first level is organization name, second part is repository name

See `RepoLayout` javadoc for more details.