### PR TITLE
#572 - read groups in AuthFromYaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.15.7</version>
+      <version>0.16.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -192,11 +192,6 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>npm-adapter</artifactId>
-      <version>0.6.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>npm-proxy-adapter</artifactId>
       <version>0.6.1</version>
     </dependency>
     <dependency>

--- a/src/main/java/com/artipie/auth/AuthFromEnv.java
+++ b/src/main/java/com/artipie/auth/AuthFromEnv.java
@@ -66,14 +66,14 @@ public final class AuthFromEnv implements Authentication {
 
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
-    public Optional<String> user(final String username, final String password) {
-        final Optional<String> result;
+    public Optional<Authentication.User> user(final String username, final String password) {
+        final Optional<Authentication.User> result;
         // @checkstyle LineLengthCheck (5 lines)
         if (Objects.equals(Objects.requireNonNull(username), this.env.get(AuthFromEnv.ENV_NAME))
             && Objects.equals(Objects.requireNonNull(password), this.env.get(AuthFromEnv.ENV_PASS))) {
-            result = Optional.of(username);
+            result = Optional.of(new Authentication.User(username));
         } else {
-            result = Optional.of("anonymous");
+            result = Optional.of(new Authentication.User("anonymous"));
         }
         return result;
     }

--- a/src/main/java/com/artipie/auth/AuthFromYaml.java
+++ b/src/main/java/com/artipie/auth/AuthFromYaml.java
@@ -42,6 +42,9 @@ import org.apache.commons.codec.digest.DigestUtils;
  *  |   pass: "plain:123"
  *  This configuration would mean that Joe should use his email to login instead of username. Do not
  *  forget to validate credentials, logins should be unique.
+ * @todo #572:30min Simplify `user()` method and get rid of nested if expressions: create separate
+ *  method to obtain password type either from separate `type` yaml field or from `pass`, get rid of
+ *  `check(String, String)` method and use `check()` with three params instead.
  */
 @SuppressWarnings({
     "PMD.AvoidDeeplyNestedIfStmts",
@@ -76,10 +79,18 @@ public final class AuthFromYaml implements Authentication {
             final String stored = users.yamlMapping(user).string("pass");
             if (stored != null) {
                 final String type = users.yamlMapping(user).string("type");
-                if (type != null && check(stored, type, pass)) {
-                    res = Optional.of(new User(user, AuthFromYaml.groups(users.yamlMapping(user))));
-                } else if (check(stored, pass)) {
-                    res = Optional.of(new User(user, AuthFromYaml.groups(users.yamlMapping(user))));
+                if (type != null) {
+                    if (check(stored, type, pass)) {
+                        res = Optional.of(
+                            new User(user, AuthFromYaml.groups(users.yamlMapping(user)))
+                        );
+                    }
+                } else {
+                    if (check(stored, pass)) {
+                        res = Optional.of(
+                            new User(user, AuthFromYaml.groups(users.yamlMapping(user)))
+                        );
+                    }
                 }
             }
         }

--- a/src/main/java/com/artipie/auth/CachedAuth.java
+++ b/src/main/java/com/artipie/auth/CachedAuth.java
@@ -52,7 +52,8 @@ public final class CachedAuth implements Authentication {
     /**
      * Static cache hash map.
      */
-    private static final ConcurrentMap<String, Optional<String>> CACHE = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, Optional<Authentication.User>> CACHE =
+        new ConcurrentHashMap<>();
 
     static {
         Executors.newSingleThreadScheduledExecutor()
@@ -74,7 +75,7 @@ public final class CachedAuth implements Authentication {
     }
 
     @Override
-    public Optional<String> user(final String username, final String password) {
+    public Optional<Authentication.User> user(final String username, final String password) {
         return CachedAuth.CACHE.computeIfAbsent(username, key -> this.origin.user(key, password));
     }
 

--- a/src/main/java/com/artipie/auth/GithubAuth.java
+++ b/src/main/java/com/artipie/auth/GithubAuth.java
@@ -79,15 +79,15 @@ public final class GithubAuth implements Authentication {
     }
 
     @Override
-    public Optional<String> user(final String username, final String password) {
-        Optional<String> result = Optional.empty();
+    public Optional<Authentication.User> user(final String username, final String password) {
+        Optional<Authentication.User> result = Optional.empty();
         final Matcher matcher = GithubAuth.PTN_NAME.matcher(username);
         if (matcher.matches()) {
             final String login = this.github.apply(password).toLowerCase(Locale.US);
             if (
                 Objects.equals(login, matcher.group(1).toLowerCase(Locale.US))
             ) {
-                result = Optional.of(login);
+                result = Optional.of(new Authentication.User(login));
             }
         }
         return result;

--- a/src/main/java/com/artipie/auth/LoggingAuth.java
+++ b/src/main/java/com/artipie/auth/LoggingAuth.java
@@ -64,8 +64,8 @@ public final class LoggingAuth implements Authentication {
     }
 
     @Override
-    public Optional<String> user(final String username, final String password) {
-        final Optional<String> res = this.origin.user(username, password);
+    public Optional<Authentication.User> user(final String username, final String password) {
+        final Optional<Authentication.User> res = this.origin.user(username, password);
         if (res.isEmpty()) {
             Logger.log(
                 this.level, this.origin,

--- a/src/test/java/com/artipie/auth/CachedAuthTest.java
+++ b/src/test/java/com/artipie/auth/CachedAuthTest.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.auth;
 
+import com.artipie.http.auth.Authentication;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
@@ -41,17 +42,19 @@ final class CachedAuthTest {
         final String username = "usr";
         final AtomicInteger counter = new AtomicInteger();
         final CachedAuth target = new CachedAuth(
-            (usr, pass) -> Optional.of(String.format("%s-%d", usr, counter.incrementAndGet()))
+            (usr, pass) -> Optional.of(
+                new Authentication.User(String.format("%s-%d", usr, counter.incrementAndGet()))
+            )
         );
         final String expected = "usr-1";
         MatcherAssert.assertThat(
             "Wrong user on first cache call",
-            target.user(username, "").orElseThrow(),
+            target.user(username, "").orElseThrow().name(),
             new IsEqual<>(expected)
         );
         MatcherAssert.assertThat(
             "Wrong user on second cache call",
-            target.user(username, "").orElseThrow(),
+            target.user(username, "").orElseThrow().name(),
             new IsEqual<>(expected)
         );
     }

--- a/src/test/java/com/artipie/auth/GithubAuthTest.java
+++ b/src/test/java/com/artipie/auth/GithubAuthTest.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.auth;
 
+import com.artipie.http.auth.Authentication;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ final class GithubAuthTest {
                     return "";
                 }
             ).user("github.com/UsEr", secret).orElseThrow(),
-            new IsEqual<>("user")
+            new IsEqual<>(new Authentication.User("user"))
         );
     }
 }


### PR DESCRIPTION
Part of #572 
Updated `http` and corrected `AuthFromYaml` read groups from `credentials.yaml` 