### PR TITLE
#401 - Docker upgraded to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>docker-adapter</artifactId>
-      <version>0.4.1</version>
+      <version>0.4.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -261,7 +261,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "docker-proxy":
-                slice = new DockerProxy(SliceFromConfig.HTTP.client(), cfg, permissions, auth);
+                slice = new DockerProxy(SliceFromConfig.HTTP, cfg, permissions, auth);
                 break;
             default:
                 throw new IllegalStateException(

--- a/src/test/java/com/artipie/docker/DockerProxyTest.java
+++ b/src/test/java/com/artipie/docker/DockerProxyTest.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Key;
 import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Permissions;
+import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
@@ -38,7 +39,6 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
-import org.eclipse.jetty.client.HttpClient;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,7 +84,7 @@ class DockerProxyTest {
 
     private static DockerProxy dockerProxy(final String yaml) throws IOException {
         return new DockerProxy(
-            new HttpClient(),
+            new JettyClientSlices(),
             new RepoConfig(
                 alias -> {
                     throw new UnsupportedOperationException();


### PR DESCRIPTION
Part of #401 
Upgraded Docker 4.0.2 that is using abstract HTTP client and does not leak proxy connections.