### PR TITLE
#572 - read/write groups in Users.FromStorageYaml

### DIFF
--- a/src/main/java/com/artipie/Settings.java
+++ b/src/main/java/com/artipie/Settings.java
@@ -72,7 +72,7 @@ public interface Settings {
      * Artipie credentials.
      * @return Completion action with credentials
      */
-    CompletionStage<Credentials> credentials();
+    CompletionStage<Users> credentials();
 
     /**
      * Fake {@link Settings} using a file storage.
@@ -89,7 +89,7 @@ public interface Settings {
         /**
          * Credentials.
          */
-        private final Credentials cred;
+        private final Users cred;
 
         /**
          * Yaml `meta` mapping.
@@ -116,7 +116,7 @@ public interface Settings {
         public Fake(final Storage storage) {
             this(
                 storage,
-                new Credentials.FromEnv(),
+                new Users.FromEnv(),
                 Yaml.createYamlMappingBuilder().build()
             );
         }
@@ -139,7 +139,7 @@ public interface Settings {
         public Fake(final Storage storage, final String layout) {
             this(
                 storage,
-                new Credentials.FromEnv(),
+                new Users.FromEnv(),
                 Yaml.createYamlMappingBuilder().build(),
                 layout
             );
@@ -150,7 +150,7 @@ public interface Settings {
          *
          * @param cred Credentials
          */
-        public Fake(final Credentials cred) {
+        public Fake(final Users cred) {
             this(new InMemoryStorage(), cred, Yaml.createYamlMappingBuilder().build());
         }
 
@@ -160,7 +160,7 @@ public interface Settings {
          * @param cred Credentials
          * @param meta Yaml `meta` mapping
          */
-        public Fake(final Credentials cred, final YamlMapping meta) {
+        public Fake(final Users cred, final YamlMapping meta) {
             this(new InMemoryStorage(), cred, meta);
         }
 
@@ -172,7 +172,7 @@ public interface Settings {
          * @param meta Yaml `meta` mapping
          * @checkstyle ParameterNumberCheck (2 lines)
          */
-        public Fake(final Storage storage, final Credentials cred, final YamlMapping meta) {
+        public Fake(final Storage storage, final Users cred, final YamlMapping meta) {
             this(storage, cred, meta, "flat");
         }
 
@@ -187,7 +187,7 @@ public interface Settings {
          */
         public Fake(
             final Storage storage,
-            final Credentials cred,
+            final Users cred,
             final YamlMapping meta,
             final String layout
         ) {
@@ -218,7 +218,7 @@ public interface Settings {
         }
 
         @Override
-        public CompletionStage<Credentials> credentials() {
+        public CompletionStage<Users> credentials() {
             return CompletableFuture.completedFuture(this.cred);
         }
     }

--- a/src/main/java/com/artipie/Users.java
+++ b/src/main/java/com/artipie/Users.java
@@ -27,6 +27,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
 import com.amihaiemil.eoyaml.YamlNode;
+import com.amihaiemil.eoyaml.YamlSequenceBuilder;
 import com.artipie.api.ContentAs;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
@@ -52,13 +53,13 @@ import org.cactoos.list.ListOf;
  * Artipie credentials.
  * @since 0.9
  */
-public interface Credentials {
+public interface Users {
 
     /**
      * Artipie users list.
      * @return Yaml as completion action
      */
-    CompletionStage<List<User>> users();
+    CompletionStage<List<User>> list();
 
     /**
      * Adds user to artipie users.
@@ -104,7 +105,7 @@ public interface Credentials {
      * Credentials from main artipie config.
      * @since 0.9
      */
-    final class FromStorageYaml implements Credentials {
+    final class FromStorageYaml implements Users {
 
         /**
          * Credentials yaml mapping key.
@@ -115,6 +116,11 @@ public interface Credentials {
          * Credentials yaml mapping key.
          */
         private static final String EMAIL = "email";
+
+        /**
+         * Groups yaml mapping key.
+         */
+        private static final String GROUPS = "groups";
 
         /**
          * Storage.
@@ -137,7 +143,7 @@ public interface Credentials {
         }
 
         @Override
-        public CompletionStage<List<User>> users() {
+        public CompletionStage<List<User>> list() {
             return this.yaml().thenApply(
                 yaml -> yaml.yamlMapping(FromStorageYaml.CREDENTIALS).keys().stream()
                     .map(
@@ -148,7 +154,15 @@ public interface Credentials {
                                 Optional.ofNullable(
                                     yaml.yamlMapping(FromStorageYaml.CREDENTIALS)
                                         .yamlMapping(name).string(FromStorageYaml.EMAIL)
-                                )
+                                ),
+                                Optional.ofNullable(
+                                    yaml.yamlMapping(FromStorageYaml.CREDENTIALS).yamlMapping(name)
+                                    .yamlSequence(FromStorageYaml.GROUPS)
+                                ).map(
+                                    groups -> groups.values().stream()
+                                        .map(item -> item.asScalar().value())
+                                        .collect(Collectors.toList())
+                                ).orElse(Collections.emptyList())
                             );
                         }
                     ).collect(Collectors.toList())
@@ -168,6 +182,13 @@ public interface Credentials {
                         );
                     if (user.mail.isPresent()) {
                         info = info.add(FromStorageYaml.EMAIL, user.mail.get());
+                    }
+                    if (!user.ugroups.isEmpty()) {
+                        YamlSequenceBuilder seq = Yaml.createYamlSequenceBuilder();
+                        for (final String group : user.ugroups) {
+                            seq = seq.add(group);
+                        }
+                        info.add(FromStorageYaml.GROUPS, seq.build());
                     }
                     result = result.add(user.uname, info.build());
                     return this.buildAndSaveCredentials(result);
@@ -241,7 +262,7 @@ public interface Credentials {
      * Credentials from env.
      * @since 0.10
      */
-    final class FromEnv implements Credentials {
+    final class FromEnv implements Users {
 
         /**
          * Environment variables.
@@ -264,7 +285,7 @@ public interface Credentials {
         }
 
         @Override
-        public CompletionStage<List<User>> users() {
+        public CompletionStage<List<User>> list() {
             return CompletableFuture.completedFuture(
                 Optional.ofNullable(this.env.get(AuthFromEnv.ENV_NAME))
                     .<List<User>>map(name -> new ListOf<>(new User(name, Optional.empty())))
@@ -312,13 +333,37 @@ public interface Credentials {
         private final Optional<String> mail;
 
         /**
+         * User groups.
+         */
+        private final List<String> ugroups;
+
+        /**
+         * Ctor.
+         * @param name Name of the user
+         * @param mail User email
+         * @param groups User groups
+         */
+        public User(final String name, final Optional<String> mail, final List<String> groups) {
+            this.uname = name;
+            this.mail = mail;
+            this.ugroups = groups;
+        }
+
+        /**
          * Ctor.
          * @param name Username
          * @param email User email
          */
         public User(final String name, final Optional<String> email) {
-            this.uname = name;
-            this.mail = email;
+            this(name, email, Collections.emptyList());
+        }
+
+        /**
+         * Ctor.
+         * @param name Username
+         */
+        public User(final String name) {
+            this(name, Optional.empty(), Collections.emptyList());
         }
 
         /**
@@ -337,6 +382,14 @@ public interface Credentials {
             return this.mail;
         }
 
+        /**
+         * Get user groups.
+         * @return List of the user groups
+         */
+        public List<String> groups() {
+            return this.ugroups;
+        }
+
         @Override
         public boolean equals(final Object other) {
             final boolean res;
@@ -347,14 +400,15 @@ public interface Credentials {
             } else {
                 final User user = (User) other;
                 res = Objects.equals(this.uname, user.uname)
-                    && Objects.equals(this.mail, user.mail);
+                    && Objects.equals(this.mail, user.mail)
+                    && Objects.equals(this.ugroups, user.ugroups);
             }
             return res;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.uname, this.mail);
+            return Objects.hash(this.uname, this.mail, this.ugroups);
         }
     }
 }

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -82,7 +82,7 @@ public final class YamlSettings implements Settings {
     @Override
     public CompletionStage<Authentication> auth() {
         return this.credentials().thenCompose(
-            Credentials::auth
+            Users::auth
         ).thenApply(
             auth -> new Authentication.Joined(new CachedAuth(new GithubAuth()), auth)
         );
@@ -109,7 +109,7 @@ public final class YamlSettings implements Settings {
 
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
-    public CompletionStage<Credentials> credentials() {
+    public CompletionStage<Users> credentials() {
         final YamlMapping cred;
         try {
             cred = Yaml.createYamlInput(this.content)
@@ -119,7 +119,7 @@ public final class YamlSettings implements Settings {
         } catch (final IOException err) {
             return CompletableFuture.failedFuture(err);
         }
-        final CompletionStage<Credentials> res;
+        final CompletionStage<Users> res;
         final String path = "path";
         if (YamlSettings.hasTypeFile(cred) && cred.string(path) != null) {
             final Storage strg;
@@ -131,11 +131,11 @@ public final class YamlSettings implements Settings {
             final KeyFromPath key = new KeyFromPath(cred.string(path));
             res = strg.exists(key).thenApply(
                 exists -> {
-                    final Credentials creds;
+                    final Users creds;
                     if (exists) {
-                        creds = new Credentials.FromStorageYaml(strg, key);
+                        creds = new Users.FromStorageYaml(strg, key);
                     } else {
-                        creds = new Credentials.FromEnv();
+                        creds = new Users.FromEnv();
                     }
                     return creds;
                 }
@@ -147,7 +147,7 @@ public final class YamlSettings implements Settings {
                 )
             );
         } else {
-            res = CompletableFuture.completedStage(new Credentials.FromEnv());
+            res = CompletableFuture.completedStage(new Users.FromEnv());
         }
         return res;
     }

--- a/src/main/java/com/artipie/api/ApiChangeUserPassword.java
+++ b/src/main/java/com/artipie/api/ApiChangeUserPassword.java
@@ -23,8 +23,8 @@
  */
 package com.artipie.api;
 
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -92,8 +92,8 @@ final class ApiChangeUserPassword implements Slice {
                 pass -> Completable.fromFuture(
                     this.settings.credentials().thenCompose(
                         cred -> cred.add(
-                            new Credentials.User(user, Optional.empty()),
-                            DigestUtils.sha256Hex(pass), Credentials.PasswordFormat.SHA256
+                            new Users.User(user, Optional.empty()),
+                            DigestUtils.sha256Hex(pass), Users.PasswordFormat.SHA256
                         )
                     ).toCompletableFuture()
                 )

--- a/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
@@ -23,8 +23,8 @@
  */
 package com.artipie.api.artifactory;
 
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.api.ContentAs;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -77,11 +77,11 @@ public final class AddUpdateUserSlice implements Slice {
                             info -> this.settings.credentials()
                                 .thenCompose(
                                     cred -> cred.add(
-                                        new Credentials.User(
+                                        new Users.User(
                                             username, Optional.of(info.getValue())
                                         ),
                                         DigestUtils.sha256Hex(info.getKey()),
-                                        Credentials.PasswordFormat.SHA256
+                                        Users.PasswordFormat.SHA256
                                     ).thenApply(ok -> new RsWithStatus(RsStatus.OK))
                                 )
                 ).orElse(CompletableFuture.completedFuture(new RsWithStatus(RsStatus.BAD_REQUEST))))

--- a/src/main/java/com/artipie/api/artifactory/DeleteUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/DeleteUserSlice.java
@@ -66,7 +66,7 @@ public final class DeleteUserSlice implements Slice {
         return user.<Response>map(
             username -> new AsyncResponse(
                 this.settings.credentials().thenCompose(
-                    cred -> cred.users().thenApply(
+                    cred -> cred.list().thenApply(
                         users -> users.stream().anyMatch(item -> item.name().equals(username))
                     ).thenCompose(
                         has -> {

--- a/src/main/java/com/artipie/api/artifactory/GetUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetUserSlice.java
@@ -62,7 +62,7 @@ public final class GetUserSlice implements Slice {
         return name.<Response>map(
             username -> new AsyncResponse(
                 this.settings.credentials().thenCompose(
-                    cred ->  cred.users().thenApply(
+                    cred ->  cred.list().thenApply(
                         users -> users.stream()
                             .filter(item -> item.name().equals(username))
                             .findFirst()

--- a/src/main/java/com/artipie/api/artifactory/GetUsersSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetUsersSlice.java
@@ -70,7 +70,7 @@ public final class GetUsersSlice implements Slice {
             final String base = this.settings.meta().string("base_url").replaceAll("/$", "");
             return new AsyncResponse(
                 this.settings.credentials().thenCompose(
-                    cred -> cred.users().<Response>thenApply(
+                    cred -> cred.list().<Response>thenApply(
                         list -> {
                             final JsonArrayBuilder json = Json.createArrayBuilder();
                             list.forEach(

--- a/src/test/java/com/artipie/UsersFromEnvTest.java
+++ b/src/test/java/com/artipie/UsersFromEnvTest.java
@@ -32,18 +32,18 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test for {@link Credentials.FromEnv}.
+ * Test for {@link Users.FromEnv}.
  * @since 0.10
  */
-class CredentialsFromEnvTest {
+class UsersFromEnvTest {
 
     @Test
     void returnsUserFromEnv() {
         final String user = "john";
         MatcherAssert.assertThat(
-            new Credentials.FromEnv(new MapOf<>(new MapEntry<>(AuthFromEnv.ENV_NAME, user)))
-                .users().toCompletableFuture().join(),
-            Matchers.containsInAnyOrder(new Credentials.User(user, Optional.empty()))
+            new Users.FromEnv(new MapOf<>(new MapEntry<>(AuthFromEnv.ENV_NAME, user)))
+                .list().toCompletableFuture().join(),
+            Matchers.containsInAnyOrder(new Users.User(user, Optional.empty()))
         );
     }
 

--- a/src/test/java/com/artipie/UsersFromStorageYamlTest.java
+++ b/src/test/java/com/artipie/UsersFromStorageYamlTest.java
@@ -25,6 +25,7 @@ package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import com.amihaiemil.eoyaml.YamlSequenceBuilder;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -34,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -41,12 +43,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test for {@link Credentials.FromStorageYaml}.
+ * Test for {@link Users.FromStorageYaml}.
  * @since 0.9
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings({"unchecked", "PMD.AvoidDuplicateLiterals"})
-class CredentialsFromStorageYamlTest {
+class UsersFromStorageYamlTest {
 
     /**
      * Test storage.
@@ -66,58 +68,60 @@ class CredentialsFromStorageYamlTest {
 
     @Test
     void readsYamlWithEmailFromStorage() {
-        final String jane = "jane";
-        final String john = "john";
+        final Users.User jane = new Users.User(
+            "jane", this.email("jane"), new ListOf<String>("readers")
+        );
+        final Users.User john = new Users.User(
+            "john", this.email("john"), new ListOf<String>("reviewers", "supporters")
+        );
         final String pass = "sha256:111";
         this.creds(new ImmutablePair<>(jane, pass), new ImmutablePair<>(john, pass));
         MatcherAssert.assertThat(
-            new Credentials.FromStorageYaml(this.storage, this.key).users()
+            new Users.FromStorageYaml(this.storage, this.key).list()
                 .toCompletableFuture().join(),
-            Matchers.containsInAnyOrder(
-                new Credentials.User(jane, this.email(jane)),
-                new Credentials.User(john, this.email(john))
-            )
+            Matchers.containsInAnyOrder(jane, john)
         );
     }
 
     @Test
     void readsYamlFromStorage() {
-        final String jane = "maria";
-        final String john = "olga";
+        final Users.User jane = new Users.User("maria");
+        final Users.User john = new Users.User("olga");
         final String pass = "sha256:000";
         this.creds(new ImmutablePair<>(jane, pass), new ImmutablePair<>(john, pass));
         this.storage.save(
             this.key,
             new Content.From(
-                this.getYaml(new ImmutablePair<>(jane, pass), new ImmutablePair<>(john, pass))
-                    .getBytes(StandardCharsets.UTF_8)
+                this.getYaml(
+                    new ImmutablePair<>(jane.name(), pass),
+                    new ImmutablePair<>(john.name(), pass)
+                ).getBytes(StandardCharsets.UTF_8)
             )
         ).join();
         MatcherAssert.assertThat(
-            new Credentials.FromStorageYaml(this.storage, this.key).users()
+            new Users.FromStorageYaml(this.storage, this.key).list()
                 .toCompletableFuture().join(),
-            Matchers.containsInAnyOrder(
-                new Credentials.User(jane, Optional.empty()),
-                new Credentials.User(john, Optional.empty())
-            )
+            Matchers.containsInAnyOrder(jane, john)
         );
     }
 
     @Test
     void addsUser() {
-        final String maria = "maria";
-        final String olga = "olga";
+        final Users.User maria = new Users.User(
+            "maria", this.email("maria"), new ListOf<String>("newbies", "tester")
+        );
+        final Users.User olga = new Users.User("olga");
         final String pass = "abc";
         final String full = String.format("sha256:%s", pass);
         this.creds(new ImmutablePair<>(maria, full));
-        new Credentials.FromStorageYaml(this.storage, this.key).add(
-            new Credentials.User(olga, this.email(olga)), pass, Credentials.PasswordFormat.SHA256
+        new Users.FromStorageYaml(this.storage, this.key).add(
+            new Users.User(olga.name(), this.email(olga.name())), pass, Users.PasswordFormat.SHA256
         ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
                 .asciiString().toCompletableFuture().join(),
             new IsEqual<>(
-                this.getYamlWithEmail(
+                this.getYamlWithEmailAndGroups(
                     new ImmutablePair<>(maria, full),
                     new ImmutablePair<>(olga, full)
                 )
@@ -127,21 +131,21 @@ class CredentialsFromStorageYamlTest {
 
     @Test
     void updatesUser() {
-        final String jack = "jack";
-        final String silvia = "silvia";
+        final Users.User jack = new Users.User("jack");
+        final Users.User silvia = new Users.User("silvia");
         final String old = "plain:345";
         final String newpass = "000";
         this.creds(new ImmutablePair<>(jack, old), new ImmutablePair<>(silvia, old));
-        new Credentials.FromStorageYaml(this.storage, this.key)
+        new Users.FromStorageYaml(this.storage, this.key)
             .add(
-                new Credentials.User(silvia, this.email(silvia)),
-                newpass, Credentials.PasswordFormat.PLAIN
+                new Users.User(silvia.name(), this.email(silvia.name())),
+                newpass, Users.PasswordFormat.PLAIN
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
                 .asciiString().toCompletableFuture().join(),
             new IsEqual<>(
-                this.getYamlWithEmail(
+                this.getYamlWithEmailAndGroups(
                     new ImmutablePair<>(jack, old),
                     new ImmutablePair<>(silvia, String.format("plain:%s", newpass))
                 )
@@ -151,55 +155,59 @@ class CredentialsFromStorageYamlTest {
 
     @Test
     void removesUser() {
-        final String mark = "mark";
-        final String ann = "ann";
+        final Users.User mark = new Users.User("mark");
+        final Users.User ann = new Users.User("ann");
         final String pass = "plain:123";
         this.creds(new ImmutablePair<>(mark, pass), new ImmutablePair<>(ann, pass));
-        new Credentials.FromStorageYaml(this.storage, this.key).remove(ann)
+        new Users.FromStorageYaml(this.storage, this.key).remove(ann.name())
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
                 .asciiString().toCompletableFuture().join(),
-            new IsEqual<>(this.getYamlWithEmail(new ImmutablePair<>(mark, pass)))
+            new IsEqual<>(this.getYamlWithEmailAndGroups(new ImmutablePair<>(mark, pass)))
         );
     }
 
     @Test
     void doNotChangeYamlOnRemoveIfUserNotFound() {
-        final String ted = "ted";
-        final String alex = "alex";
+        final Users.User ted = new Users.User("ted");
+        final Users.User alex = new Users.User("alex");
         final String pass = "plain:098";
         this.creds(new ImmutablePair<>(ted, pass), new ImmutablePair<>(alex, pass));
-        new Credentials.FromStorageYaml(this.storage, this.key).remove("alice")
+        new Users.FromStorageYaml(this.storage, this.key).remove("alice")
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
                 .asciiString().toCompletableFuture().join(),
             new IsEqual<>(
-                this.getYamlWithEmail(
+                this.getYamlWithEmailAndGroups(
                     new ImmutablePair<>(ted, pass), new ImmutablePair<>(alex, pass)
                 )
             )
         );
     }
 
-    private void creds(final Pair<String, String>... users) {
+    private void creds(final Pair<Users.User, String>... users) {
         this.storage.save(
             this.key,
-            new Content.From(this.getYamlWithEmail(users).getBytes(StandardCharsets.UTF_8))
+            new Content.From(this.getYamlWithEmailAndGroups(users).getBytes(StandardCharsets.UTF_8))
         ).join();
     }
 
-    private String getYamlWithEmail(final Pair<String, String>... users) {
+    private String getYamlWithEmailAndGroups(final Pair<Users.User, String>... users) {
         YamlMappingBuilder mapping = Yaml.createYamlMappingBuilder();
-        for (final Pair<String, String> user : users) {
-            mapping = mapping.add(
-                user.getKey(),
-                Yaml.createYamlMappingBuilder()
-                    .add("pass", user.getValue())
-                    .add("email", this.email(user.getKey()).get())
-                    .build()
-            );
+        for (final Pair<Users.User, String> user : users) {
+            YamlMappingBuilder map = Yaml.createYamlMappingBuilder()
+                .add("pass", user.getValue())
+                .add("email", this.email(user.getKey().name()).get());
+            if (!user.getKey().groups().isEmpty()) {
+                YamlSequenceBuilder seq = Yaml.createYamlSequenceBuilder();
+                for (final String item : user.getKey().groups()) {
+                    seq = seq.add(item);
+                }
+                map = map.add("groups", seq.build());
+            }
+            mapping = mapping.add(user.getKey().name(), map.build());
         }
         return Yaml.createYamlMappingBuilder().add(
             "credentials",

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -136,7 +136,7 @@ class YamlSettingsTest {
         Files.writeString(yaml, this.credentials());
         MatcherAssert.assertThat(
             settings.credentials().toCompletableFuture().join(),
-            new IsInstanceOf(Credentials.FromStorageYaml.class)
+            new IsInstanceOf(Users.FromStorageYaml.class)
         );
     }
 

--- a/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
+++ b/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
@@ -24,8 +24,8 @@
 package com.artipie.api;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -79,7 +79,7 @@ class ApiChangeUserPasswordTest {
         MatcherAssert.assertThat(
             "ApiChangeUserPassword response should be FOUND",
             new ApiChangeUserPassword(
-                new Settings.Fake(new Credentials.FromStorageYaml(this.storage, this.key))
+                new Settings.Fake(new Users.FromStorageYaml(this.storage, this.key))
             ),
             new SliceHasResponse(
                 Matchers.allOf(
@@ -108,7 +108,7 @@ class ApiChangeUserPasswordTest {
         MatcherAssert.assertThat(
             "ApiChangeUserPassword response should be FOUND",
             new ApiChangeUserPassword(
-                new Settings.Fake(new Credentials.FromStorageYaml(this.storage, this.key))
+                new Settings.Fake(new Users.FromStorageYaml(this.storage, this.key))
             ),
             new SliceHasResponse(
                 Matchers.allOf(

--- a/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
@@ -24,8 +24,8 @@
 package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -101,7 +101,7 @@ final class AddUpdateUserSliceTest {
         MatcherAssert.assertThat(
             "AddUpdateUserSlice response should be OK",
             new AddUpdateUserSlice(
-                new Settings.Fake(new Credentials.FromStorageYaml(storage, key))
+                new Settings.Fake(new Users.FromStorageYaml(storage, key))
             ).response(rqline.toString(), Headers.EMPTY, this.jsonBody(pswd, username)),
             new RsHasStatus(RsStatus.OK)
         );
@@ -132,7 +132,7 @@ final class AddUpdateUserSliceTest {
         MatcherAssert.assertThat(
             "AddUpdateUserSlice response should be OK",
             new AddUpdateUserSlice(
-                new Settings.Fake(new Credentials.FromStorageYaml(storage, key))
+                new Settings.Fake(new Users.FromStorageYaml(storage, key))
             ).response(rqline.toString(), Headers.EMPTY, this.jsonBody(newpswd, username)),
             new RsHasStatus(RsStatus.OK)
         );

--- a/src/test/java/com/artipie/api/artifactory/DeleteUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/DeleteUserSliceTest.java
@@ -24,8 +24,8 @@
 package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -80,7 +80,7 @@ final class DeleteUserSliceTest {
         final Key key = new Key.From("_credentials.yaml");
         this.creds("john", storage, key);
         MatcherAssert.assertThat(
-            new DeleteUserSlice(new Settings.Fake(new Credentials.FromStorageYaml(storage, key))),
+            new DeleteUserSlice(new Settings.Fake(new Users.FromStorageYaml(storage, key))),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.NOT_FOUND),
                 new RequestLine(RqMethod.DELETE, "/api/security/users/notfound")
@@ -95,7 +95,7 @@ final class DeleteUserSliceTest {
         this.creds("jane", storage, key);
         MatcherAssert.assertThat(
             "DeleteUserSlice response",
-            new DeleteUserSlice(new Settings.Fake(new Credentials.FromStorageYaml(storage, key))),
+            new DeleteUserSlice(new Settings.Fake(new Users.FromStorageYaml(storage, key))),
             new SliceHasResponse(
                 Matchers.allOf(
                     new RsHasStatus(RsStatus.OK),

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionsSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionsSliceTest.java
@@ -25,8 +25,8 @@ package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -68,7 +68,7 @@ final class GetPermissionsSliceTest {
         storage.save(new Key.From(this.nameYaml(cache)), Content.EMPTY).join();
         MatcherAssert.assertThat(
             new GetPermissionsSlice(
-                new Settings.Fake(storage, new Credentials.FromEnv(), GetPermissionsSliceTest.META)
+                new Settings.Fake(storage, new Users.FromEnv(), GetPermissionsSliceTest.META)
             ),
             new SliceHasResponse(
                 new RsHasBody(

--- a/src/test/java/com/artipie/api/artifactory/GetUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetUserSliceTest.java
@@ -24,8 +24,8 @@
 package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -66,7 +66,7 @@ class GetUserSliceTest {
         final Key key = new Key.From("_credentials.yaml");
         this.creds("john", storage, key);
         MatcherAssert.assertThat(
-            new GetUserSlice(new Settings.Fake(new Credentials.FromStorageYaml(storage, key))),
+            new GetUserSlice(new Settings.Fake(new Users.FromStorageYaml(storage, key))),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.NOT_FOUND),
                 new RequestLine(RqMethod.GET, "/api/security/users/josh")
@@ -81,7 +81,7 @@ class GetUserSliceTest {
         final Key key = new Key.From("_cred.yaml");
         this.creds(username, storage, key);
         MatcherAssert.assertThat(
-            new GetUserSlice(new Settings.Fake(new Credentials.FromStorageYaml(storage, key))),
+            new GetUserSlice(new Settings.Fake(new Users.FromStorageYaml(storage, key))),
             new SliceHasResponse(
                 Matchers.allOf(
                     new RsHasStatus(RsStatus.OK),

--- a/src/test/java/com/artipie/api/artifactory/GetUsersSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetUsersSliceTest.java
@@ -25,8 +25,8 @@ package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -72,7 +72,7 @@ class GetUsersSliceTest {
         MatcherAssert.assertThat(
             new GetUsersSlice(
                 new Settings.Fake(
-                    new Credentials.FromStorageYaml(storage, key),
+                    new Users.FromStorageYaml(storage, key),
                     GetUsersSliceTest.META
                 )
             ),

--- a/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
+++ b/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
@@ -24,8 +24,8 @@
 package com.artipie.http;
 
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.Credentials;
 import com.artipie.Settings;
+import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Storage;
 import com.artipie.http.auth.Authentication;
@@ -166,7 +166,7 @@ final class DockerRoutingSliceTest {
         }
 
         @Override
-        public CompletionStage<Credentials> credentials() {
+        public CompletionStage<Users> credentials() {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
Part of #572 
Renamed `Credenctials` to `Users` which seem much more appropriate and implemented read/write user groups operation.