### PR TITLE
Include readmes from examples into dashboard pages on build

### DIFF
--- a/examples/binary/README.md
+++ b/examples/binary/README.md
@@ -4,7 +4,7 @@
 
 Try this `repo.yaml` file:
 
-<code>
+<pre>
 repo:
   type: file
   storage:
@@ -13,14 +13,14 @@ repo:
   permissions:
     "*":
       - "*"
-</code>
+</pre>
 
 Use `PUT` HTTP request to upload a file, and `GET` for downloading.</p>
 
 Example using [HTTPie](https://httpie.org/) CLI tool for uploading and downloading:
-<code>
+<pre>
 http -a {{user}}:password PUT https://central.artipie.com/{{user}}/{{name}}/file.bin @file.bin
 http GET https://central.artipie.com/{{user}}/{{name}}/file.bin --output=./file.bin
-</code>
+</pre>
 
 // TODO: add curl example

--- a/examples/binary/README.md
+++ b/examples/binary/README.md
@@ -1,10 +1,10 @@
-### Binary Repo
+### Binary repository
 
 [![](https://github.com/artipie/artipie/workflows/Proof::binary/badge.svg)](./examples/binary)
 
 Try this `repo.yaml` file:
 
-```yaml
+<code>
 repo:
   type: file
   storage:
@@ -13,8 +13,14 @@ repo:
   permissions:
     "*":
       - "*"
-```
+</code>
 
-You can send HTTP PUT/GET requests
-to `http://localhost:8080/repo/<filename>` to upload/download a binary file,
-e.g. `http://localhost:8080/repo/libsqlite3.so`.
+Use `PUT` HTTP request to upload a file, and `GET` for downloading.</p>
+
+Example using [HTTPie](https://httpie.org/) CLI tool for uploading and downloading:
+<code>
+http -a {{user}}:password PUT https://central.artipie.com/{{user}}/{{name}}/file.bin @file.bin
+http GET https://central.artipie.com/{{user}}/{{name}}/file.bin --output=./file.bin
+</code>
+
+// TODO: add curl example

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -4,13 +4,13 @@
 
 Try this `docker.yaml` file:
 
-```yaml
+<pre>
 repo:
   type: docker
   storage:
     type: fs
     path: /tmp/artipie/data/my-docker
-```
+</pre>
 
 Docker registry has to be protected by HTTPS.
 
@@ -27,14 +27,14 @@ docker push central.artipie.com/{{user}}/{{name}}/alpine:3.11
 
 Try this `docker-proxy.yaml` file to host a proxy to `registry-1.docker.io` registry:
 
-```yaml
+<pre>
 repo:
   type: docker-proxy
   settings:
     host: registry-1.docker.io
     username: Aladdin # optional
     password: OpenSesame # optional
-```
+</pre>
 
 Artipie will redirect all pull requests to specified registry.
 
@@ -42,7 +42,7 @@ Proxy repository supports caching in local storage.
 To enable it and make previously accessed images available when source repository is down 
 add `storage` section to config:
 
-```yaml
+<pre>
 repo:
   type: docker-proxy
   settings:
@@ -50,4 +50,4 @@ repo:
   storage:
     type: fs
     path: /tmp/artipie/data/my-docker-cache
-```
+</pre>

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -12,22 +12,16 @@ repo:
     path: /tmp/artipie/data/my-docker
 ```
 
-Docker registry has to be protected by HTTPS and should have no prefix in path.
-In order to access this Docker repository it is required to run a reverse proxy such as
-[nginx](https://nginx.org/) or [lighttpd](https://www.lighttpd.net/) to protect Artipie
-with HTTPS and add forwarding of requests from `my-docker.my-company.com/<path>` to
-`my-artipie.my-company.com/my-docker/<path>`.
-Then to push your Docker image use the following command:
+Docker registry has to be protected by HTTPS.
 
-```bash
-$ docker push my-docker.my-company.com/my-image
-```
+Tag your image with `central.artipie.com/{{user}}/{{name}}` image prefix,
+and push it to central.artipie.com then. E.g.
+for `alpine:3.11` use:
+<pre>
+docker tag alpine:3.11 central.artipie.com/{{user}}/{{name}}/alpine:3.11
+docker push central.artipie.com/{{user}}/{{name}}/alpine:3.11
+</pre>
 
-To pull the image use the following command:
-
-```bash
-$ docker pull my-docker.my-company.com/my-image
-```
 
 ### Docker Proxy Repo
 

--- a/examples/maven/README.md
+++ b/examples/maven/README.md
@@ -11,92 +11,41 @@ repo:
     type: fs
     path: /var/artipie/maven
   permissions:
-    admin:
-      - upload
-      - download
-    jeff:
+    {{user}}:
       - upload
       - download
     "*":
       - download
 ```
 
-Add [`<distributionManagement>`](https://maven.apache.org/pom.html#Distribution_Management)
-section to your
-[`pom.xml`](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html)
-(don't forget to specify authentication credentials in
-[`~/.m2/settings.xml`](https://maven.apache.org/settings.html#Servers)
-for `artipie` server):
+With this configuration,
+the user `{{user}}` will be able to publish Maven artifacts,
+and all other users will be able to download.
 
-```xml
-<project>
+This is how you may configure it inside your
+<a href="https://maven.apache.org/guides/introduction/introduction-to-the-pom.html"><code>pom.xml</code></a>:</p>
+
+<pre>&lt;project&gt;
   [...]
-  <distributionManagement>
-    <snapshotRepository>
-      <id>artipie</id>
-      <url>http://localhost:8080/maven</url>
-    </snapshotRepository>
-    <repository>
-      <id>artipie</id>
-      <url>http://localhost:8080/maven</url>
-    </repository>
-  </distributionManagement>
-</project>
-```
+  &lt;distributionManagement&gt;
+    &lt;snapshotRepository&gt;
+      &lt;id&gt;artipie&lt;/id&gt;
+      &lt;url&gt;https://central.artipie.com/{{user}}/{{name}}&lt;/url&gt;
+    &lt;/snapshotRepository&gt;
+    &lt;repository&gt;
+      &lt;id&gt;artipie&lt;/id&gt;
+      &lt;url&gt;https://central.artipie.com/{{user}}/{{name}}&lt;/url&gt;
+    &lt;/repository&gt;
+  &lt;/distributionManagement&gt;
+  &lt;repositories&gt;
+    &lt;repository&gt;
+      &lt;id&gt;artipie&lt;/id&gt;
+      &lt;url&gt;https://central.artipie.com/{{user}}/{{name}}&lt;/url&gt;
+    &lt;/repository&gt;
+  &lt;/repositories&gt;
+&lt;/project&gt;</pre>
 
-Then, `mvn deploy` your project.
-
-Add [`<repository>`](https://maven.apache.org/pom.html#Repositories) and
-[`<pluginRepository>`](https://maven.apache.org/pom.html#Repositories)
-to your `pom.xml` (alternatively
-[configure](https://maven.apache.org/guides/mini/guide-multiple-repositories.html)
-it via
-[`~/.m2/settings.xml`](https://maven.apache.org/settings.html)) to use deployed artifacts:
-
-```xml
-<project>
-  [...]
-  <pluginRepositories>
-    <pluginRepository>
-      <id>artipie</id>
-      <name>artipie plugins</name>
-      <url>http://localhost:8080/maven</url>
-    </pluginRepository>
-  </pluginRepositories>
-  <repositories>
-    <repository>
-      <id>artipie</id>
-      <name>artipie builds</name>
-      <url>http://localhost:8080/maven</url>
-    </repository>
-  </repositories>
-</project>
-```
-
-Run `mvn install` (or `mvn install -U` to force download dependencies).
-
-### Maven proxy Repo
-
-Try this `maven-central.yaml` file to host a proxy to Maven central:
-
-```yaml
-repo:
-  type: maven-proxy
-  storage: default
-```
-
-Artipie will redirect all Maven requests to Maven central.
-Add it [as a mirror](https://maven.apache.org/guides/mini/guide-mirror-settings.html)
-to `settings.xml`:
-```xml
-<settings>
-  <mirrors>
-    <mirror>
-      <id>artipie-mirror</id>
-      <name>Artipie Mirror Repository</name>
-      <url>https://central.artipie.com/mirrors/maven-central</url>
-      <mirrorOf>central</mirrorOf>
-    </mirror>
-  </mirrors>
-</settings>
-```
+<p>You publish just with
+<a href="https://maven.apache.org/plugins/maven-deploy-plugin/usage.html"><code>mvn deploy</code></a>
+and you download with
+<a href="https://maven.apache.org/plugins/maven-compiler-plugin/index.html"><code>mvn compile</code></a>.

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,85 @@ SOFTWARE.
         <filtering>true</filtering>
       </testResource>
     </testResources>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-resources</directory>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>copy-markdown-documentation</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy file="${basedir}/examples/binary/README.md" tofile="${project.build.directory}/examples-md/file.md"/>
+                <copy file="${basedir}/examples/docker/README.md" tofile="${project.build.directory}/examples-md/docker.md"/>
+                <copy file="${basedir}/examples/gem/README.md" tofile="${project.build.directory}/examples-md/gem.md"/>
+                <copy file="${basedir}/examples/go/README.md" tofile="${project.build.directory}/examples-md/go.md"/>
+                <copy file="${basedir}/examples/helm/README.md" tofile="${project.build.directory}/examples-md/helm.md"/>
+                <copy file="${basedir}/examples/maven/README.md" tofile="${project.build.directory}/examples-md/maven.md"/>
+                <copy file="${basedir}/examples/npm/README.md" tofile="${project.build.directory}/examples-md/npm.md"/>
+                <copy file="${basedir}/examples/nuget/README.md" tofile="${project.build.directory}/examples-md/nuget.md"/>
+                <copy file="${basedir}/examples/php/README.md" tofile="${project.build.directory}/examples-md/php.md"/>
+                <copy file="${basedir}/examples/python/README.md" tofile="${project.build.directory}/examples-md/pypi.md"/>
+                <copy file="${basedir}/examples/rpm/README.md" tofile="${project.build.directory}/examples-md/rpm.md"/>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-rename-html-documentation</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy file="${project.build.directory}/examples-html/file.html" toFile="${project.build.directory}/classes/dashboard/file.hbs"/>
+                <copy file="${project.build.directory}/examples-html/docker.html" toFile="${project.build.directory}/classes/dashboard/docker.hbs"/>
+                <copy file="${project.build.directory}/examples-html/gem.html" toFile="${project.build.directory}/classes/dashboard/gem.hbs"/>
+                <copy file="${project.build.directory}/examples-html/go.html" toFile="${project.build.directory}/classes/dashboard/go.hbs"/>
+                <copy file="${project.build.directory}/examples-html/helm.html" toFile="${project.build.directory}/classes/dashboard/helm.hbs"/>
+                <copy file="${project.build.directory}/examples-html/maven.html" toFile="${project.build.directory}/classes/dashboard/maven.hbs"/>
+                <copy file="${project.build.directory}/examples-html/npm.html" toFile="${project.build.directory}/classes/dashboard/npm.hbs"/>
+                <copy file="${project.build.directory}/examples-html/nuget.html" toFile="${project.build.directory}/classes/dashboard/nuget.hbs"/>
+                <copy file="${project.build.directory}/examples-html/php.html" toFile="${project.build.directory}/classes/dashboard/php.hbs"/>
+                <copy file="${project.build.directory}/examples-html/pypi.html" toFile="${project.build.directory}/classes/dashboard/pypi.hbs"/>
+                <copy file="${project.build.directory}/examples-html/rpm.html" toFile="${project.build.directory}/classes/dashboard/rpm.hbs"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.ruleoftech</groupId>
+        <artifactId>markdown-page-generator-plugin</artifactId>
+        <version>2.2.0</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <inputDirectory>${project.build.directory}/examples-md/</inputDirectory>
+          <outputDirectory>${project.build.directory}/examples-html</outputDirectory>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>

--- a/src/main/java/com/artipie/dashboard/RepoPage.java
+++ b/src/main/java/com/artipie/dashboard/RepoPage.java
@@ -111,7 +111,7 @@ final class RepoPage implements Page {
                         new MapOf<>(
                             new MapEntry<>("title", name),
                             new MapEntry<>("user", parts[0]),
-                            new MapEntry<>("name", parts[1]),
+                            new MapEntry<>("name", parts[1].replaceAll("/$", "")),
                             new MapEntry<>("config", yaml.toString()),
                             new MapEntry<>("found", true),
                             new MapEntry<>("type", yaml.yamlMapping("repo").value("type").asScalar().value())
@@ -124,7 +124,7 @@ final class RepoPage implements Page {
                         new MapOf<>(
                             new MapEntry<>("title", name),
                             new MapEntry<>("user", parts[0]),
-                            new MapEntry<>("name", parts[1]),
+                            new MapEntry<>("name", parts[1].replaceAll("/$", "")),
                             new MapEntry<>("found", false),
                             new MapEntry<>(
                                 "type",

--- a/src/main/resources/dashboard/repo.hbs
+++ b/src/main/resources/dashboard/repo.hbs
@@ -89,14 +89,7 @@ and saves artifacts in Artipie storage cache.</p>
 </pre>
 </p>
 {{/eq}}{{#eq type "docker"}}
-<p>Tag your image with <code>central.artipie.com/{{user}}/{{repo}}</code> image prefix,
-and push it to central.artipie.com then. E.g.
-for <code>alpine:3.11</code> use:
-<pre>
-docker tag alpine:3.11 central.artipie.com/{{user}}/{{repo}}alpine:3.11
-docker push central.artipie.com/{{user}}/{{repo}}alpine:3.11
-</pre>
-</p>
+{{>docker}}
 {{/eq}}
 {{#eq type "maven-group"}}
 <p>To use Maven grouped (virtual) repository first create at least two Maven or Maven proxy repositories.
@@ -108,14 +101,7 @@ group-settings, pay attention that order does matter: first repository in the li
 accessed first, then second, etc. Repository name should be fully formatted, include your username
 prefix, e.g. <code>{{user}}/maven</code>.</p>
 {{/eq}}{{#eq type "file"}}
-<p>It's just a binary files repository. Use <code>PUT</code> HTTP request to upload a file,
-and <code>GET</code> for downloading.</p>
-<p>E.g. using <a href="https://httpie.org/">HTTPie</a> CLI tool:
-<pre>
-# uploading file.bin
-http -a {{user}}:password PUT https://central.artipie.com/{{user}}/{{repo}}file.bin @file.bin
-# downloading file.bin
-http GET https://central.artipie.com/{{user}}/{{repo}}file.bin --output=./file.bin
+{{> file}}
 {{/eq}}
 
 {{/partial}}


### PR DESCRIPTION
#348 - First PR for including example readme files into dashboard help.

The build process:
 1. Copying `README.md` from examples to temporary build directory and rename it (on `generate-resources`)
 2. Convert markdown readmes to HTML pages (on `generate-resources`)
 3. Copy generated pages to classpath resources (on `process-resources`)

Dashboard repo page includes this readme as a part of `body` content if repo type matches expected readme type.