### PR TITLE
#572 - add reader group and permission

### DIFF
--- a/src/main/java/com/artipie/RepoPermissions.java
+++ b/src/main/java/com/artipie/RepoPermissions.java
@@ -75,7 +75,7 @@ public interface RepoPermissions {
      */
     CompletionStage<Void> update(
         String repo,
-        Collection<UserPermission> permissions,
+        Collection<PermissionItem> permissions,
         Collection<PathPattern> patterns
     );
 
@@ -84,7 +84,7 @@ public interface RepoPermissions {
      * @param repo Repository name
      * @return Completion action with map with users and permissions
      */
-    CompletionStage<Collection<UserPermission>> permissions(String repo);
+    CompletionStage<Collection<PermissionItem>> permissions(String repo);
 
     /**
      * Read included path patterns.
@@ -154,7 +154,7 @@ public interface RepoPermissions {
         @Override
         public CompletionStage<Void> update(
             final String repo,
-            final Collection<UserPermission> permissions,
+            final Collection<PermissionItem> permissions,
             final Collection<PathPattern> patterns) {
             final Key key = FromSettings.repoSettingsKey(repo);
             return this.repo(key).thenApply(
@@ -162,7 +162,7 @@ public interface RepoPermissions {
                     YamlMappingBuilder res = FromSettings.copyRepoSection(mapping);
                     YamlMappingBuilder perms = Yaml.createYamlMappingBuilder();
                     if (!permissions.isEmpty()) {
-                        for (final UserPermission item : permissions) {
+                        for (final PermissionItem item : permissions) {
                             perms = perms.add(item.name, item.yaml().build());
                         }
                         res = res.add(FromSettings.PERMISSIONS, perms.build());
@@ -185,13 +185,13 @@ public interface RepoPermissions {
         }
 
         @Override
-        public CompletionStage<Collection<UserPermission>> permissions(final String repo) {
+        public CompletionStage<Collection<PermissionItem>> permissions(final String repo) {
             return this.repo(FromSettings.repoSettingsKey(repo)).thenApply(
                 yaml -> Optional.ofNullable(yaml.yamlMapping(FromSettings.PERMISSIONS))
             ).thenApply(
                 yaml -> yaml.map(
                     perms -> perms.keys().stream().map(
-                        node -> new UserPermission(
+                        node -> new PermissionItem(
                             node.asScalar().value(),
                             perms.yamlSequence(node.asScalar().value()).values().stream()
                             .map(item -> item.asScalar().value())
@@ -287,7 +287,7 @@ public interface RepoPermissions {
      * User permission item.
      * @since 0.10
      */
-    final class UserPermission {
+    final class PermissionItem {
 
         /**
          * Username.
@@ -304,7 +304,7 @@ public interface RepoPermissions {
          * @param name Username
          * @param permissions Permissions
          */
-        public UserPermission(final String name, final List<String> permissions) {
+        public PermissionItem(final String name, final List<String> permissions) {
             this.name = name;
             this.perms = permissions;
         }
@@ -333,7 +333,7 @@ public interface RepoPermissions {
             } else if (other == null || getClass() != other.getClass()) {
                 res = false;
             } else {
-                final UserPermission that = (UserPermission) other;
+                final PermissionItem that = (PermissionItem) other;
                 res = Objects.equals(this.name, that.name)
                     && Objects.equals(this.perms, that.perms);
             }

--- a/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonString;
+import org.cactoos.list.ListOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
 import org.reactivestreams.Publisher;
@@ -114,7 +115,7 @@ public final class AddUpdatePermissionSlice implements Slice {
     }
 
     /**
-     * Converts json permissions into list of {@link RepoPermissions.UserPermission}.
+     * Update repo permissions.
      * @param json Json body
      * @param name Repository name
      * @return True - if JSON is valid and update performed,
@@ -123,11 +124,11 @@ public final class AddUpdatePermissionSlice implements Slice {
     private CompletionStage<Boolean> update(final JsonObject json, final String name) {
         final JsonObject repo = json.getJsonObject("repo");
         final JsonObject users = repo.getJsonObject("actions").getJsonObject("users");
-        final List<RepoPermissions.UserPermission> res = new ArrayList<>(users.size());
+        final List<RepoPermissions.PermissionItem> res = new ArrayList<>(users.size() + 1);
         users.forEach(
             (user, perms) ->
                 res.add(
-                    new RepoPermissions.UserPermission(
+                    new RepoPermissions.PermissionItem(
                         user, perms.asJsonArray().stream()
                         .map(item -> item.toString().replace("\"", ""))
                         .map(
@@ -142,6 +143,7 @@ public final class AddUpdatePermissionSlice implements Slice {
                     )
                 )
         );
+        res.add(new RepoPermissions.PermissionItem("/readers", new ListOf<String>("read")));
         final List<RepoPermissions.PathPattern> patterns = Optional.ofNullable(
             repo.getJsonArray("include-patterns")
         )

--- a/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
@@ -34,7 +34,6 @@ import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonString;
@@ -123,27 +123,21 @@ public final class AddUpdatePermissionSlice implements Slice {
      */
     private CompletionStage<Boolean> update(final JsonObject json, final String name) {
         final JsonObject repo = json.getJsonObject("repo");
-        final JsonObject users = repo.getJsonObject("actions").getJsonObject("users");
-        final List<RepoPermissions.PermissionItem> res = new ArrayList<>(users.size() + 1);
-        users.forEach(
-            (user, perms) ->
-                res.add(
-                    new RepoPermissions.PermissionItem(
-                        user, perms.asJsonArray().stream()
-                        .map(item -> item.toString().replace("\"", ""))
-                        .map(
-                            item -> Optional.ofNullable(
-                                AddUpdatePermissionSlice.MAPPING.get(item)
-                            ).orElseThrow(
-                                () -> new IllegalArgumentException(
-                                    String.format("Unsupported permission '%s'!", item)
-                                )
-                            )
-                        ).distinct().collect(Collectors.toList())
+        final String actions = "actions";
+        final List<RepoPermissions.PermissionItem> res =
+            Stream.concat(
+                Stream.of(new RepoPermissions.PermissionItem("/readers", new ListOf<>("read"))),
+                Stream.concat(
+                    AddUpdatePermissionSlice.permsFromJson(
+                        Optional.ofNullable(repo.getJsonObject(actions).getJsonObject("users")),
+                        ""
+                    ),
+                    AddUpdatePermissionSlice.permsFromJson(
+                        Optional.ofNullable(repo.getJsonObject(actions).getJsonObject("groups")),
+                        "/"
                     )
                 )
-        );
-        res.add(new RepoPermissions.PermissionItem("/readers", new ListOf<String>("read")));
+            ).distinct().collect(Collectors.toList());
         final List<RepoPermissions.PathPattern> patterns = Optional.ofNullable(
             repo.getJsonArray("include-patterns")
         )
@@ -162,5 +156,33 @@ public final class AddUpdatePermissionSlice implements Slice {
             result = CompletableFuture.completedFuture(false);
         }
         return result;
+    }
+
+    /**
+     * Permission items from json.
+     * @param perms Json permissions
+     * @param prefix Prefix for permission name
+     * @return List of {@link RepoPermissions.PermissionItem}
+     */
+    private static Stream<RepoPermissions.PermissionItem> permsFromJson(
+        final Optional<JsonObject> perms, final String prefix
+    ) {
+        return perms.map(items -> items.entrySet().stream()).map(
+            items -> items.map(
+                json -> new RepoPermissions.PermissionItem(
+                    String.format("%s%s", prefix, json.getKey()), json.getValue()
+                    .asJsonArray().stream().map(item -> item.toString().replace("\"", ""))
+                    .map(
+                        item -> Optional.ofNullable(
+                            AddUpdatePermissionSlice.MAPPING.get(item)
+                        ).orElseThrow(
+                            () -> new IllegalArgumentException(
+                                String.format("Unsupported permission '%s'!", item)
+                            )
+                        )
+                    ).distinct().collect(Collectors.toList())
+                )
+            )
+        ).orElse(Stream.empty());
     }
 }

--- a/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
@@ -34,10 +34,10 @@ import com.artipie.http.rs.RsWithStatus;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -45,6 +45,7 @@ import javax.json.JsonString;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.cactoos.list.ListOf;
 import org.reactivestreams.Publisher;
 
 /**
@@ -108,15 +109,17 @@ public final class AddUpdateUserSlice implements Slice {
             json -> {
                 final Optional<Pair<Users.User, String>> res;
                 if (json.containsKey(pswd) && json.containsKey(email)) {
-                    List<String> list = new ArrayList<>(1);
+                    Set<String> set = new HashSet<>(1);
                     if (json.containsKey(groups)) {
-                        list = json.getJsonArray(groups).getValuesAs(JsonString.class)
-                            .stream().map(JsonString::getString).collect(Collectors.toList());
+                        set = json.getJsonArray(groups).getValuesAs(JsonString.class)
+                            .stream().map(JsonString::getString).collect(Collectors.toSet());
                     }
-                    list.add("readers");
+                    set.add("readers");
                     res = Optional.of(
                         new ImmutablePair<>(
-                            new Users.User(name, Optional.of(json.getString(email)), list),
+                            new Users.User(
+                                name, Optional.of(json.getString(email)), new ListOf<>(set)
+                            ),
                             json.getString(pswd)
                         )
                     );

--- a/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdateUserSlice.java
@@ -34,7 +34,7 @@ import com.artipie.http.rs.RsWithStatus;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,11 +108,12 @@ public final class AddUpdateUserSlice implements Slice {
             json -> {
                 final Optional<Pair<Users.User, String>> res;
                 if (json.containsKey(pswd) && json.containsKey(email)) {
-                    List<String> list = Collections.emptyList();
+                    List<String> list = new ArrayList<>(1);
                     if (json.containsKey(groups)) {
                         list = json.getJsonArray(groups).getValuesAs(JsonString.class)
                             .stream().map(JsonString::getString).collect(Collectors.toList());
                     }
+                    list.add("readers");
                     res = Optional.of(
                         new ImmutablePair<>(
                             new Users.User(name, Optional.of(json.getString(email)), list),

--- a/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
@@ -105,7 +105,7 @@ public final class GetPermissionSlice implements Slice {
      */
     private static JsonObject response(
         final Collection<RepoPermissions.PathPattern> patterns,
-        final Collection<RepoPermissions.UserPermission> permissions,
+        final Collection<RepoPermissions.PermissionItem> permissions,
         final String repo
     ) {
         return Json.createObjectBuilder()
@@ -122,10 +122,10 @@ public final class GetPermissionSlice implements Slice {
      * @return Users section JSON.
      */
     private static JsonObject users(
-        final Collection<RepoPermissions.UserPermission> permissions
+        final Collection<RepoPermissions.PermissionItem> permissions
     ) {
         final JsonObjectBuilder builder = Json.createObjectBuilder();
-        for (final RepoPermissions.UserPermission perm : permissions) {
+        for (final RepoPermissions.PermissionItem perm : permissions) {
             final JsonArrayBuilder array = Json.createArrayBuilder();
             perm.permissions().stream().map(
                 item -> {

--- a/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
+++ b/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
@@ -81,14 +81,14 @@ class RepoPermissionsFromSettingsTest {
         final String upload = "upload";
         final String repo = "maven";
         final RepoPerms perm = new RepoPerms(
-            new RepoPermissions.UserPermission(john, new ListOf<String>(download, upload))
+            new RepoPermissions.PermissionItem(john, new ListOf<String>(download, upload))
         );
         perm.saveSettings(this.storage, repo);
         MatcherAssert.assertThat(
             new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).permissions(repo)
                 .toCompletableFuture().join(),
             Matchers.contains(
-                new RepoPermissions.UserPermission(john, new ListOf<String>(download, upload))
+                new RepoPermissions.PermissionItem(john, new ListOf<String>(download, upload))
             )
         );
     }
@@ -140,7 +140,7 @@ class RepoPermissionsFromSettingsTest {
         final String add = "add";
         final RepoPerms perm = new RepoPerms(
             Collections.singleton(
-                new RepoPermissions.UserPermission(david, new ListOf<String>(add, "update"))
+                new RepoPermissions.PermissionItem(david, new ListOf<String>(add, "update"))
             ),
             new ListOf<>("**")
         );
@@ -153,9 +153,9 @@ class RepoPermissionsFromSettingsTest {
             .update(
                 repo,
                 new ListOf<>(
-                    new RepoPermissions.UserPermission(olga, new ListOf<>(download, deploy)),
-                    new RepoPermissions.UserPermission(victor, new ListOf<>(deploy)),
-                    new RepoPermissions.UserPermission(david, new ListOf<>(download, add))
+                    new RepoPermissions.PermissionItem(olga, new ListOf<>(download, deploy)),
+                    new RepoPermissions.PermissionItem(victor, new ListOf<>(deploy)),
+                    new RepoPermissions.PermissionItem(david, new ListOf<>(download, add))
                 ),
                 new ListOf<>(new RepoPermissions.PathPattern("rpm/*"))
             ).toCompletableFuture().join();
@@ -191,7 +191,7 @@ class RepoPermissionsFromSettingsTest {
         new RepoPermissions.FromSettings(new Settings.Fake(this.storage))
             .update(
                 repo,
-                new ListOf<>(new RepoPermissions.UserPermission(ann, new ListOf<>(download))),
+                new ListOf<>(new RepoPermissions.PermissionItem(ann, new ListOf<>(download))),
                 new ListOf<>(new RepoPermissions.PathPattern("**"))
             )
             .toCompletableFuture().join();
@@ -211,7 +211,7 @@ class RepoPermissionsFromSettingsTest {
     void deletesPermissionSection() throws IOException {
         final String repo = "nuget";
         final RepoPerms perm = new RepoPerms(
-            new RepoPermissions.UserPermission("someone", new ListOf<String>("r", "w"))
+            new RepoPermissions.PermissionItem("someone", new ListOf<String>("r", "w"))
         );
         perm.saveSettings(this.storage, repo);
         new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).remove(repo)

--- a/src/test/java/com/artipie/RepoPerms.java
+++ b/src/test/java/com/artipie/RepoPerms.java
@@ -52,7 +52,7 @@ public final class RepoPerms {
     /**
      * Collection with user permissions.
      */
-    private final Collection<RepoPermissions.UserPermission> usersperms;
+    private final Collection<RepoPermissions.PermissionItem> usersperms;
 
     /**
      * Collection of included patterns.
@@ -70,7 +70,7 @@ public final class RepoPerms {
      * Ctor.
      * @param userperm Permission for a single user
      */
-    public RepoPerms(final RepoPermissions.UserPermission userperm) {
+    public RepoPerms(final RepoPermissions.PermissionItem userperm) {
         this(Collections.singleton(userperm));
     }
 
@@ -78,7 +78,7 @@ public final class RepoPerms {
      * Primary ctor.
      * @param usersperms Collection with user permissions
      */
-    public RepoPerms(final Collection<RepoPermissions.UserPermission> usersperms) {
+    public RepoPerms(final Collection<RepoPermissions.PermissionItem> usersperms) {
         this(usersperms, Collections.emptyList());
     }
 
@@ -88,7 +88,7 @@ public final class RepoPerms {
      * @param patterns Collection of included patterns.
      */
     public RepoPerms(
-        final Collection<RepoPermissions.UserPermission> usersperms,
+        final Collection<RepoPermissions.PermissionItem> usersperms,
         final Collection<String> patterns
     ) {
         this.usersperms = usersperms;
@@ -153,7 +153,7 @@ public final class RepoPerms {
     private YamlMapping permsYaml() {
         YamlMappingBuilder perms = Yaml.createYamlMappingBuilder();
         if (!this.usersperms.isEmpty()) {
-            for (final RepoPermissions.UserPermission user : this.usersperms) {
+            for (final RepoPermissions.PermissionItem user : this.usersperms) {
                 perms = perms.add(user.username(), user.yaml().build());
             }
         }

--- a/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
@@ -94,23 +94,28 @@ class AddUpdatePermissionSliceTest {
         );
         MatcherAssert.assertThat(
             "Sets permissions for bob",
-            this.permissionsForUser(repo, "bob"),
+            this.permissionsFor(repo, "bob"),
             Matchers.containsInAnyOrder("read", "write", "*")
         );
         MatcherAssert.assertThat(
             "Sets permissions for alice",
-            this.permissionsForUser(repo, "alice"),
+            this.permissionsFor(repo, "alice"),
             Matchers.containsInAnyOrder("write", "read")
         );
         MatcherAssert.assertThat(
             "Sets permissions for john",
-            this.permissionsForUser(repo, "john"),
+            this.permissionsFor(repo, "john"),
             Matchers.containsInAnyOrder("*")
         );
         MatcherAssert.assertThat(
             "Sets patterns",
             this.patterns(repo),
             Matchers.contains("**", "maven/**")
+        );
+        MatcherAssert.assertThat(
+            "Sets readers group",
+            this.permissionsFor(repo, "/readers"),
+            Matchers.contains("read")
         );
     }
 
@@ -141,7 +146,7 @@ class AddUpdatePermissionSliceTest {
         );
     }
 
-    private List<String> permissionsForUser(final String repo, final String user)
+    private List<String> permissionsFor(final String repo, final String user)
         throws IOException {
         return this.repo(repo).yamlMapping("permissions").yamlSequence(user)
             .values().stream().map(node -> node.asScalar().value())

--- a/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
@@ -47,7 +47,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -116,7 +115,8 @@ final class AddUpdateUserSliceTest {
             rqmeth,
             String.format("/api/security/users/%s", username)
         );
-        final List<String> groups = new ListOf<>("a-team", "b-team");
+        final String ateam = "a-team";
+        final String bteam = "b-team";
         this.creds("person", Collections.emptyList());
         MatcherAssert.assertThat(
             "AddUpdateUserSlice response should be OK",
@@ -126,7 +126,7 @@ final class AddUpdateUserSliceTest {
                 )
             ).response(
                 rqline.toString(), Headers.EMPTY,
-                this.jsonBody(pswd, username, groups)
+                this.jsonBody(pswd, username, new ListOf<String>(ateam, bteam))
             ),
             new RsHasStatus(RsStatus.OK)
         );
@@ -140,8 +140,8 @@ final class AddUpdateUserSliceTest {
             this.readCreds(username).yamlSequence("groups")
                 .values().stream().map(node -> node.asScalar().value())
                 .collect(Collectors.toList()),
-            new IsEqual<>(
-                Stream.concat(groups.stream(), Stream.of("readers")).collect(Collectors.toList())
+            Matchers.containsInAnyOrder(
+                ateam, bteam, "readers"
             )
         );
     }

--- a/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
@@ -47,13 +47,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -115,7 +116,7 @@ final class AddUpdateUserSliceTest {
             rqmeth,
             String.format("/api/security/users/%s", username)
         );
-        final List<String> groups = new ListOf<>("readers", "a-team");
+        final List<String> groups = new ListOf<>("a-team", "b-team");
         this.creds("person", Collections.emptyList());
         MatcherAssert.assertThat(
             "AddUpdateUserSlice response should be OK",
@@ -139,7 +140,9 @@ final class AddUpdateUserSliceTest {
             this.readCreds(username).yamlSequence("groups")
                 .values().stream().map(node -> node.asScalar().value())
                 .collect(Collectors.toList()),
-            new IsEqual<>(groups)
+            new IsEqual<>(
+                Stream.concat(groups.stream(), Stream.of("readers")).collect(Collectors.toList())
+            )
         );
     }
 
@@ -171,9 +174,11 @@ final class AddUpdateUserSliceTest {
             new IsEqual<>(this.shaPswd(newpswd))
         );
         MatcherAssert.assertThat(
-            "Yaml has no groups",
-            this.readCreds(username).yamlSequence("groups"),
-            new IsNull<>()
+            "Yaml has readers group only",
+            this.readCreds(username).yamlSequence("groups")
+                .values().stream().map(node -> node.asScalar().value())
+                .collect(Collectors.toList()),
+            Matchers.contains("readers")
         );
     }
 

--- a/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
@@ -82,9 +82,9 @@ class DeletePermissionSliceTest {
         final Key.From key = new Key.From(String.format("%s.yaml", repo));
         final RepoPerms perms = new RepoPerms(
             List.of(
-                new RepoPermissions.UserPermission("admin", new ListOf<String>("*")),
-                new RepoPermissions.UserPermission("john", new ListOf<String>("delete")),
-                new RepoPermissions.UserPermission("*", new ListOf<String>("download"))
+                new RepoPermissions.PermissionItem("admin", new ListOf<String>("*")),
+                new RepoPermissions.PermissionItem("john", new ListOf<String>("delete")),
+                new RepoPermissions.PermissionItem("*", new ListOf<String>("download"))
             )
         );
         perms.saveSettings(storage, repo);

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -111,8 +111,8 @@ class GetPermissionSliceTest {
         final String mark = "mark";
         final RepoPerms perm = new RepoPerms(
             List.of(
-                new RepoPermissions.UserPermission(john, new ListOf<String>("read", "write")),
-                new RepoPermissions.UserPermission(mark, new ListOf<String>("*"))
+                new RepoPermissions.PermissionItem(john, new ListOf<String>("read", "write")),
+                new RepoPermissions.PermissionItem(mark, new ListOf<String>("*"))
             ),
             Collections.singletonList("**/*")
         );


### PR DESCRIPTION
Part of #573 
- user created from `AddUpdateUserSlice` always is in `readers` group
- repo permissions updated/created from `AddUpdatePermissionSlice` always include `read` right for `readers` groups