### PR TITLE
Publish benchmarks results 

### DIFF
--- a/benchmarks/0.10/benchmark-results.json
+++ b/benchmarks/0.10/benchmark-results.json
@@ -1,0 +1,32 @@
+{
+    "docker": {
+        "single-upload": {
+            "artipie": {
+                "images": [
+                    {
+                        "ubuntu": 5.29334831237793
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 25.21306324005127
+                    },
+                    {
+                        "g4s8/artipie-base": 35.10451364517212
+                    }
+                ]
+            },
+            "docker-registry": {
+                "images": [
+                    {
+                        "ubuntu": 4.696374893188477
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 25.344408750534058
+                    },
+                    {
+                        "g4s8/artipie-base": 35.11510944366455
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/benchmarks/0.9.1/benchmark-results.json
+++ b/benchmarks/0.9.1/benchmark-results.json
@@ -1,0 +1,32 @@
+{
+    "docker": {
+        "single-upload": {
+            "artipie": {
+                "images": [
+                    {
+                        "ubuntu": 5.151881217956543
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 23.79420018196106
+                    },
+                    {
+                        "g4s8/artipie-base": 31.27388072013855
+                    }
+                ]
+            },
+            "docker-registry": {
+                "images": [
+                    {
+                        "ubuntu": 4.529898643493652
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 24.357195377349854
+                    },
+                    {
+                        "g4s8/artipie-base": 33.13980197906494
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/benchmarks/0.9.2/benchmark-results.json
+++ b/benchmarks/0.9.2/benchmark-results.json
@@ -1,0 +1,32 @@
+{
+    "docker": {
+        "single-upload": {
+            "artipie": {
+                "images": [
+                    {
+                        "ubuntu": 5.149324417114258
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 23.911609172821045
+                    },
+                    {
+                        "g4s8/artipie-base": 32.80001950263977
+                    }
+                ]
+            },
+            "docker-registry": {
+                "images": [
+                    {
+                        "ubuntu": 4.545761346817017
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 24.308050394058228
+                    },
+                    {
+                        "g4s8/artipie-base": 33.25234794616699
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/benchmarks/0.9.3/benchmark-results.json
+++ b/benchmarks/0.9.3/benchmark-results.json
@@ -1,0 +1,32 @@
+{
+    "docker": {
+        "single-upload": {
+            "artipie": {
+                "images": [
+                    {
+                        "ubuntu": 5.22969388961792
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 23.39838218688965
+                    },
+                    {
+                        "g4s8/artipie-base": 31.62078595161438
+                    }
+                ]
+            },
+            "docker-registry": {
+                "images": [
+                    {
+                        "ubuntu": 4.6897571086883545
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 24.525537490844727
+                    },
+                    {
+                        "g4s8/artipie-base": 31.12988519668579
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/benchmarks/0.9.5/benchmark-results.json
+++ b/benchmarks/0.9.5/benchmark-results.json
@@ -1,0 +1,32 @@
+{
+    "docker": {
+        "single-upload": {
+            "artipie": {
+                "images": [
+                    {
+                        "ubuntu": 5.188218832015991
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 24.38041377067566
+                    },
+                    {
+                        "g4s8/artipie-base": 31.886632680892944
+                    }
+                ]
+            },
+            "docker-registry": {
+                "images": [
+                    {
+                        "ubuntu": 4.738774061203003
+                    },
+                    {
+                        "graphiteapp/graphite-statsd": 24.551284074783325
+                    },
+                    {
+                        "g4s8/artipie-base": 34.70336890220642
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Remove old and publish new benchmarks results for Artipie versions `0.10 0.9.5 0.9.3 0.9.2 0.9.1`

Related #431.