### PR TITLE
#574 - permissions mapping in AddUpdatePermissionSlice

### DIFF
--- a/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
@@ -93,12 +93,17 @@ class AddUpdatePermissionSliceTest {
         MatcherAssert.assertThat(
             "Sets permissions for bob",
             this.permissionsForUser(repo, "bob"),
-            Matchers.containsInAnyOrder("read", "write", "manage")
+            Matchers.containsInAnyOrder("read", "write", "*")
         );
         MatcherAssert.assertThat(
             "Sets permissions for alice",
             this.permissionsForUser(repo, "alice"),
-            Matchers.containsInAnyOrder("write", "annotate", "read")
+            Matchers.containsInAnyOrder("write", "read")
+        );
+        MatcherAssert.assertThat(
+            "Sets permissions for john",
+            this.permissionsForUser(repo, "john"),
+            Matchers.containsInAnyOrder("*")
         );
     }
 
@@ -123,8 +128,9 @@ class AddUpdatePermissionSliceTest {
             "    \"repositories\": [\"local-rep1\", \"remote-rep1\", \"virtual-rep2\"],",
             "    \"actions\": {",
             "          \"users\" : {",
-            "            \"bob\": [\"read\",\"write\",\"manage\"],",
-            "            \"alice\" : [\"write\",\"annotate\", \"read\"]",
+            "            \"bob\": [\"r\",\"write\",\"manage\"],",
+            "            \"alice\" : [\"w\", \"read\"],",
+            "            \"john\" : [\"admin\"]",
             "          },",
             "          \"groups\" : {",
             "            \"dev-leads\" : [\"manage\",\"read\",\"annotate\"],",


### PR DESCRIPTION
Part of #574 
I've added permissions mapping to `AddUpdatePermissionSlice` before saving them to repo config, possible permissions values are from [this](https://www.jfrog.com/confluence/display/JFROG/Security+Configuration+JSON#SecurityConfigurationJSON-application/vnd.org.jfrog.artifactory.security.PermissionTargetV2+json) docs.
Note that
- `annotate`, `managedXrayMeta` and `distribute` are not included as we do not know what they mean and how to translate them
- `admin` and `manage` are translated to `*` which means any actions will be allowed to these users

I'm planning to document it when we discuss, possibly change something and merge this PR. 