### PR TITLE
#499 - Added Docker local repository auth tests

### DIFF
--- a/src/test/java/com/artipie/docker/DockerLocalAuthIT.java
+++ b/src/test/java/com/artipie/docker/DockerLocalAuthIT.java
@@ -1,0 +1,177 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.ArtipieServer;
+import com.artipie.docker.junit.DockerClient;
+import com.artipie.docker.junit.DockerClientSupport;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration test for auth in local Docker repositories.
+ *
+ * @since 0.10
+ * @todo #449:30min Check negative auth cases.
+ *  `DockerLocalAuthIT` contains tests for authenticated access
+ *  when there is enough permissions for certain operations.
+ *  However, to ensure that auth works as expected we need to check cases for auth failure:
+ *  - attempt to access with unknown user
+ *  - attempt to write with user without write permissions
+ *  - attempt to read with user without read permissions
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@DockerClientSupport
+@Disabled
+final class DockerLocalAuthIT {
+
+    /**
+     * Example docker image to use in tests.
+     */
+    private Image image;
+
+    /**
+     * Docker client.
+     */
+    private DockerClient client;
+
+    /**
+     * Tested Artipie server.
+     */
+    private ArtipieServer server;
+
+    /**
+     * Docker repository.
+     */
+    private String repository;
+
+    @BeforeEach
+    void setUp(@TempDir final Path root) throws Exception {
+        final String config = Yaml.createYamlMappingBuilder().add(
+            "repo",
+            Yaml.createYamlMappingBuilder()
+                .add("type", "docker")
+                .add(
+                    "storage",
+                    Yaml.createYamlMappingBuilder()
+                        .add("type", "fs")
+                        .add("path", root.resolve("data").toString())
+                        .build()
+                )
+                .add(
+                    "permissions",
+                    Yaml.createYamlMappingBuilder()
+                        .add(
+                            ArtipieServer.ALICE.name(),
+                            Yaml.createYamlSequenceBuilder()
+                                .add("read")
+                                .add("write")
+                                .build()
+                        )
+                        .add(
+                            ArtipieServer.BOB.name(),
+                            Yaml.createYamlSequenceBuilder()
+                                .add("read")
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        ).build().toString();
+        this.server = new ArtipieServer(root, "my-docker", config);
+        final int port = this.server.start();
+        this.repository = String.format("localhost:%d", port);
+        this.image = this.prepareImage();
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.server.stop();
+    }
+
+    @Test
+    void shouldPush() throws Exception {
+        this.login(ArtipieServer.ALICE);
+        final String output = this.client.run("push", this.image.remote());
+        MatcherAssert.assertThat(
+            output,
+            new AllOf<>(
+                Arrays.asList(
+                    new StringContains(String.format("%s: Pushed", this.image.layer())),
+                    new StringContains(String.format("latest: digest: %s", this.image.digest()))
+                )
+            )
+        );
+    }
+
+    @Test
+    void shouldPullPushed() throws Exception {
+        this.login(ArtipieServer.ALICE);
+        this.client.run("push", this.image.remote());
+        this.client.run("image", "rm", this.image.name());
+        this.client.run("image", "rm", this.image.remote());
+        this.login(ArtipieServer.BOB);
+        final String output = this.client.run("pull", this.image.remote());
+        MatcherAssert.assertThat(
+            output,
+            new StringContains(
+                String.format("Status: Downloaded newer image for %s", this.image.remote())
+            )
+        );
+    }
+
+    private Image prepareImage() throws Exception {
+        this.login(ArtipieServer.ALICE);
+        final Image source = new Image.ForOs();
+        this.client.run("pull", source.remoteByDigest());
+        final String local = "my-docker/my-test";
+        this.client.run("tag", source.remoteByDigest(), String.format("%s:latest", local));
+        final Image img = new Image.From(
+            this.repository,
+            local,
+            source.digest(),
+            source.layer()
+        );
+        this.client.run("tag", source.remoteByDigest(), img.remote());
+        return img;
+    }
+
+    private void login(final ArtipieServer.User user) throws Exception {
+        this.client.run(
+            "login",
+            "--username", user.name(),
+            "--password", user.password(),
+            this.repository
+        );
+    }
+}


### PR DESCRIPTION
Closes #499 
Added test cases for Docker repository when auth is required.
Th tests are disabled, because feature does not work at the moment. See #521 