### PR TITLE
Added health endpoint

### DIFF
--- a/src/main/java/com/artipie/http/HealthSlice.java
+++ b/src/main/java/com/artipie/http/HealthSlice.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http;
+
+import com.artipie.Settings;
+import com.artipie.api.RsJson;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.json.Json;
+import org.reactivestreams.Publisher;
+
+/**
+ * Health check slice.
+ * <p>
+ * Returns JSON with verbose status checks,
+ * response status is {@code OK} if all status passed and {@code BAD_REQUEST} if any failed.
+ * </p>
+ * @since 0.10
+ * @checkstyle AvoidInlineConditionalsCheck (500 lines)
+ */
+public final class HealthSlice implements Slice {
+
+    /**
+     * Artipie settings.
+     */
+    private final Settings settings;
+
+    /**
+     * New health slice.
+     * @param settings Artipie settings
+     */
+    public HealthSlice(final Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public Response response(final String line,
+        final Iterable<Map.Entry<String, String>> headers, final Publisher<ByteBuffer> body) {
+        return new AsyncResponse(
+            this.storageStatus().thenApply(
+                ok ->
+                    new RsWithStatus(
+                        new RsJson(
+                            Json.createArrayBuilder().add(
+                                Json.createObjectBuilder().add("storage", ok ? "ok" : "failure")
+                            ).build()
+                        ),
+                        ok ? RsStatus.OK : RsStatus.BAD_REQUEST
+                    )
+            )
+        );
+    }
+
+    /**
+     * Checks storage status by writing {@code OK} to storage.
+     * @return True if OK
+     * @checkstyle ReturnCountCheck (10 lines)
+     */
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    private CompletionStage<Boolean> storageStatus() {
+        try {
+            return this.settings.storage().save(
+                new Key.From(".system", "test"),
+                new Content.From("OK".getBytes(StandardCharsets.US_ASCII))
+            ).thenApply(none -> true).exceptionally(ignore -> false);
+        } catch (final IOException ignore) {
+            return CompletableFuture.completedFuture(false);
+        }
+    }
+}

--- a/src/main/java/com/artipie/http/HealthSlice.java
+++ b/src/main/java/com/artipie/http/HealthSlice.java
@@ -43,7 +43,7 @@ import org.reactivestreams.Publisher;
  * Health check slice.
  * <p>
  * Returns JSON with verbose status checks,
- * response status is {@code OK} if all status passed and {@code BAD_REQUEST} if any failed.
+ * response status is {@code OK} if all status passed and {@code UNAVAILABLE} if any failed.
  * </p>
  * @since 0.10
  * @checkstyle AvoidInlineConditionalsCheck (500 lines)
@@ -75,7 +75,7 @@ public final class HealthSlice implements Slice {
                                 Json.createObjectBuilder().add("storage", ok ? "ok" : "failure")
                             ).build()
                         ),
-                        ok ? RsStatus.OK : RsStatus.BAD_REQUEST
+                        ok ? RsStatus.OK : RsStatus.UNAVAILABLE
                     )
             )
         );

--- a/src/main/java/com/artipie/http/Pie.java
+++ b/src/main/java/com/artipie/http/Pie.java
@@ -88,6 +88,10 @@ public final class Pie extends Slice.Wrap {
                                 new SliceRoute(
                                     Pie.EMPTY_PATH,
                                     new RtRulePath(
+                                        new RtRule.ByPath(Pattern.compile("/\\.health")),
+                                        new HealthSlice(settings)
+                                    ),
+                                    new RtRulePath(
                                         new RtRule.ByPath(Pattern.compile("/api/?.*")),
                                         new ArtipieApi(settings)
                                     ),

--- a/src/test/java/com/artipie/http/HealthSliceTest.java
+++ b/src/test/java/com/artipie/http/HealthSliceTest.java
@@ -69,7 +69,7 @@ final class HealthSliceTest {
             new HealthSlice(new Settings.Fake(new FileStorage(Paths.get("/proc")))),
             new SliceHasResponse(
                 Matchers.allOf(
-                    new RsHasStatus(RsStatus.BAD_REQUEST),
+                    new RsHasStatus(RsStatus.UNAVAILABLE),
                     new RsHasBody("[{\"storage\":\"failure\"}]", StandardCharsets.UTF_8)
                 ),
                 HealthSliceTest.REQ_LINE

--- a/src/test/java/com/artipie/http/HealthSliceTest.java
+++ b/src/test/java/com/artipie/http/HealthSliceTest.java
@@ -66,7 +66,7 @@ final class HealthSliceTest {
     @Test
     void returnsBadRequestForBrokenStorage() {
         MatcherAssert.assertThat(
-            new HealthSlice(new Settings.Fake(new FileStorage(Paths.get("/proc")))),
+            new HealthSlice(new Settings.Fake(new FileStorage(Paths.get("/")))),
             new SliceHasResponse(
                 Matchers.allOf(
                     new RsHasStatus(RsStatus.UNAVAILABLE),

--- a/src/test/java/com/artipie/http/HealthSliceTest.java
+++ b/src/test/java/com/artipie/http/HealthSliceTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http;
+
+import com.artipie.Settings;
+import com.artipie.asto.fs.FileStorage;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link HealthSlice}.
+ *
+ * @since 0.10
+ */
+final class HealthSliceTest {
+
+    /**
+     * Request line for health endpoint.
+     */
+    private static final RequestLine REQ_LINE = new RequestLine(RqMethod.GET, "/.health");
+
+    @Test
+    void returnsOkForValidStorage() {
+        MatcherAssert.assertThat(
+            new HealthSlice(new Settings.Fake()),
+            new SliceHasResponse(
+                Matchers.allOf(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasBody("[{\"storage\":\"ok\"}]", StandardCharsets.UTF_8)
+                ),
+                HealthSliceTest.REQ_LINE
+            )
+        );
+    }
+
+    @Test
+    void returnsBadRequestForBrokenStorage() {
+        MatcherAssert.assertThat(
+            new HealthSlice(new Settings.Fake(new FileStorage(Paths.get("/proc")))),
+            new SliceHasResponse(
+                Matchers.allOf(
+                    new RsHasStatus(RsStatus.BAD_REQUEST),
+                    new RsHasBody("[{\"storage\":\"failure\"}]", StandardCharsets.UTF_8)
+                ),
+                HealthSliceTest.REQ_LINE
+            )
+        );
+    }
+}


### PR DESCRIPTION
#392 - added health endpoint for primary storage, it returns `OK` status if check passed and `BAD_REQUEST` (it seems to be the standard error for health check errors), and JSON array response with verbose statuses for each check (only storage for now).