### PR TITLE
Slices and storages measured decorator

### DIFF
--- a/src/main/java/com/artipie/MeasuredSlice.java
+++ b/src/main/java/com/artipie/MeasuredSlice.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie;
+
+import com.artipie.http.Connection;
+import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.rs.RsStatus;
+import com.jcabi.log.Logger;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice implementation which measures request and response time.
+ * @since 0.10
+ */
+public final class MeasuredSlice implements Slice {
+
+    /**
+     * Origin slice.
+     */
+    private final Slice origin;
+
+    /**
+     * Wraps slice with measured decorator.
+     * @param origin Origin slice to measure
+     */
+    public MeasuredSlice(final Slice origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public Response response(final String line,
+        final Iterable<Map.Entry<String, String>> headers, final Publisher<ByteBuffer> body) {
+        final Response res;
+        if (Logger.isDebugEnabled(MeasuredSlice.class)) {
+            res = this.debugResponse(line, headers, body);
+        } else {
+            res = this.origin.response(line, headers, body);
+        }
+        return res;
+    }
+
+    /**
+     * Debug response.
+     * @param line Request line
+     * @param headers Headers
+     * @param body Body
+     * @return Response
+     */
+    private Response debugResponse(final String line,
+        final Iterable<Map.Entry<String, String>> headers, final Publisher<ByteBuffer> body) {
+        final long start = System.nanoTime();
+        final StringBuilder message = new StringBuilder();
+        message.append(line).append(": ");
+        final Response response = this.origin.response(line, headers, body);
+        message.append(String.format("response=%s ", millisMessage(start)));
+        return new MeasuredResponse(response, message, start);
+    }
+
+    /**
+     * Amount of milliseconds from time.
+     * @param from Starting point in nanoseconds
+     * @return Formatted milliseconds message
+     */
+    private static String millisMessage(final long from) {
+        // @checkstyle MagicNumberCheck (1 line)
+        return String.format("%dms", (System.nanoTime() - from) / 1_000_000);
+    }
+
+    /**
+     * Measured response wrapper.
+     * @since 0.10
+     */
+    @SuppressWarnings("PMD.AvoidStringBufferField")
+    private static final class MeasuredResponse implements Response {
+
+        /**
+         * Origin response.
+         */
+        private final Response origin;
+
+        /**
+         * Log message builder.
+         */
+        private final StringBuilder message;
+
+        /**
+         * Start time.
+         */
+        private final long start;
+
+        /**
+         * New measured response.
+         * @param origin Origin response
+         * @param message Log message builder
+         * @param start Start time nanoseconds
+         */
+        MeasuredResponse(final Response origin, final StringBuilder message,
+            final long start) {
+            this.origin = origin;
+            this.message = message;
+            this.start = start;
+        }
+
+        @Override
+        public CompletionStage<Void> send(final Connection con) {
+            final long send = System.nanoTime();
+            return this.origin.send(new MeasuredConnection(con, this.message)).thenRun(
+                () -> {
+                    final String log;
+                    synchronized (this.message) {
+                        log = this.message.append(String.format("send=%s ", millisMessage(send)))
+                            .append(String.format("total=%s", millisMessage(this.start)))
+                            .toString();
+                    }
+                    Logger.debug(MeasuredSlice.class, log);
+                }
+            );
+        }
+    }
+
+    /**
+     * Measured connection wrapper.
+     * @since 0.10
+     */
+    @SuppressWarnings("PMD.AvoidStringBufferField")
+    private static final class MeasuredConnection implements Connection {
+
+        /**
+         * Origin connection.
+         */
+        private final Connection origin;
+
+        /**
+         * Log message builder.
+         */
+        private final StringBuilder message;
+
+        /**
+         * New measured connection.
+         * @param origin Origin connection
+         * @param message Log message builder
+         */
+        private MeasuredConnection(final Connection origin, final StringBuilder message) {
+            this.origin = origin;
+            this.message = message;
+        }
+
+        @Override
+        public CompletionStage<Void> accept(final RsStatus status, final Headers headers,
+            final Publisher<ByteBuffer> body) {
+            final long time = System.nanoTime();
+            return this.origin.accept(status, headers, body).thenRun(
+                () -> {
+                    synchronized (this.message) {
+                        this.message.append(String.format("accept=%s ", millisMessage(time)));
+                    }
+                }
+            );
+        }
+    }
+}

--- a/src/main/java/com/artipie/MeasuredStorage.java
+++ b/src/main/java/com/artipie/MeasuredStorage.java
@@ -1,0 +1,299 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.Transaction;
+import com.jcabi.log.Logger;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Storage implementation which measures IO operations execution time.
+ * @since 0.10
+ * @checkstyle AnonInnerLengthCheck (500 lines)
+ */
+public final class MeasuredStorage implements Storage {
+
+    /**
+     * Origin storage.
+     */
+    private final Storage origin;
+
+    /**
+     * Wraps storage with measured decorator.
+     * @param storage Origin storage to measure
+     */
+    public MeasuredStorage(final Storage storage) {
+        this.origin = storage;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(final Key key) {
+        final long start = System.nanoTime();
+        return this.origin.exists(key).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class, "exists(%s): %s", key.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Collection<Key>> list(final Key key) {
+        final long start = System.nanoTime();
+        return this.origin.list(key).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class, "list(%s): %s", key.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Void> save(final Key key, final Content content) {
+        final long start = System.nanoTime();
+        return this.origin.save(
+            key,
+            new Content() {
+                @Override
+                public Optional<Long> size() {
+                    return content.size();
+                }
+
+                @Override
+                public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+                    content.subscribe(
+                        new Subscriber<>() {
+                            @Override
+                            public void onSubscribe(final Subscription subscription) {
+                                Logger.debug(
+                                    MeasuredStorage.class,
+                                    "save(%s): onSubscribe(subscription=%s) %s",
+                                    key.string(), subscription, millisMessage(start)
+                                );
+                                subscriber.onSubscribe(
+                                    new Subscription() {
+                                        @Override
+                                        public void request(final long num) {
+                                            Logger.debug(
+                                                MeasuredStorage.class,
+                                                "save(%s): request(n=%d) %s",
+                                                key.string(), num, millisMessage(start)
+                                            );
+                                            subscription.request(num);
+                                        }
+
+                                        @Override
+                                        public void cancel() {
+                                            Logger.debug(
+                                                MeasuredStorage.class,
+                                                "save(%s): cancel() %s",
+                                                key.string(), millisMessage(start)
+                                            );
+                                            subscription.cancel();
+                                        }
+                                    }
+                                );
+                            }
+
+                            @Override
+                            public void onNext(final ByteBuffer buffer) {
+                                Logger.debug(
+                                    MeasuredStorage.class,
+                                    "save(%s): next(buffer=%s) %s",
+                                    key.string(), buffer, millisMessage(start)
+                                );
+                                subscriber.onNext(buffer);
+                            }
+
+                            @Override
+                            public void onError(final Throwable err) {
+                                Logger.debug(
+                                    MeasuredStorage.class,
+                                    "save(%s): onError(subscription=%s) %s",
+                                    key.string(), err, millisMessage(start)
+                                );
+                                subscriber.onError(err);
+                            }
+
+                            @Override
+                            public void onComplete() {
+                                Logger.debug(
+                                    MeasuredStorage.class,
+                                    "save(%s): onComplete() %s",
+                                    key.string(), millisMessage(start)
+                                );
+                                subscriber.onComplete();
+                            }
+                        }
+                    );
+                }
+            }
+        ).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class,
+                    "save(%s): %s",
+                    key.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Void> move(final Key src, final Key dst) {
+        final long start = System.nanoTime();
+        return this.origin.move(src, dst).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class,
+                    "move(%s, %s): %s",
+                    src.string(), dst.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Long> size(final Key key) {
+        final long start = System.nanoTime();
+        return this.origin.size(key).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class, "size(%s): %s", key.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Content> value(final Key key) {
+        final long start = System.nanoTime();
+        return this.origin.value(key).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class,
+                    "value(%s): %s", key.string(), millisMessage(start)
+                );
+                return new Content() {
+                    @Override
+                    public Optional<Long> size() {
+                        return res.size();
+                    }
+
+                    @Override
+                    public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+                        res.subscribe(
+                            new Subscriber<>() {
+                                @Override
+                                public void onSubscribe(final Subscription subscription) {
+                                    Logger.debug(
+                                        MeasuredStorage.class,
+                                        "value(%s): onSubscribe(%s) %s",
+                                        key.string(), subscription, millisMessage(start)
+                                    );
+                                    subscriber.onSubscribe(subscription);
+                                }
+
+                                @Override
+                                public void onNext(final ByteBuffer buffer) {
+                                    Logger.debug(
+                                        MeasuredStorage.class,
+                                        "value(%s): onNext(%s) %s",
+                                        key.string(), buffer, millisMessage(start)
+                                    );
+                                    subscriber.onNext(buffer);
+                                }
+
+                                @Override
+                                public void onError(final Throwable err) {
+                                    Logger.debug(
+                                        MeasuredStorage.class,
+                                        "value(%s): error(%s) %s",
+                                        key.string(), err, millisMessage(start)
+                                    );
+                                    subscriber.onError(err);
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                    Logger.debug(
+                                        MeasuredStorage.class,
+                                        "value(%s): complete() %s",
+                                        key.string(), millisMessage(start)
+                                    );
+                                    subscriber.onComplete();
+                                }
+                            }
+                        );
+                    }
+                };
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(final Key key) {
+        final long start = System.nanoTime();
+        return this.origin.delete(key).thenApply(
+            res -> {
+                Logger.debug(
+                    MeasuredStorage.class,
+                    "delete(%s): %s", key.string(), millisMessage(start)
+                );
+                return res;
+            }
+        );
+    }
+
+    @Override
+    public CompletableFuture<Transaction> transaction(final List<Key> list) {
+        return this.origin.transaction(list);
+    }
+
+    /**
+     * Amount of milliseconds from time.
+     * @param from Starting point in nanoseconds
+     * @return Formatted milliseconds message
+     */
+    private static String millisMessage(final long from) {
+        // @checkstyle MagicNumberCheck (1 line)
+        return String.format("%dms", (System.nanoTime() - from) / 1_000_000);
+    }
+}

--- a/src/main/java/com/artipie/RepoConfig.java
+++ b/src/main/java/com/artipie/RepoConfig.java
@@ -147,7 +147,7 @@ public final class RepoConfig {
      * @return Async storage for repo
      */
     public Storage storage(final YamlMapping config) {
-        return this.storageOpt(config).orElseThrow(
+        return this.storageOpt(config).map(MeasuredStorage::new).orElseThrow(
             () -> new IllegalStateException("Storage is not configured")
         );
     }

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -55,6 +55,7 @@ import org.reactivestreams.Publisher;
  *  providers there. E.g. user can use ordered list of env auth, github auth
  *  and auth from yaml file.
  * @checkstyle ReturnCountCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class YamlSettings implements Settings {
 
@@ -78,12 +79,14 @@ public final class YamlSettings implements Settings {
 
     @Override
     public Storage storage() throws IOException {
-        return new YamlStorage(
-            Yaml.createYamlInput(this.content)
-                .readYamlMapping()
-                .yamlMapping(YamlSettings.KEY_META)
-                .yamlMapping("storage")
-        ).storage();
+        return new MeasuredStorage(
+            new YamlStorage(
+                Yaml.createYamlInput(this.content)
+                    .readYamlMapping()
+                    .yamlMapping(YamlSettings.KEY_META)
+                    .yamlMapping("storage")
+            ).storage()
+        );
     }
 
     @Override

--- a/src/main/java/com/artipie/http/Pie.java
+++ b/src/main/java/com/artipie/http/Pie.java
@@ -24,6 +24,7 @@
 
 package com.artipie.http;
 
+import com.artipie.MeasuredSlice;
 import com.artipie.Settings;
 import com.artipie.api.ArtipieApi;
 import com.artipie.dashboard.DashboardSlice;
@@ -69,20 +70,22 @@ public final class Pie extends Slice.Wrap {
     public Pie(final Settings settings) {
         super(
             new SafeSlice(
-                new DockerRoutingSlice(
-                    new LoggingSlice(
-                        Level.INFO,
-                        new SliceRoute(
-                            Pie.EMPTY_PATH,
-                            new RtRulePath(
-                                new RtRule.ByPath(Pattern.compile("/api/?.*")),
-                                new ArtipieApi(settings)
-                            ),
-                            new RtRulePath(
-                                new RtIsDashboard(settings), new DashboardSlice(settings)
-                            ),
-                            new RtRulePath(
-                                RtRule.FALLBACK, new SliceByPath(settings)
+                new MeasuredSlice(
+                    new DockerRoutingSlice(
+                        new LoggingSlice(
+                            Level.INFO,
+                            new SliceRoute(
+                                Pie.EMPTY_PATH,
+                                new RtRulePath(
+                                    new RtRule.ByPath(Pattern.compile("/api/?.*")),
+                                    new ArtipieApi(settings)
+                                ),
+                                new RtRulePath(
+                                    new RtIsDashboard(settings), new DashboardSlice(settings)
+                                ),
+                                new RtRulePath(
+                                    RtRule.FALLBACK, new SliceByPath(settings)
+                                )
                             )
                         )
                     )

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -4,3 +4,5 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %d %t %c - %m%n
 
+#log4j.logger.com.artipie.MeasuredSlice=DEBUG
+#log4j.logger.com.artipie.MeasuredStorage=DEBUG

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -24,8 +24,6 @@
 package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.artipie.asto.fs.FileStorage;
-import com.artipie.asto.s3.S3Storage;
 import com.artipie.auth.AuthFromEnv;
 import com.artipie.http.auth.Authentication;
 import java.nio.file.Files;
@@ -58,7 +56,7 @@ class YamlSettingsTest {
         );
         MatcherAssert.assertThat(
             settings.storage(),
-            Matchers.instanceOf(FileStorage.class)
+            Matchers.notNullValue()
         );
     }
 
@@ -81,7 +79,7 @@ class YamlSettingsTest {
         );
         MatcherAssert.assertThat(
             settings.storage(),
-            Matchers.instanceOf(S3Storage.class)
+            Matchers.notNullValue()
         );
     }
 


### PR DESCRIPTION
#382 - added measured decorator for all slices and storages if debug logging enabled. It prints execution time of all reuqests and all IO operations with `DEBUG` level.

The result of this measurement: some upload requests can be fetched from HTTP connection about 2-3 seconds for Maven repository, e.g. this is the log for small checksum file upload (size = 32 bytes): next `ByteBuffer` was requested from subscribtion in `0ms`, received after `2996ms` and saved at `2996ms` (less than `1ms`), completed in `2997ms` (moved temporary file to destination in less than `2ms`)
```
    [DEBUG] 2020-07-27 17:14:33,280 FileStorage-11 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): onSubscribe(subscription=0) 0ms
    [DEBUG] 2020-07-27 17:14:33,280 FileStorage-11 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): request(n=3) 0ms
    [DEBUG] 2020-07-27 17:14:36,276 vert.x-eventloop-thread-1 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): next(buffer=java.nio.HeapByteBuffer[pos=0 lim=32 cap=32]) 2996ms
    [DEBUG] 2020-07-27 17:14:36,276 vert.x-eventloop-thread-1 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): onComplete() 2996ms
    [DEBUG] 2020-07-27 17:14:36,276 FileStorage-2 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): request(n=3) 2996ms
    [INFO] 2020-07-27 17:14:36,277 FileStorage-3 com.artipie.asto.fs.FileStorage - Save 'artipie/test/com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5': Optional.empty
    [DEBUG] 2020-07-27 17:14:36,277 FileStorage-3 com.artipie.MeasuredStorage - save(com/artipie/sample-for-deployment/1.0/sample-for-deployment-1.0.pom.md5): 2997ms
    [INFO] 2020-07-27 17:14:36,277 FileStorage-3 com.artipie.http.rt.SliceRoute - << CREATED
```

But binary `file` repository doesn't have such issue and can upload big files much faster.