### PR TITLE
#570 - Extracted BaseSlice, MainSlice and AllRepositoriesSlice

### DIFF
--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -26,11 +26,10 @@ package com.artipie;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.http.Pie;
-import com.artipie.http.TrafficMetricSlice;
+import com.artipie.http.BaseSlice;
+import com.artipie.http.MainSlice;
 import com.artipie.metrics.Metrics;
 import com.artipie.metrics.MetricsFromConfig;
-import com.artipie.metrics.PrefixedMetrics;
 import com.artipie.metrics.nop.NopMetrics;
 import com.artipie.vertx.VertxSliceServer;
 import com.jcabi.log.Logger;
@@ -223,13 +222,7 @@ public final class VertxMain {
     ) {
         final VertxSliceServer server = new VertxSliceServer(
             this.vertx,
-            new TrafficMetricSlice(
-                new ResponseMetricsSlice(
-                    new Pie(settings),
-                    new PrefixedMetrics(metrics, "http.response.")
-                ),
-                new PrefixedMetrics(metrics, "http.")
-            ),
+            new BaseSlice(metrics, new MainSlice(settings)),
             sport
         );
         this.servers.add(server);

--- a/src/main/java/com/artipie/http/AllRepositoriesSlice.java
+++ b/src/main/java/com/artipie/http/AllRepositoriesSlice.java
@@ -21,33 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.artipie;
+package com.artipie.http;
 
-import com.artipie.http.Headers;
-import com.artipie.http.Pie;
-import com.artipie.http.hm.RsHasStatus;
-import com.artipie.http.rq.RequestLine;
-import com.artipie.http.rs.RsStatus;
-import io.reactivex.Flowable;
-import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Test;
+import com.artipie.Settings;
 
 /**
- * Test for {@link Pie}.
- * @since 0.2
+ * Slice handles repository requests extracting repository name from URI path.
+ *
+ * @since 0.11
  */
-public final class PieTest {
+public final class AllRepositoriesSlice extends Slice.Wrap {
 
-    @Test
-    public void unexistingRepoReturnNotFound() {
-        MatcherAssert.assertThat(
-            "Must return 404 HTTP status",
-            new Pie(new Settings.Fake()).response(
-                new RequestLine("GET", "/repo/foo", "HTTP/1.1").toString(),
-                Headers.EMPTY,
-                Flowable.empty()
-            ),
-            new RsHasStatus(RsStatus.NOT_FOUND)
-        );
+    /**
+     * Ctor.
+     *
+     * @param settings Artipie settings.
+     */
+    public AllRepositoriesSlice(final Settings settings) {
+        super(new DockerRoutingSlice(settings, new SliceByPath(settings)));
     }
 }

--- a/src/main/java/com/artipie/http/BaseSlice.java
+++ b/src/main/java/com/artipie/http/BaseSlice.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http;
+
+import com.artipie.MeasuredSlice;
+import com.artipie.ResponseMetricsSlice;
+import com.artipie.http.slice.LoggingSlice;
+import com.artipie.metrics.Metrics;
+import com.artipie.metrics.PrefixedMetrics;
+import java.time.Duration;
+import java.util.logging.Level;
+
+/**
+ * Slice is base for any slice served by Artipie.
+ * It is designed to gather request & response metrics, perform logging, handle errors at top level.
+ * With all that functionality provided request are forwarded to origin slice
+ * and response is given back to caller.
+ *
+ * @since 0.11
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class BaseSlice extends Slice.Wrap {
+
+    /**
+     * Ctor.
+     *
+     * @param metrics Metrics.
+     * @param origin Origin slice.
+     */
+    public BaseSlice(final Metrics metrics, final Slice origin) {
+        super(
+            new TrafficMetricSlice(
+                new ResponseMetricsSlice(
+                    new SafeSlice(
+                        new TimeoutSlice(
+                            new MeasuredSlice(
+                                new LoggingSlice(
+                                    Level.INFO,
+                                    origin
+                                )
+                            ),
+                            Duration.ofMinutes(1)
+                        )
+                    ),
+                    new PrefixedMetrics(metrics, "http.response.")
+                ),
+                new PrefixedMetrics(metrics, "http.")
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/AllRepositoriesSliceTest.java
+++ b/src/test/java/com/artipie/AllRepositoriesSliceTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie;
+
+import com.artipie.asto.Content;
+import com.artipie.http.AllRepositoriesSlice;
+import com.artipie.http.Headers;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link AllRepositoriesSlice}.
+ *
+ * @since 0.11
+ */
+public final class AllRepositoriesSliceTest {
+
+    @Test
+    public void unexistingRepoReturnNotFound() {
+        MatcherAssert.assertThat(
+            "Must return 404 HTTP status",
+            new AllRepositoriesSlice(new Settings.Fake()).response(
+                new RequestLine(RqMethod.GET, "/repo/foo").toString(),
+                Headers.EMPTY,
+                Content.EMPTY
+            ),
+            new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+}


### PR DESCRIPTION
Part of #570 
Extracted `BaseSlice`, `MainSlice` and `AllRepositoriesSlice`.
`BaseSlice` is expected to be used for running repository slice on separate port later.