### PR TITLE
Rollback accidentally deleted config file

### DIFF
--- a/examples/binary/configs/repo.yaml
+++ b/examples/binary/configs/repo.yaml
@@ -1,0 +1,8 @@
+repo:
+  type: file
+  storage:
+    type: fs
+    path: /var/artipie/data
+  permissions:
+    "*":
+      - "*"


### PR DESCRIPTION
Rollback accidentally deleted config file so the binary Proof would pass now.

Related to #154.