### PR TITLE
Normalize Docker paths

### DIFF
--- a/src/main/java/com/artipie/http/DockerRoutingSlice.java
+++ b/src/main/java/com/artipie/http/DockerRoutingSlice.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http;
+
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RequestLineFrom;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.http.client.utils.URIBuilder;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice decorator which redirects all Docker V2 API requests to Artipie format paths.
+ * @since 0.9
+ */
+final class DockerRoutingSlice implements Slice {
+
+    /**
+     * Docker V2 API path pattern.
+     */
+    private static final Pattern PTN_PATH = Pattern.compile("/v2((/.*)?)");
+
+    /**
+     * Origin slice.
+     */
+    private final Slice origin;
+
+    /**
+     * Decorates slice with Docker V2 API routing.
+     * @param origin Origin slice
+     */
+    DockerRoutingSlice(final Slice origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        final RequestLineFrom req = new RequestLineFrom(line);
+        final Matcher matcher = PTN_PATH.matcher(req.uri().getPath());
+        final Response rsp;
+        if (matcher.matches()) {
+            rsp = this.origin.response(
+                new RequestLine(
+                    req.method().toString(),
+                    new URIBuilder(req.uri()).setPath(matcher.group(1)).toString(),
+                    req.version()
+                ).toString(),
+                headers, body
+            );
+        } else {
+            rsp = this.origin.response(line, headers, body);
+        }
+        return rsp;
+    }
+}

--- a/src/main/java/com/artipie/http/DockerRoutingSlice.java
+++ b/src/main/java/com/artipie/http/DockerRoutingSlice.java
@@ -25,6 +25,7 @@ package com.artipie.http;
 
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rq.RqHeaders;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -37,6 +38,11 @@ import org.reactivestreams.Publisher;
  * @since 0.9
  */
 final class DockerRoutingSlice implements Slice {
+
+    /**
+     * Real path header name.
+     */
+    private static final String HDR_REAL_PATH = "X-RealPath";
 
     /**
      * Docker V2 API path pattern.
@@ -60,7 +66,8 @@ final class DockerRoutingSlice implements Slice {
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
         final RequestLineFrom req = new RequestLineFrom(line);
-        final Matcher matcher = PTN_PATH.matcher(req.uri().getPath());
+        final String path = req.uri().getPath();
+        final Matcher matcher = PTN_PATH.matcher(path);
         final Response rsp;
         if (matcher.matches()) {
             rsp = this.origin.response(
@@ -69,11 +76,55 @@ final class DockerRoutingSlice implements Slice {
                     new URIBuilder(req.uri()).setPath(matcher.group(1)).toString(),
                     req.version()
                 ).toString(),
-                headers, body
+                new Headers.From(headers, DockerRoutingSlice.HDR_REAL_PATH, path),
+                body
             );
         } else {
             rsp = this.origin.response(line, headers, body);
         }
         return rsp;
+    }
+
+    /**
+     * Slice which reverts real path from headers if exists.
+     * @since 0.9
+     */
+    public static final class Reverted implements Slice {
+
+        /**
+         * Origin slice.
+         */
+        private final Slice origin;
+
+        /**
+         * New {@link Slice} decorator to revert real path.
+         * @param origin Origin slice
+         */
+        Reverted(final Slice origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public Response response(final String line,
+            final Iterable<Map.Entry<String, String>> headers,
+            final Publisher<ByteBuffer> body) {
+            final String path;
+            final RqHeaders hdr = new RqHeaders(headers, DockerRoutingSlice.HDR_REAL_PATH);
+            final RequestLineFrom req = new RequestLineFrom(line);
+            if (hdr.isEmpty()) {
+                path = req.uri().getPath();
+            } else {
+                path = hdr.get(0);
+            }
+            return this.origin.response(
+                new RequestLine(
+                    req.method().toString(),
+                    new URIBuilder(req.uri()).setPath(path).toString(),
+                    req.version()
+                ).toString(),
+                headers,
+                body
+            );
+        }
     }
 }

--- a/src/main/java/com/artipie/http/Pie.java
+++ b/src/main/java/com/artipie/http/Pie.java
@@ -79,7 +79,9 @@ public final class Pie extends Slice.Wrap {
                         new RtRulePath(
                             new RtIsDashboard(settings), new DashboardSlice(settings)
                         ),
-                        new RtRulePath(RtRule.FALLBACK, new SliceByPath(settings))
+                        new RtRulePath(
+                            RtRule.FALLBACK, new DockerRoutingSlice(new SliceByPath(settings))
+                        )
                     )
                 )
             )

--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -89,7 +89,8 @@ final class SliceByPath implements Slice {
                 }
                 key = new Key.From(split[0]);
             }
-            return this.repositories.slice(key).response(line, headers, body);
+            return new DockerRoutingSlice.Reverted(this.repositories.slice(key))
+                .response(line, headers, body);
         } catch (final IOException err) {
             return new RsWithBody(
                 new RsWithStatus(RsStatus.INTERNAL_ERROR),

--- a/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
+++ b/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
@@ -70,6 +70,19 @@ final class DockerRoutingSliceTest {
         );
     }
 
+    @Test
+    void revertsDockerRequest() throws Exception {
+        final String path = "/v2/one/two";
+        verify(
+            new DockerRoutingSlice(
+                new DockerRoutingSlice.Reverted(
+                    new AssertSlice(new RqLineHasUri(new RqLineHasUri.HasPath(path)))
+                )
+            ),
+            path
+        );
+    }
+
     private static void verify(final Slice slice, final String path) throws Exception {
         slice.response(
             new RequestLine(RqMethod.GET, path).toString(),

--- a/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
+++ b/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http;
+
+import com.artipie.http.hm.AssertSlice;
+import com.artipie.http.hm.RqLineHasUri;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import io.reactivex.Flowable;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link DockerRoutingSlice}.
+ *
+ * @since 0.9
+ */
+final class DockerRoutingSliceTest {
+
+    @Test
+    void removesDockerPrefix() throws Exception {
+        verify(
+            new DockerRoutingSlice(
+                new AssertSlice(new RqLineHasUri(new RqLineHasUri.HasPath("/foo/bar")))
+            ),
+            "/v2/foo/bar"
+        );
+    }
+
+    @Test
+    void ignoresNonDockerRequests() throws Exception {
+        final String path = "/repo/name";
+        verify(
+            new DockerRoutingSlice(
+                new AssertSlice(new RqLineHasUri(new RqLineHasUri.HasPath(path)))
+            ),
+            path
+        );
+    }
+
+    @Test
+    void emptyDockerRequest() throws Exception {
+        verify(
+            new DockerRoutingSlice(
+                new AssertSlice(new RqLineHasUri(new RqLineHasUri.HasPath("")))
+            ),
+            "/v2"
+        );
+    }
+
+    private static void verify(final Slice slice, final String path) throws Exception {
+        slice.response(
+            new RequestLine(RqMethod.GET, path).toString(),
+            Collections.emptyList(), Flowable.empty()
+        ).send(
+            (status, headers, body) -> CompletableFuture.completedFuture(null)
+        ).toCompletableFuture().get();
+    }
+}

--- a/src/test/java/com/artipie/http/package-info.java
+++ b/src/test/java/com/artipie/http/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for Artipie HTTP layer.
+ *
+ * @since 0.9
+ */
+package com.artipie.http;


### PR DESCRIPTION
#274 - Programmatically normalize Docker `/v2` requests to Artipie path format: `/v2/repo/image` -> `/repo/image`.