### PR TITLE
#565 - Artifactory API corrections

### DIFF
--- a/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
@@ -44,8 +44,8 @@ import javax.json.JsonValue;
 import org.reactivestreams.Publisher;
 
 /**
- * Artifactory `PUT /api/security/permissions/{target}` endpoint, returns json with
- * permissions (= repository) information.
+ * Artifactory `PUT /api/security/permissions/{target}` endpoint, updates `permissions` section
+ * in repository section.
  * @since 0.10
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
@@ -70,9 +70,9 @@ public final class GetPermissionSlice implements Slice {
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
         final Optional<String> opt = new FromRqLine(line, FromRqLine.RqPattern.REPO).get();
-        return new AsyncResponse(
-            opt.map(
-                repo -> new Unchecked<>(this.settings::storage).value()
+        return opt.<Response>map(
+            repo -> new AsyncResponse(
+                new Unchecked<>(this.settings::storage).value()
                     .exists(new Key.From(String.format("%s.yaml", repo))).thenCompose(
                         exists -> {
                             final CompletionStage<Response> res;
@@ -89,8 +89,8 @@ public final class GetPermissionSlice implements Slice {
                             return res;
                         }
                     )
-            ).orElse(CompletableFuture.completedFuture(new RsWithStatus(RsStatus.BAD_REQUEST)))
-        );
+            )
+        ).orElse(new RsWithStatus(RsStatus.BAD_REQUEST));
     }
 
     /**

--- a/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
@@ -65,6 +65,17 @@ class DeletePermissionSliceTest {
     }
 
     @Test
+    void returnsNotFoundIfRepositoryDoesNotExists() {
+        MatcherAssert.assertThat(
+            new DeletePermissionSlice(new Settings.Fake()),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.NOT_FOUND),
+                new RequestLine(RqMethod.DELETE, "/api/security/permissions/pypi")
+            )
+        );
+    }
+
+    @Test
     void deletesRepoPermissions() throws IOException {
         final Storage storage = new InMemoryStorage();
         final String repo = "docker";

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -74,12 +74,11 @@ class GetPermissionSliceTest {
 
     @Test
     void returnsNotFoundIfRepoDoesNotExists() {
-        final String repo = "pypi";
         MatcherAssert.assertThat(
             new GetPermissionSlice(new Settings.Fake(this.storage)),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.NOT_FOUND),
-                new RequestLine(RqMethod.GET, String.format("/api/security/permissions/%s", repo))
+                new RequestLine(RqMethod.GET, "/api/security/permissions/pypi")
             )
         );
     }

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -73,6 +73,18 @@ class GetPermissionSliceTest {
     }
 
     @Test
+    void returnsNotFoundIfRepoDoesNotExists() {
+        final String repo = "pypi";
+        MatcherAssert.assertThat(
+            new GetPermissionSlice(new Settings.Fake(this.storage)),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.NOT_FOUND),
+                new RequestLine(RqMethod.GET, String.format("/api/security/permissions/%s", repo))
+            )
+        );
+    }
+
+    @Test
     void returnsEmptyUsersIfNoPermissionsSet() {
         final String repo = "docker";
         final RepoPerms perm = new RepoPerms();


### PR DESCRIPTION
Closes #565 
Fixed `DeletePermissionSlice` and `GetPermissionSlice` to return 404 if repository does not exist.