### PR TITLE
Accept Artifactory create-repo API requests

### DIFF
--- a/src/main/java/com/artipie/api/ContentAs.java
+++ b/src/main/java/com/artipie/api/ContentAs.java
@@ -29,8 +29,12 @@ import com.artipie.asto.Concatenation;
 import com.artipie.asto.Remaining;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
+import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 import org.reactivestreams.Publisher;
 
 /**
@@ -54,6 +58,17 @@ public final class ContentAs<T>
     public static final ContentAs<YamlMapping> YAML = new ContentAs<>(
         bytes -> Yaml.createYamlInput(new String(bytes, StandardCharsets.UTF_8))
             .readYamlMapping()
+    );
+
+    /**
+     * Content as JSON.
+     */
+    public static final ContentAs<JsonObject> JSON = new ContentAs<>(
+        bytes -> {
+            try (JsonReader reader = Json.createReader(new ByteArrayInputStream(bytes))) {
+                return reader.readObject();
+            }
+        }
     );
 
     /**

--- a/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
@@ -113,7 +113,7 @@ public final class CreateRepoSlice implements Slice {
         final String key = json.getString("key", "");
         if (!key.isEmpty() && "local".equals(json.getString("rclass", ""))
             && "docker".equals(json.getString("packageType", ""))
-            && "v2".equals(json.getString("dockerApiVersion", ""))) {
+            && "V2".equals(json.getString("dockerApiVersion", ""))) {
             res = Optional.of(key);
         } else {
             res = Optional.empty();

--- a/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.api.artifactory;
+
+import com.artipie.Settings;
+import com.artipie.api.ContentAs;
+import com.artipie.asto.Key;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import com.jcabi.log.Logger;
+import io.reactivex.Single;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.json.JsonObject;
+import org.reactivestreams.Publisher;
+
+/**
+ * Artifactory create repo API slice, it accepts json and create new docker repository by
+ * creating corresponding YAML configuration.
+ * @since 0.9
+ */
+public final class CreateRepoSlice implements Slice {
+
+    /**
+     * Artipie settings.
+     */
+    private final Settings settings;
+
+    /**
+     * Ctor.
+     * @param settings Artipie settings
+     */
+    public CreateRepoSlice(final Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        // @checkstyle ReturnCountCheck (20 lines)
+        return new AsyncResponse(
+            Single.just(body).to(ContentAs.JSON).flatMap(
+                json -> Single.fromFuture(
+                    valid(json).map(
+                        name -> {
+                            try {
+                                return this.settings.storage().exists(
+                                    new Key.From(String.format("%s.yaml", name))
+                                ).thenApply(
+                                    exists -> {
+                                        final Response res;
+                                        if (exists) {
+                                            res = new RsWithStatus(RsStatus.BAD_REQUEST);
+                                        } else {
+                                            res = new RsWithStatus(RsStatus.OK);
+                                        }
+                                        return res;
+                                    }
+                                );
+                            } catch (final IOException ex) {
+                                Logger.error(this, ex.toString());
+                                return CompletableFuture.completedFuture(
+                                    new RsWithStatus(RsStatus.INTERNAL_ERROR)
+                                );
+                            }
+                        }
+                    ).orElse(
+                        CompletableFuture.completedFuture(new RsWithStatus(RsStatus.BAD_REQUEST))
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Checks if json is valid (contains new repo key and supported setting) and
+     * return new repo name.
+     * @param json Json to read repo name from
+     * @return True if json is correct
+     */
+    private static Optional<String> valid(final JsonObject json) {
+        final Optional<String> res;
+        final String key = json.getString("key", "");
+        if (!key.isEmpty() && "local".equals(json.getString("rclass", ""))
+            && "docker".equals(json.getString("packageType", ""))
+            && "v2".equals(json.getString("dockerApiVersion", ""))) {
+            res = Optional.of(key);
+        } else {
+            res = Optional.empty();
+        }
+        return res;
+    }
+
+}

--- a/src/main/java/com/artipie/api/artifactory/package-info.java
+++ b/src/main/java/com/artipie/api/artifactory/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Artifactory API support.
+ *
+ * @since 0.9
+ */
+package com.artipie.api.artifactory;

--- a/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
@@ -96,7 +96,7 @@ class CreateRepoSliceTest {
                     .add("key", "my_repo")
                     .add("rclass", "local")
                     .add("packageType", "docker")
-                    .add("dockerApiVersion", "v2")
+                    .add("dockerApiVersion", "V2")
                     .build().toString().getBytes()
             )
         );

--- a/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.api.artifactory;
+
+import com.artipie.Settings;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.RsStatus;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link CreateRepoSlice}.
+ * @since 0.9
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class CreateRepoSliceTest {
+
+    @Test
+    void returnsOkIfJsonIsValid() {
+        MatcherAssert.assertThat(
+            new CreateRepoSlice(new Settings.Fake()).response(
+                new RequestLine("PUT", "/api/repositories/my_repo").toString(),
+                Collections.emptyList(),
+                this.jsonBody()
+            ),
+            new RsHasStatus(RsStatus.OK)
+        );
+    }
+
+    @Test
+    void returnsBadRequestIfRepoAlreadyExists() {
+        final Storage storage = new InMemoryStorage();
+        storage.save(new Key.From("my_repo.yaml"), new Content.From(new byte[]{}));
+        MatcherAssert.assertThat(
+            new CreateRepoSlice(new Settings.Fake(storage)).response(
+                new RequestLine("PUT", "/api/repositories/my_repo").toString(),
+                Collections.emptyList(),
+                this.jsonBody()
+            ),
+            new RsHasStatus(RsStatus.BAD_REQUEST)
+        );
+    }
+
+    @Test
+    void returnsBadRequestIfJsonIsNotValid() {
+        MatcherAssert.assertThat(
+            new CreateRepoSlice(new Settings.Fake()).response(
+                new RequestLine("PUT", "/api/repositories/my_repo").toString(),
+                Collections.emptyList(),
+                Flowable.fromArray(
+                    ByteBuffer.wrap(
+                        Json.createObjectBuilder()
+                            .add("some", "key")
+                            .build().toString().getBytes()
+                    )
+                )
+            ),
+            new RsHasStatus(RsStatus.BAD_REQUEST)
+        );
+    }
+
+    private Flowable<ByteBuffer> jsonBody() {
+        return Flowable.fromArray(
+            ByteBuffer.wrap(
+                Json.createObjectBuilder()
+                    .add("key", "my_repo")
+                    .add("rclass", "local")
+                    .add("packageType", "docker")
+                    .add("dockerApiVersion", "v2")
+                    .build().toString().getBytes()
+            )
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/api/artifactory/package-info.java
+++ b/src/test/java/com/artipie/api/artifactory/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Artifactory API support, tests.
+ *
+ * @since 0.9
+ */
+package com.artipie.api.artifactory;


### PR DESCRIPTION
Part of #413: added create repo api slice, implemented json body parsing and validation.