### PR TITLE
#555 - user CRUD API fully described

### DIFF
--- a/ARTIFACTORY_API_SUPPORT.md
+++ b/ARTIFACTORY_API_SUPPORT.md
@@ -89,7 +89,7 @@ Possible responses:
 > **DELETE** /api/security/users/{userName}
 
 Possible responses:
-- `200 OK User '{userName}' has been removed successfully.` when user `{userName}` was successfully removed
+- `200 OK User '{userName}' has been removed successfully.` when user with `{userName}` was successfully removed
 - `404 NOT FOUND` when user was not found
 - `500 INTERNAL ERROR` in the case of unexpected server error
 

--- a/ARTIFACTORY_API_SUPPORT.md
+++ b/ARTIFACTORY_API_SUPPORT.md
@@ -67,7 +67,7 @@ If user is not found `404 NOT FOUND` status is returned.
 
 ### Create Or Update User
 
-[Creates, replaces](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-CreateorReplaceUser) or [updates](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-UpdateUser) user with {userName} from request URL.
+[Creates, replaces](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-CreateorReplaceUser) or [updates](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-UpdateUser) user with `{userName}` from request URL.
 
 > **PUT**/**POST** /api/security/users/{userName}
 
@@ -89,7 +89,7 @@ Possible responses:
 > **DELETE** /api/security/users/{userName}
 
 Possible responses:
-- `200 OK User '{userName}' has been removed successfully.` when user {userName} was successfully removed
+- `200 OK User '{userName}' has been removed successfully.` when user `{userName}` was successfully removed
 - `404 NOT FOUND` when user was not found
 - `500 INTERNAL ERROR` in the case of unexpected server error
 

--- a/ARTIFACTORY_API_SUPPORT.md
+++ b/ARTIFACTORY_API_SUPPORT.md
@@ -64,3 +64,32 @@ lastLoggedIn | string | Default `2020-01-01T01:01:01.000+01:00` | Y
 realm | string | User realm, value `Internal` is always returned | Y
 
 If user is not found `404 NOT FOUND` status is returned.
+
+### Create Or Update User
+
+[Creates, replaces](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-CreateorReplaceUser) or [updates](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-UpdateUser) user with {userName} from request URL.
+
+> **PUT**/**POST** /api/security/users/{userName}
+
+Consumes json with the following fields (any other fields are ignored): 
+
+Field name | Type | Meaning | Required
+------ | ------ | ------ | ------
+password | string | User password | Y
+
+Possible responses:
+- `200 OK` when user was successfully created or updated
+- `400 BAD REQUEST` when invalid json was sent
+- `500 INTERNAL ERROR` in the case of unexpected server error
+
+### Delete User
+
+[Removes](https://www.jfrog.com/confluence/display/rtf/artifactory+rest+api#ArtifactoryRESTAPI-DeleteUser) an Artipie user. 
+
+> **DELETE** /api/security/users/{userName}
+
+Possible responses:
+- `200 OK User '{userName}' has been removed successfully.` when user {userName} was successfully removed
+- `404 NOT FOUND` when user was not found
+- `500 INTERNAL ERROR` in the case of unexpected server error
+

--- a/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
@@ -80,7 +80,7 @@ public final class AddUpdateUserSlice implements Slice {
                                         username, DigestUtils.sha256Hex(haspassw),
                                         Credentials.PasswordFormat.SHA256
                                     ).thenApply(ok -> new RsWithStatus(RsStatus.OK)))
-                ).orElse(CompletableFuture.completedFuture(new RsWithStatus(RsStatus.NOT_FOUND))))
+                ).orElse(CompletableFuture.completedFuture(new RsWithStatus(RsStatus.BAD_REQUEST))))
             )
         ).orElse(new RsWithStatus(RsStatus.BAD_REQUEST));
     }

--- a/src/main/java/com/artipie/api/artifactory/DeleteUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/DeleteUserSlice.java
@@ -28,9 +28,11 @@ import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -71,7 +73,15 @@ public final class DeleteUserSlice implements Slice {
                             final CompletionStage<Response> resp;
                             if (has) {
                                 resp = cred.remove(username)
-                                    .thenApply(ok -> new RsWithStatus(RsStatus.OK));
+                                    .thenApply(
+                                        ok -> new RsWithBody(
+                                            new RsWithStatus(RsStatus.OK),
+                                            String.format(
+                                                "User '%s' has been removed successfully.",
+                                                username
+                                            ).getBytes(StandardCharsets.UTF_8)
+                                        )
+                                    );
                             } else {
                                 resp = CompletableFuture.completedFuture(StandardRs.NOT_FOUND);
                             }

--- a/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
@@ -70,11 +70,11 @@ final class AddUpdateUserSliceTest {
 
     @ParameterizedTest
     @EnumSource(value = RqMethod.class, names = {"PUT", "POST"})
-    void returnsNotFoundIfCredentialsAreEmpty(final RqMethod rqmeth) {
+    void returnsBadRequestIfCredentialsAreEmpty(final RqMethod rqmeth) {
         MatcherAssert.assertThat(
             new AddUpdateUserSlice(new Settings.Fake()),
             new SliceHasResponse(
-                new RsHasStatus(RsStatus.NOT_FOUND),
+                new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(rqmeth, "/api/security/users/empty")
             )
         );

--- a/src/test/java/com/artipie/api/artifactory/DeleteUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/DeleteUserSliceTest.java
@@ -31,6 +31,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
@@ -39,6 +40,7 @@ import com.artipie.http.rs.RsStatus;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 
@@ -95,7 +97,12 @@ final class DeleteUserSliceTest {
             "DeleteUserSlice response",
             new DeleteUserSlice(new Settings.Fake(new Credentials.FromStorageYaml(storage, key))),
             new SliceHasResponse(
-                new RsHasStatus(RsStatus.OK),
+                Matchers.allOf(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasBody(
+                        "User 'jane' has been removed successfully.", StandardCharsets.UTF_8
+                    )
+                ),
                 new RequestLine(RqMethod.DELETE, "/api/security/users/jane")
             )
         );


### PR DESCRIPTION
Part of #555.
I've fully described user CRUD API and fixed 2 slices to correspond Artifactory API:
- made `DeleteUserSlice` return `User '{userName}' has been removed successfully.` 
- made `AddUpdateUserSlice` return bad request when invalid json was sent