### PR TITLE
#413 - create yaml config on create repo request

### DIFF
--- a/src/main/java/com/artipie/api/ArtipieApi.java
+++ b/src/main/java/com/artipie/api/ArtipieApi.java
@@ -26,6 +26,7 @@ package com.artipie.api;
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.Settings;
 import com.artipie.YamlPermissions;
+import com.artipie.api.artifactory.CreateRepoSlice;
 import com.artipie.asto.Concatenation;
 import com.artipie.asto.Key;
 import com.artipie.asto.Remaining;
@@ -143,6 +144,13 @@ public final class ArtipieApi extends Slice.Wrap {
                                     new RtRule.ByMethod(RqMethod.POST)
                                 ),
                                 new ApiChangeUserPassword(settings)
+                            ),
+                            new RtRulePath(
+                                new RtRule.All(
+                                    new RtRule.ByPath(Pattern.compile("/api/repositories/.*")),
+                                    new RtRule.ByMethod(RqMethod.PUT)
+                                ),
+                                new CreateRepoSlice(settings)
                             )
                         ),
                         new Permission.ByName("api", perm),

--- a/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
@@ -36,24 +36,52 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link CreateRepoSlice}.
  * @since 0.9
+ * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class CreateRepoSliceTest {
 
     @Test
-    void returnsOkIfJsonIsValid() {
+    void returnsOkAndSavesYamlIfJsonIsValidWithUser() {
+        final Storage storage = new InMemoryStorage();
         MatcherAssert.assertThat(
-            new CreateRepoSlice(new Settings.Fake()).response(
+            "Returns 200 OK",
+            new CreateRepoSlice(new Settings.Fake(storage)).response(
+                new RequestLine("PUT", "/api/repositories/username/my_repo").toString(),
+                Collections.emptyList(),
+                this.jsonBody()
+            ),
+            new RsHasStatus(RsStatus.OK)
+        );
+        MatcherAssert.assertThat(
+            "Saves yaml to storage",
+            storage.exists(new Key.From("username/my_repo.yaml")).join(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void returnsOkAndSavesYamlIfJsonIsValid() {
+        final Storage storage = new InMemoryStorage();
+        MatcherAssert.assertThat(
+            "Returns 200 OK",
+            new CreateRepoSlice(new Settings.Fake(storage)).response(
                 new RequestLine("PUT", "/api/repositories/my_repo").toString(),
                 Collections.emptyList(),
                 this.jsonBody()
             ),
             new RsHasStatus(RsStatus.OK)
+        );
+        MatcherAssert.assertThat(
+            "Saves yaml to storage",
+            storage.exists(new Key.From("my_repo.yaml")).join(),
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
For #413 
- added regexp to handle with/without username requests to support both configuration layouts
- implemented saving yaml to storage
- added new endpoint for `CreateRepoSlice` 