### PR TITLE
#548 - Storage list slice gives only immediate children of root node

### DIFF
--- a/src/main/java/com/artipie/api/artifactory/GetStorageSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetStorageSlice.java
@@ -60,11 +60,12 @@ public final class GetStorageSlice implements Slice {
     @Override
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
+        final Key root = Key.ROOT;
         return new AsyncResponse(
-            this.storage.list(Key.ROOT)
+            this.storage.list(root)
                 .thenApply(
                     list -> {
-                        final KeyList keys = new KeyList();
+                        final KeyList keys = new KeyList(root);
                         list.forEach(keys::add);
                         return keys.print(new JsonOutput());
                     }

--- a/src/main/java/com/artipie/api/artifactory/KeyList.java
+++ b/src/main/java/com/artipie/api/artifactory/KeyList.java
@@ -39,14 +39,22 @@ import java.util.Set;
 public final class KeyList {
 
     /**
+     * Root key.
+     */
+    private final Key root;
+
+    /**
      * Key set.
      */
     private final Set<Key> keys;
 
     /**
      * Ctor.
+     *
+     * @param root Root key.
      */
-    public KeyList() {
+    public KeyList(final Key root) {
+        this.root = root;
         this.keys = new HashSet<>();
     }
 
@@ -69,7 +77,9 @@ public final class KeyList {
         final List<Key> list = new ArrayList<>(this.keys);
         list.sort(Comparator.comparing(Key::string));
         for (final Key key : list) {
-            format.add(key, key.parent().map(this.keys::contains).orElse(false));
+            if (key.parent().map(this.root::equals).orElse(true)) {
+                format.add(key, key.parent().map(this.keys::contains).orElse(false));
+            }
         }
         return format.result();
     }

--- a/src/test/java/com/artipie/api/artifactory/KeyListTest.java
+++ b/src/test/java/com/artipie/api/artifactory/KeyListTest.java
@@ -39,7 +39,7 @@ final class KeyListTest {
 
     @Test
     void printsSortedKeys() {
-        final KeyList target = new KeyList();
+        final KeyList target = new KeyList(Key.ROOT);
         for (final String item : Arrays.asList("aaa/111", "bbb/111", "aaa/222", "ccc", "bbb/222")) {
             target.add(new Key.From(item));
         }
@@ -48,12 +48,28 @@ final class KeyListTest {
             Matchers.stringContainsInOrder(
                 Arrays.asList(
                     "aaa/",
+                    "bbb/",
+                    "ccc"
+                )
+            )
+        );
+    }
+
+    @Test
+    void printsChildrenOnly() {
+        final KeyList target = new KeyList(new Key.From("aaa"));
+        for (final String item : Arrays.asList(
+            "aaa/111", "aaa/bbb/111", "aaa/222", "ccc", "aaa/bbb/222"
+        )) {
+            target.add(new Key.From(item));
+        }
+        MatcherAssert.assertThat(
+            target.print(new DummyFormat(new StringBuilder())),
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
                     "aaa/111",
                     "aaa/222",
-                    "bbb/",
-                    "bbb/111",
-                    "bbb/222",
-                    "ccc"
+                    "bbb/"
                 )
             )
         );


### PR DESCRIPTION
Part of #548 
Storage list slice gives only immediate children of root node