### PR TITLE
Bump helm adapter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>helm-adapter</artifactId>
-      <version>0.1.2</version>
+      <version>0.1.3</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -173,7 +173,15 @@ public final class SliceFromConfig extends Slice.Wrap {
                 slice = new GemSlice(storage, null);
                 break;
             case "helm":
-                slice = new HelmSlice(storage);
+                slice = new TrimPathSlice(
+                    new HelmSlice(
+                        storage,
+                        cfg.path(),
+                        permissions,
+                        new BasicIdentities(auth)
+                    ),
+                    prefix
+                );
                 break;
             case "rpm":
                 slice = new TrimPathSlice(


### PR DESCRIPTION
Related to #188 

* Helm adapter version has been updated to version 0.1.3. 
* The repo name is removed from the request path.