### PR TITLE
#647 - document repo perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
 
 ## Repository permissions
 
-Permissions for repository operations can granted in the repo configuration file:
+Permissions for repository operations can be granted in the repo configuration file:
 ```yaml
 repo:
   ...
@@ -142,7 +142,7 @@ repo:
 All repositories support `read` and `write` operations, files repository also supports `delete` operation.
 
 Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
-and every user within the group can read from the repository, `read` and `write` operations are granted to user named `jane`.
+and every user within the group can read from the repository, `jane` is allowed to `read` and `write`.
 We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example above 
 can perform any operation in the repository.
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ All repositories support `read` and `write` operations, other specific permissio
 in certain repository types.
 
 Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
-and every user within the group can read from the repository, `jane` is allowed to `read` and `write`.
-We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example above 
+and every user within the group can read from the repository, user named `jane` is allowed to `read` and `write`.
+We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example 
 can perform any operation in the repository.
 
-If `permissions` section is absent in repo config then any supported operation is allowed for everyone,
+If `permissions` section is absent in repo config, then any supported operation is allowed for everyone,
 empty `permissions` section restricts any operations for anyone.
 
 ## Multitenancy

--- a/README.md
+++ b/README.md
@@ -73,11 +73,42 @@ understand how Artipie is designed.
 
 ## Contents
 
-- [Multitenancy](#multitenancy)
-- [Repository permissions](#repository-permissions)
 - [Storage configuration](#storage-configuration)
+- [Repository permissions](#repository-permissions)
+- [Multitenancy](#multitenancy)
 - [Metrics](#metrics)
 - [Artipie REST API](#artipie-rest-api)
+
+## Storage configuration
+
+TBW
+
+## Repository permissions
+
+Permissions for repository operations can be granted in the repo configuration file:
+```yaml
+repo:
+  ...
+  permissions:
+    jane:
+      - read
+      - write
+    admin:
+      - "*"
+    /readers:
+      - read
+```
+
+All repositories support `read` and `write` operations, other specific permissions may be supported 
+in certain repository types.
+
+Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
+and every user within the group can read from the repository, `jane` is allowed to `read` and `write`.
+We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example above 
+can perform any operation in the repository.
+
+If `permissions` section is absent in repo config then any supported operation is allowed for everyone,
+empty `permissions` section restricts any operations for anyone.
 
 ## Multitenancy
 
@@ -122,33 +153,6 @@ docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
   -e ARTIPIE_USER_NAME=artipie -e ARTIPIE_USER_PASS=qwerty \
   artipie/artipie:latest
 ```
-
-## Repository permissions
-
-Permissions for repository operations can be granted in the repo configuration file:
-```yaml
-repo:
-  ...
-  permissions:
-    jane:
-      - read
-      - write
-    admin:
-      - "*"
-    /readers:
-      - read
-```
-
-All repositories support `read` and `write` operations, files repository also supports `delete` operation.
-
-Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
-and every user within the group can read from the repository, `jane` is allowed to `read` and `write`.
-We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example above 
-can perform any operation in the repository.
-
-## Storage configuration
-
-TBW
 
 ## Single repository on port
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ We recommend you read the "Architecture" section in our
 [White Paper](https://github.com/artipie/white-paper) to fully
 understand how Artipie is designed.
 
+## Contents
+
+- [Multitenancy](#multitenancy)
+- [Repository permissions](#repository-permissions)
+- [Storage configuration](#storage-configuration)
+- [Metrics](#metrics)
+- [Artipie REST API](#artipie-rest-api)
+
 ## Multitenancy
 
 You may want to run Artipie for your company, which has a few teams.
@@ -115,17 +123,32 @@ docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
   artipie/artipie:latest
 ```
 
-## Metrics
+## Repository permissions
 
-You may enable some basic metrics collecting and periodic publishing to application log
-by adding `metrics` to `meta` section of global configuration file `/etc/artipie.yml`:
-
+Permissions for repository operations can granted in the repo configuration file:
 ```yaml
-meta:
-  metrics:
-    type: log # Metrics type, for now only `log` type is supported
-    interval: 5 # Publishing interval in seconds, default value is 5
+repo:
+  ...
+  permissions:
+    jane:
+      - read
+      - write
+    admin:
+      - "*"
+    /readers:
+      - read
 ```
+
+All repositories support `read` and `write` operations, files repository also supports `delete` operation.
+
+Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
+and every user within the group can read from the repository, `read` and `write` operations are granted to user named `jane`.
+We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example above 
+can perform any operation in the repository.
+
+## Storage configuration
+
+TBW
 
 ## Single repository on port
 
@@ -145,6 +168,18 @@ repo:
 
 *NOTE: Artipie scans repositories for port configuration only on start, 
 so server requires restart in order to apply changes made in runtime.* 
+
+## Metrics
+
+You may enable some basic metrics collecting and periodic publishing to application log
+by adding `metrics` to `meta` section of global configuration file `/etc/artipie.yml`:
+
+```yaml
+meta:
+  metrics:
+    type: log # Metrics type, for now only `log` type is supported
+    interval: 5 # Publishing interval in seconds, default value is 5
+```
 
 ## Artipie REST API
 


### PR DESCRIPTION
Part of #647 
Added TOC and documented repo permissions. You can check md [here](https://github.com/olenagerasimova/artipie/tree/647-repo-perms)