### PR TITLE
Updated http, asto and pypi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.15.3</version>
+      <version>0.15.5</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.23.3</version>
+      <version>0.23.4</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>pypi-adapter</artifactId>
-      <version>0.6</version>
+      <version>0.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>


### PR DESCRIPTION
Updated http to `0.15.5`, asto to `0.23.4` and pypi to `0.6.1`.