### PR TITLE
#572 - Update adapters and docs

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -62,6 +62,7 @@ name | string | User name | Y
 email | string | User email | Y
 lastLoggedIn | string | Default `2020-01-01T01:01:01.000+01:00` | Y
 realm | string | User realm, value `Internal` is always returned | Y
+groups | json array | User groups | Y
 
 If user is not found `404 NOT FOUND` status is returned.
 
@@ -77,6 +78,7 @@ Field name | Type | Meaning | Required
 ------ | ------ | ------ | ------
 password | string | User password | Y
 email | string | User email | Y
+groups | json array | User groups | N
 
 Possible responses:
 - `200 OK` when user was successfully created or updated

--- a/examples/npm/configs/npm_repo.yaml
+++ b/examples/npm/configs/npm_repo.yaml
@@ -1,5 +1,5 @@
 repo:
-  path: "/npm_repo/"
+  url: "http://localhost:8080/npm_repo"
   type: npm
   storage:
     type: fs

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>files-adapter</artifactId>
-      <version>0.5</version>
+      <version>0.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -223,7 +223,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>gem-adapter</artifactId>
-      <version>0.4</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -243,22 +243,22 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>nuget-adapter</artifactId>
-      <version>0.3.1</version>
+      <version>0.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>pypi-adapter</artifactId>
-      <version>0.6.2</version>
+      <version>0.6.3</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>helm-adapter</artifactId>
-      <version>0.1.3</version>
+      <version>0.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>docker-adapter</artifactId>
-      <version>0.4.4</version>
+      <version>0.4.5</version>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>npm-adapter</artifactId>
-      <version>0.6.1</version>
+      <version>0.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -218,7 +218,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>rpm-adapter</artifactId>
-      <version>1.2</version>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -228,7 +228,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>composer-adapter</artifactId>
-      <version>0.1</version>
+      <version>0.2</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.3.9</version>
+    <version>0.4</version>
   </parent>
   <artifactId>artipie</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -320,7 +320,7 @@ SOFTWARE.
     <testResources>
       <testResource>
         <directory>${basedir}/src/test/resources</directory>
-        <filtering>true</filtering>
+        <filtering>false</filtering>
       </testResource>
     </testResources>
     <plugins>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -203,7 +203,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "php":
-                slice = new PhpComposer(cfg.storage());
+                slice = trimIfNotStandalone(settings, standalone, new PhpComposer(cfg.storage()));
                 break;
             case "nuget":
                 slice = trimIfNotStandalone(
@@ -260,12 +260,15 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "npm-proxy":
-                slice = new NpmProxySlice(
-                    cfg.path(),
-                    new NpmProxy(
-                        new NpmProxyConfig(cfg.settings().orElseThrow()),
-                        Vertx.vertx(),
-                        cfg.storage()
+                slice = trimIfNotStandalone(
+                    settings, standalone,
+                    new NpmProxySlice(
+                        cfg.path(),
+                        new NpmProxy(
+                            new NpmProxyConfig(cfg.settings().orElseThrow()),
+                            Vertx.vertx(),
+                            cfg.storage()
+                        )
                     )
                 );
                 break;

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -166,12 +166,15 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "npm":
-                slice = new NpmSlice(
-                    cfg.url(),
-                    new Npm(cfg.storage()),
-                    cfg.storage(),
-                    permissions,
-                    new BasicIdentities(auth)
+                slice = trimIfNotStandalone(
+                    settings, standalone,
+                    new NpmSlice(
+                        cfg.url(),
+                        new Npm(cfg.storage()),
+                        cfg.storage(),
+                        permissions,
+                        new BasicIdentities(auth)
+                    )
                 );
                 break;
             case "gem":

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -62,8 +62,11 @@ import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.http.client.utils.URIBuilder;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Slice from repo config.
@@ -159,7 +162,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                 break;
             case "npm":
                 slice = new NpmSlice(
-                    cfg.path(),
+                    new Unchecked<>(() -> new URL(cfg.path())).value(),
                     new Npm(cfg.storage()),
                     cfg.storage(),
                     permissions,
@@ -189,7 +192,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "php":
-                slice = new PhpComposer(cfg.path(), cfg.storage());
+                slice = new PhpComposer(cfg.storage());
                 break;
             case "nuget":
                 slice = new TrimPathSlice(

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -169,7 +169,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                 break;
             case "npm":
                 slice = new NpmSlice(
-                    new Unchecked<>(() -> new URL(cfg.path())).value(),
+                    cfg.url(),
                     new Npm(cfg.storage()),
                     cfg.storage(),
                     permissions,

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -62,9 +62,7 @@ import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.stream.Collectors;
-import org.cactoos.scalar.Unchecked;
 
 /**
  * Slice from repo config.


### PR DESCRIPTION
Part #572 
Updated adapters and docs, faced the following issues:
- could not update `npm-adapter` to `0.7` due to 
> [ERROR] Failed to execute goal on project artipie: Could not resolve dependencies for project com.artipie:artipie:jar:1.0-SNAPSHOT: Failed to collect dependencies at com.artipie:npm-adapter:jar:0.7: Failed to read artifact descriptor for com.artipie:npm-adapter:jar:0.7: Could not transfer artifact com.artipie:npm-adapters:pom:0.7 from/to artipie-central (https://central.artipie.com/artipie/maven): Failed to transfer file: https://central.artipie.com/artipie/maven/com/artipie/npm-adapters/0.7/npm-adapters-0.7.pom. Return code is: 502 , ReasonPhrase:Bad Gateway. -> [Help 1]

(force update of the local repository did not help)
- composer-adapter is not yes released
- rpm-adapter is not released due to error with javadoc formatting (created https://github.com/artipie/rpm-adapter/pull/365 to fix)
