### PR TITLE
Using storage aliases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.amihaiemil.web</groupId>
       <artifactId>eo-yaml</artifactId>
-      <version>3.1.0</version>
+      <version>4.3.5</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/com/artipie/RpPermissions.java
+++ b/src/main/java/com/artipie/RpPermissions.java
@@ -23,6 +23,7 @@
  */
 package com.artipie;
 
+import com.amihaiemil.eoyaml.Scalar;
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlSequence;
@@ -90,7 +91,7 @@ public final class RpPermissions implements Permissions {
      * @return True if action is allowed
      */
     private static boolean check(final YamlSequence seq, final String action) {
-        return seq != null && seq.values().stream().map(Object::toString)
+        return seq != null && seq.values().stream().map(node -> Scalar.class.cast(node).value())
             .anyMatch(item -> item.equals(action) || item.equals(RpPermissions.WILDCARD));
     }
 

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -32,7 +32,6 @@ import com.artipie.files.FilesSlice;
 import com.artipie.gem.GemSlice;
 import com.artipie.http.GoSlice;
 import com.artipie.http.Slice;
-import com.artipie.http.async.AsyncSlice;
 import com.artipie.http.auth.Authentication;
 import com.artipie.http.auth.BasicIdentities;
 import com.artipie.http.auth.Permissions;
@@ -47,12 +46,7 @@ import com.artipie.nuget.http.NuGet;
 import com.artipie.pypi.PySlice;
 import com.artipie.rpm.http.RpmSlice;
 import io.vertx.reactivex.core.Vertx;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 import java.util.regex.Pattern;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
 
 /**
  * Slice from repo config.
@@ -60,6 +54,7 @@ import org.cactoos.map.MapOf;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ParameterNameCheck (500 lines)
  * @checkstyle ParameterNumberCheck (500 lines)
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
  */
 public final class SliceFromConfig extends Slice.Wrap {
 
@@ -73,7 +68,7 @@ public final class SliceFromConfig extends Slice.Wrap {
     public SliceFromConfig(final RepoConfig config, final Vertx vertx,
         final Authentication auth, final Pattern prefix) {
         super(
-            new AsyncSlice(SliceFromConfig.build(config, vertx, auth, prefix))
+            SliceFromConfig.build(config, vertx, auth, prefix)
         );
     }
 
@@ -89,154 +84,62 @@ public final class SliceFromConfig extends Slice.Wrap {
      *  we should throw an IllegalStateException with the message "Unsupported repository type '%s'"
      * @checkstyle LineLengthCheck (100 lines)
      */
-    static CompletionStage<Slice> build(final RepoConfig cfg, final Vertx vertx,
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    static Slice build(final RepoConfig cfg, final Vertx vertx,
         final Authentication auth, final Pattern prefix) {
-        return cfg.type().thenCompose(
-            type -> cfg.storage().thenCombine(
-                cfg.permissions(),
-                (storage, permissions) -> new MapOf<String, Function<RepoConfig, CompletionStage<Slice>>>(
-                    new MapEntry<>(
-                        "file",
-                        config -> CompletableFuture.completedStage(
-                            new TrimPathSlice(
-                                new FilesSlice(storage, permissions, auth),
-                                prefix
-                            )
-                        )
-                    ),
-                    new MapEntry<>(
-                        "npm",
-                        config -> config.path().thenCombine(
-                            config.settings(),
-                            (path, settings) -> new NpmSlice(
-                                path,
-                                new Npm(storage),
-                                storage,
-                                permissions,
-                                new BasicIdentities(auth)
-                            )
-                        )
-                    ),
-                    new MapEntry<>(
-                        "gem",
-                        config -> CompletableFuture.completedStage(new GemSlice(storage, vertx.fileSystem()))
-                    ),
-                    new MapEntry<>(
-                        "rpm",
-                        config -> CompletableFuture.completedStage(
-                            new TrimPathSlice(
-                                new RpmSlice(storage), prefix
-                            )
-                        )
-                    ),
-                    new MapEntry<>(
-                        "php",
-                        config -> php(config, storage)
-                    ),
-                    new MapEntry<>(
-                        "nuget",
-                        config -> nuGet(cfg, storage, permissions, auth)
-                    ),
-                    new MapEntry<>(
-                        "maven",
-                        config -> CompletableFuture.completedStage(
-                            new TrimPathSlice(
-                                new MavenSlice(storage, permissions, auth),
-                                prefix
-                            )
-                        )
-                    ),
-                    new MapEntry<>(
-                        "go", config -> CompletableFuture.completedStage(new GoSlice(storage))
-                    ),
-                    new MapEntry<>(
-                        "npm-proxy",
-                        config -> config.path().thenCombine(
-                            config.settings(),
-                            (path, settings) -> new NpmProxySlice(
-                                path,
-                                new NpmProxy(
-                                    new NpmProxyConfig(settings.orElseThrow()),
-                                    vertx,
-                                    storage
-                                )
-                            )
-                        )
-                    ),
-                    new MapEntry<>(
-                        "pypi", config -> pypi(cfg, storage)
-                    ),
-                    new MapEntry<>(
-                        "docker", config -> docker(cfg, storage)
-                    )
-                ).get(type).apply(cfg)
-            ).thenCompose(Function.identity()).thenCompose(
-                slice -> cfg.contentLengthMax().thenApply(
-                    opt -> opt.<Slice>map(limit -> new ContentLengthRestriction(slice, limit))
-                        .orElse(slice)
-                )
-            )
-        );
-    }
-
-    /**
-     * Creates PHP Composer slice.
-     *
-     * @param config Repository config.
-     * @param storage Storage.
-     * @return Slice instance.
-     */
-    private static CompletionStage<Slice> php(final RepoConfig config, final Storage storage) {
-        return config.path().thenApply(
-            path -> new PhpComposer(path, storage)
-        );
-    }
-
-    /**
-     * Creates Python slice.
-     *
-     * @param config Repository config.
-     * @param storage Storage.
-     * @return Slice instance.
-     */
-    private static CompletionStage<Slice> pypi(final RepoConfig config, final Storage storage) {
-        return config.path().thenApply(
-            path -> new PySlice(path, storage)
-        );
-    }
-
-    /**
-     * Creates NuGet slice.
-     *
-     * @param config Repository config.
-     * @param storage Storage.
-     * @param permissions Access permissions.
-     * @param auth Auth details.
-     * @return Slice instance.
-     */
-    private static CompletionStage<Slice> nuGet(
-        final RepoConfig config,
-        final Storage storage,
-        final Permissions permissions,
-        final Authentication auth
-    ) {
-        return config.url().thenCompose(
-            url -> config.path().thenApply(
-                path -> new NuGet(url, path, storage, permissions, auth)
-            )
-        );
-    }
-
-    /**
-     * Creates Docker slice.
-     *
-     * @param config Repository config.
-     * @param storage Storage.
-     * @return Slice instance.
-     */
-    private static CompletionStage<Slice> docker(final RepoConfig config, final Storage storage) {
-        return config.path().thenApply(
-            path -> new DockerSlice(path, new AstoDocker(storage))
-        );
+        final Slice slice;
+        final Storage storage = cfg.storage();
+        final Permissions permissions = cfg.permissions();
+        switch (cfg.type()) {
+            case "file":
+                slice = new TrimPathSlice(new FilesSlice(storage, permissions, auth), prefix);
+                break;
+            case "npm":
+                slice = new NpmSlice(
+                    cfg.path(),
+                    new Npm(storage),
+                    storage,
+                    permissions,
+                    new BasicIdentities(auth)
+                );
+                break;
+            case "gem":
+                slice = new GemSlice(storage, vertx.fileSystem());
+                break;
+            case "rpm":
+                slice = new TrimPathSlice(new RpmSlice(storage), prefix);
+                break;
+            case "php":
+                slice = new PhpComposer(cfg.path(), storage);
+                break;
+            case "nuget":
+                slice = new NuGet(cfg.url(), cfg.path(), storage, permissions, auth);
+                break;
+            case "maven":
+                slice = new TrimPathSlice(new MavenSlice(storage, permissions, auth), prefix);
+                break;
+            case "go":
+                slice = new GoSlice(storage);
+                break;
+            case "npm-proxy":
+                slice = new NpmProxySlice(
+                    cfg.path(),
+                    new NpmProxy(new NpmProxyConfig(cfg.settings().orElseThrow()), vertx, storage)
+                );
+                break;
+            case "pypi":
+                slice = new PySlice(cfg.path(), storage);
+                break;
+            case "docker":
+                slice = new DockerSlice(cfg.path(), new AstoDocker(storage));
+                break;
+            default:
+                throw new IllegalStateException(
+                    String.format("Unsupported repository type '%s", cfg.type())
+                );
+        }
+        return cfg.contentLengthMax()
+            .<Slice>map(limit -> new ContentLengthRestriction(slice, limit))
+            .orElse(slice);
     }
 }

--- a/src/main/java/com/artipie/StorageAliases.java
+++ b/src/main/java/com/artipie/StorageAliases.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Key;
+import com.artipie.asto.Remaining;
+import com.artipie.asto.Storage;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import io.reactivex.Flowable;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Storage configuration by alias.
+ * @since 0.4
+ */
+public interface StorageAliases {
+
+    /**
+     * Empty storage alias.
+     */
+    StorageAliases EMPTY = alias -> {
+        throw new IllegalStateException(String.format("No storage alias found: %s", alias));
+    };
+
+    /**
+     * Find storage by alias.
+     * @param alias Storage alias
+     * @return Storage instance
+     */
+    Storage storage(String alias);
+
+    /**
+     * Find storage aliases config for repo.
+     * @param storage Config storage
+     * @param repo Repo key
+     * @return Async storages
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    static CompletableFuture<StorageAliases> find(final Storage storage, final Key repo) {
+        final Key.From key = new Key.From(repo, "_storages.yaml");
+        return storage.exists(key).thenCompose(
+            found -> {
+                final CompletableFuture<StorageAliases> res;
+                if (found) {
+                    res = storage.value(key).thenCompose(
+                        pub -> Flowable.fromPublisher(pub)
+                            .reduce(
+                                new StringBuilder(),
+                                (acc, buf) -> acc.append(
+                                    new String(new Remaining(buf).bytes(), StandardCharsets.UTF_8)
+                                )
+                            )
+                            .map(cnt -> Yaml.createYamlInput(cnt.toString()).readYamlMapping())
+                            .to(SingleInterop.get())
+                            .thenApply(FromYaml::new)
+                    );
+                } else {
+                    res = repo.parent()
+                        .map(parent -> StorageAliases.find(storage, parent))
+                        .orElse(CompletableFuture.completedFuture(StorageAliases.EMPTY));
+                }
+                return res;
+            }
+        );
+    }
+
+    /**
+     * Storage aliases from Yaml config.
+     * @since 0.4
+     */
+    final class FromYaml implements StorageAliases {
+
+        /**
+         * Aliases yaml.
+         */
+        private final YamlMapping yaml;
+
+        /**
+         * Aliases from yaml.
+         * @param yaml Yaml
+         */
+        public FromYaml(final YamlMapping yaml) {
+            this.yaml = yaml;
+        }
+
+        @Override
+        public Storage storage(final String alias) {
+            return new YamlStorage(this.yaml.yamlMapping("storages").yamlMapping(alias)).storage();
+        }
+    }
+}

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -72,7 +72,7 @@ public final class YamlSettings implements Settings {
 
     @Override
     public Storage storage() throws IOException {
-        return new YamlStorageSettings(
+        return new YamlStorage(
             Yaml.createYamlInput(this.content)
                 .readYamlMapping()
                 .yamlMapping(YamlSettings.META)

--- a/src/main/java/com/artipie/YamlStorage.java
+++ b/src/main/java/com/artipie/YamlStorage.java
@@ -42,7 +42,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
  * @since 0.2
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class YamlStorageSettings {
+final class YamlStorage {
 
     /**
      * YAML storage settings.
@@ -53,7 +53,7 @@ final class YamlStorageSettings {
      * Ctor.
      * @param yaml YAML storage settings.
      */
-    YamlStorageSettings(final YamlMapping yaml) {
+    YamlStorage(final YamlMapping yaml) {
         this.yaml = yaml;
     }
 
@@ -63,7 +63,8 @@ final class YamlStorageSettings {
      * @return Storage instance.
      */
     public Storage storage() {
-        final YamlMapping strict = new StrictYamlMapping(this.yaml);
+        @SuppressWarnings("deprecation") final YamlMapping strict =
+            new StrictYamlMapping(this.yaml);
         final String type = strict.string("type");
         final Storage storage;
         if ("fs".equals(type)) {
@@ -80,8 +81,9 @@ final class YamlStorageSettings {
      * Creates {@link S3AsyncClient} instance based on YAML config.
      *
      * @return Built S3 client.
-     * @checkstyle MethodNameCheck (2 lines)
+     * @checkstyle MethodNameCheck (3 lines)
      */
+    @SuppressWarnings("deprecation")
     private S3AsyncClient s3Client() {
         final S3AsyncClientBuilder builder = S3AsyncClient.builder();
         final String region = this.yaml.string("region");

--- a/src/main/java/com/artipie/repo/OrgLayout.java
+++ b/src/main/java/com/artipie/repo/OrgLayout.java
@@ -26,6 +26,7 @@ package com.artipie.repo;
 import com.artipie.RepoConfig;
 import com.artipie.Settings;
 import com.artipie.SliceFromConfig;
+import com.artipie.StorageAliases;
 import com.artipie.asto.Key;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncSlice;
@@ -106,13 +107,16 @@ public final class OrgLayout implements RepoLayout {
                         final Slice slice;
                         if (exist) {
                             slice = new AsyncSlice(
-                                storage.value(key).thenCombine(
+                                StorageAliases.find(storage, key.parent().get()).thenCompose(
+                                    aliases -> storage.value(key).thenCompose(
+                                        config -> RepoConfig.fromPublisher(
+                                            aliases, new Key.From(repo), config
+                                        )
+                                    )
+                                ).thenCombine(
                                     new Unchecked<>(this.settings::auth).value(),
-                                    (content, auth) -> new SliceFromConfig(
-                                        new RepoConfig(new Key.From(namespace, repo), content),
-                                        this.vertx,
-                                        auth,
-                                        OrgLayout.REPO_PREF
+                                    (config, auth) -> new SliceFromConfig(
+                                        config, this.vertx, auth, OrgLayout.REPO_PREF
                                     )
                                 )
                             );

--- a/src/test/java/com/artipie/RepoConfigTest.java
+++ b/src/test/java/com/artipie/RepoConfigTest.java
@@ -49,10 +49,9 @@ public final class RepoConfigTest {
     private Vertx vertx;
 
     @Test
-    public void readsCustom()
-        throws URISyntaxException, ExecutionException, InterruptedException {
+    public void readsCustom() throws Exception {
         final RepoConfig config = this.readFull();
-        final YamlMapping yaml = config.settings().toCompletableFuture().get().orElseThrow();
+        final YamlMapping yaml = config.settings().orElseThrow();
         MatcherAssert.assertThat(
             yaml.string("custom-property"),
             new IsEqual<>("custom-value")
@@ -60,12 +59,11 @@ public final class RepoConfigTest {
     }
 
     @Test
-    public void failsToReadCustom()
-        throws URISyntaxException, ExecutionException, InterruptedException {
+    public void failsToReadCustom() throws Exception {
         final RepoConfig config = this.readMin();
         MatcherAssert.assertThat(
             "Unexpected custom config",
-            config.settings().toCompletableFuture().get().isEmpty()
+            config.settings().isEmpty()
         );
     }
 
@@ -74,7 +72,7 @@ public final class RepoConfigTest {
         final RepoConfig config = this.readFull();
         final long value = 123L;
         MatcherAssert.assertThat(
-            config.contentLengthMax().toCompletableFuture().join(),
+            config.contentLengthMax(),
             new IsEqual<>(Optional.of(value))
         );
     }
@@ -83,7 +81,7 @@ public final class RepoConfigTest {
     public void readEmptyContentLengthMax() throws Exception {
         final RepoConfig config = this.readMin();
         MatcherAssert.assertThat(
-            config.contentLengthMax().toCompletableFuture().join().isEmpty(),
+            config.contentLengthMax().isEmpty(),
             new IsEqual<>(true)
         );
     }
@@ -98,16 +96,16 @@ public final class RepoConfigTest {
         this.vertx.close();
     }
 
-    private RepoConfig readFull() throws URISyntaxException {
+    private RepoConfig readFull() throws Exception {
         return this.readFromResource("repo-full-config.yml");
     }
 
-    private RepoConfig readMin() throws URISyntaxException {
+    private RepoConfig readMin() throws Exception {
         return this.readFromResource("repo-min-config.yml");
     }
 
     private RepoConfig readFromResource(final String name)
-        throws URISyntaxException {
+        throws URISyntaxException, ExecutionException, InterruptedException {
         final RxFile file = new RxFile(
             Paths.get(
                 Thread.currentThread()
@@ -116,6 +114,7 @@ public final class RepoConfigTest {
                     .toURI()
             )
         );
-        return new RepoConfig(new Key.From(name), file.flow());
+        return RepoConfig.fromPublisher(StorageAliases.EMPTY, new Key.From(name), file.flow())
+            .toCompletableFuture().get();
     }
 }

--- a/src/test/java/com/artipie/YamlStorageTest.java
+++ b/src/test/java/com/artipie/YamlStorageTest.java
@@ -35,17 +35,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for {@link YamlStorageSettings}.
+ * Tests for {@link YamlStorage}.
  *
  * @checkstyle MethodNameCheck (500 lines)
  * @since 0.2
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class YamlStorageSettingsTest {
+class YamlStorageTest {
 
     @Test
     public void shouldBuildFileStorageFromSettings() throws Exception {
-        final YamlStorageSettings settings = new YamlStorageSettings(
+        final YamlStorage settings = new YamlStorage(
             Yaml.createYamlInput("type: fs\npath: /artipie/storage\n").readYamlMapping()
         );
         MatcherAssert.assertThat(
@@ -56,7 +56,7 @@ class YamlStorageSettingsTest {
 
     @Test
     public void shouldBuildS3StorageFromFullSettings() throws Exception {
-        final YamlStorageSettings settings = new YamlStorageSettings(
+        final YamlStorage settings = new YamlStorage(
             Yaml.createYamlInput(
                 String.join(
                     "",
@@ -80,7 +80,7 @@ class YamlStorageSettingsTest {
     @Test
     public void shouldBuildS3StorageFromMinimalSettings() throws Exception {
         System.getProperties().put("aws.region", "my-region");
-        final YamlStorageSettings settings = new YamlStorageSettings(
+        final YamlStorage settings = new YamlStorage(
             Yaml.createYamlInput(
                 String.join(
                     "",
@@ -103,7 +103,7 @@ class YamlStorageSettingsTest {
     @MethodSource("badYamls")
     public void shouldFailProvideStorageFromBadYaml(final String yaml)
         throws Exception {
-        final YamlStorageSettings settings = new YamlStorageSettings(
+        final YamlStorage settings = new YamlStorage(
             Yaml.createYamlInput(yaml).readYamlMapping()
         );
         Assertions.assertThrows(RuntimeException.class, settings::storage);


### PR DESCRIPTION
#78 - using storage aliases for repo configuration. Refactored `RepoConfig` methods to be synchronous to avoid one more (5-th) callback parameter for constructing configuration. This feature helps to hide actual credentials from config and restrict user permissions to allow modify repository settings only without changing storage configuration (in case of Central).