### PR TITLE
#574 - `GetPermissionSlice` and docs corrected

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -133,7 +133,7 @@ Returns json of the following format:
   "principals": {
     "users" : {
       "bob": ["r", "w", "m"],
-      "alice" : ["d", "w", "n", "r"]
+      "alice" : ["d", "w", "r"]
     }   
   }
 }
@@ -145,6 +145,13 @@ Field name | Type | Meaning | Required
 ------ | ------ | ------ | ------
 repositories | json array | Repository name, always one-element array with the `{permissionTargetName}` item | Y
 principals | json object | Repository permissions details, contains `users` element with user permission details | Y
+
+Here is the set of supported permissions along with shortening convention 
+(`delete` is supported for file storage only):
+
+```text
+w=deploy; m=admin; d=delete; r=read
+```
 
 If requested `{permissionTargetName}` does not exist, `404 NOT FOUND` status is returned.
 
@@ -162,7 +169,7 @@ Consumes json of the following form:
      "actions": {
        "users" : {
           "bob": ["read", "write", "manage"],
-          "alice" : ["write", "annotate", "read"]
+          "alice" : ["write", "read"]
        }
      }
    }
@@ -170,6 +177,12 @@ Consumes json of the following form:
 ```
 where field `users` contains list of the user names and corresponding permissions, all other fields 
 are ignored. 
+
+The following synonyms and shortened values for standard operations are supported:
+- `read` - `r` 
+- `write` - `w`, `deploy`
+- `delete` - `d`
+- `manage` (any operation is allowed) - `m`, `admin`
 
 Possible responses:
 - `200 OK` when permissions were added successfully

--- a/REST_API.md
+++ b/REST_API.md
@@ -146,11 +146,10 @@ Field name | Type | Meaning | Required
 repositories | json array | Repository name, always one-element array with the `{permissionTargetName}` item | Y
 principals | json object | Repository permissions details, contains `users` element with user permission details | Y
 
-Here is the set of supported permissions along with shortening convention 
-(`delete` is supported for file storage only):
+The set of supported permissions along with the shortening convention:
 
 ```text
-w=deploy; m=admin; d=delete; r=read
+w=deploy; m=admin; r=read; d=delete (`delete` is supported for file storage only)
 ```
 
 If requested `{permissionTargetName}` does not exist, `404 NOT FOUND` status is returned.

--- a/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
@@ -104,7 +104,17 @@ public final class GetPermissionSlice implements Slice {
         final JsonObjectBuilder builder = Json.createObjectBuilder();
         for (final RepoPermissions.UserPermission perm : permissions) {
             final JsonArrayBuilder array = Json.createArrayBuilder();
-            perm.permissions().forEach(array::add);
+            perm.permissions().stream().map(
+                item -> {
+                    final String mapped;
+                    if (item.equals("*")) {
+                        mapped = "m";
+                    } else {
+                        mapped = item.substring(0, 1);
+                    }
+                    return mapped;
+                }
+            ).forEach(array::add);
             builder.add(perm.username(), array.build());
         }
         return Json.createObjectBuilder()

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -102,12 +102,10 @@ class GetPermissionSliceTest {
         final String repo = "maven";
         final String john = "john";
         final String mark = "mark";
-        final String download = "download";
-        final String upload = "upload";
         final RepoPerms perm = new RepoPerms(
             List.of(
-                new RepoPermissions.UserPermission(john, new ListOf<String>(download, upload)),
-                new RepoPermissions.UserPermission(mark, new ListOf<String>(download))
+                new RepoPermissions.UserPermission(john, new ListOf<String>("read", "write")),
+                new RepoPermissions.UserPermission(mark, new ListOf<String>("*"))
             )
         );
         perm.saveSettings(this.storage, repo);
@@ -118,8 +116,8 @@ class GetPermissionSliceTest {
                     this.response(
                         repo,
                         Json.createObjectBuilder()
-                            .add(john, Json.createArrayBuilder().add(download).add(upload).build())
-                            .add(mark, Json.createArrayBuilder().add(download).build())
+                            .add(john, Json.createArrayBuilder().add("r").add("w").build())
+                            .add(mark, Json.createArrayBuilder().add("m").build())
                             .build()
                     )
                 ),


### PR DESCRIPTION
Closes #574 
I've changed `GetPermissionSlice` to shorten permissions actions and corrected docs.