### PR TITLE
#660 - used RepoConfigYaml in various tests

### DIFF
--- a/src/main/java/com/artipie/RepoPermissions.java
+++ b/src/main/java/com/artipie/RepoPermissions.java
@@ -310,6 +310,15 @@ public interface RepoPermissions {
         }
 
         /**
+         * Ctor.
+         * @param name Username
+         * @param permission Permission
+         */
+        public PermissionItem(final String name, final String permission) {
+            this(name, Collections.singletonList(permission));
+        }
+
+        /**
          * Get username.
          * @return String username
          */

--- a/src/test/java/com/artipie/RepoConfigYaml.java
+++ b/src/test/java/com/artipie/RepoConfigYaml.java
@@ -76,12 +76,12 @@ public final class RepoConfigYaml {
     }
 
     /**
-     * Adds port to config.
-     * @param url Port
+     * Adds url to config.
+     * @param url Url
      * @return Itself
      */
     public RepoConfigYaml withUrl(final String url) {
-        this.builder = this.builder.add("url", String.valueOf(url));
+        this.builder = this.builder.add("url", url);
         return this;
     }
 

--- a/src/test/java/com/artipie/RepoConfigYaml.java
+++ b/src/test/java/com/artipie/RepoConfigYaml.java
@@ -25,6 +25,9 @@ package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import com.amihaiemil.eoyaml.YamlSequenceBuilder;
+import com.artipie.asto.Content;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 /**
@@ -73,6 +76,16 @@ public final class RepoConfigYaml {
     }
 
     /**
+     * Adds port to config.
+     * @param url Port
+     * @return Itself
+     */
+    public RepoConfigYaml withUrl(final String url) {
+        this.builder = this.builder.add("url", String.valueOf(url));
+        return this;
+    }
+
+    /**
      * Adds permissions section to config.
      * @param perms Permissions
      * @return Itself
@@ -96,8 +109,26 @@ public final class RepoConfigYaml {
         return this;
     }
 
+    /**
+     * Adds remotes to config.
+     * @param remotes Remotes yaml sequence
+     * @return Itself
+     */
+    public RepoConfigYaml withRemotes(final YamlSequenceBuilder remotes) {
+        this.builder = this.builder.add("remotes", remotes.build());
+        return this;
+    }
+
     @Override
     public String toString() {
         return Yaml.createYamlMappingBuilder().add("repo", this.builder.build()).build().toString();
+    }
+
+    /**
+     * Repo settings as content.
+     * @return Instanse of {@link Content}
+     */
+    public Content toContent() {
+        return new Content.From(this.toString().getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/com/artipie/RepoPerms.java
+++ b/src/test/java/com/artipie/RepoPerms.java
@@ -68,6 +68,15 @@ public final class RepoPerms {
 
     /**
      * Ctor.
+     * @param user Username
+     * @param action Action
+     */
+    public RepoPerms(final String user, final String action) {
+        this(new RepoPermissions.PermissionItem(user, action));
+    }
+
+    /**
+     * Ctor.
      * @param userperm Permission for a single user
      */
     public RepoPerms(final RepoPermissions.PermissionItem userperm) {

--- a/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
@@ -24,6 +24,7 @@
 package com.artipie.api.artifactory;
 
 import com.artipie.IsJson;
+import com.artipie.RepoConfigYaml;
 import com.artipie.Settings;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
@@ -111,16 +112,7 @@ class GetStorageSliceTest {
         final Storage storage = new LoggingStorage(new InMemoryStorage());
         storage.save(
             new Key.From(String.format("%s.yaml", name)),
-            new Content.From(
-                String.join(
-                    "\n",
-                    "repo:",
-                    "  type: file",
-                    "  storage:",
-                    "    type: fs",
-                    String.format("    path: %s", temp.toString())
-                ).getBytes()
-            )
+            new RepoConfigYaml("file").withFileStorage(temp).toContent()
         );
         final Storage repo = new SubStorage(new Key.From(name), new FileStorage(temp));
         repo.save(new Key.From("foo/bar/1"), Content.EMPTY).join();

--- a/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
+++ b/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
@@ -25,6 +25,8 @@ package com.artipie.auth;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.RepoPermissions;
+import com.artipie.RepoPerms;
 import com.artipie.YamlPermissions;
 import com.artipie.http.auth.BasicIdentities;
 import com.artipie.http.auth.Permission;
@@ -55,7 +57,7 @@ import org.junit.jupiter.api.Test;
 public class AuthAndPermissionsTest {
 
     @Test
-    void allowsDownloadWhenAuthHeaderIsNotPresent() throws IOException {
+    void allowsDownloadWhenAuthHeaderIsNotPresent() {
         MatcherAssert.assertThat(
             new SliceAuth(
                 new SliceSimple(StandardRs.EMPTY),
@@ -173,7 +175,7 @@ public class AuthAndPermissionsTest {
     }
 
     @Test
-    void authIsNotRequiredForPublicRepo() throws IOException {
+    void authIsNotRequiredForPublicRepo() {
         final RsStatus status = RsStatus.ACCEPTED;
         MatcherAssert.assertThat(
             new SliceAuth(
@@ -226,25 +228,20 @@ public class AuthAndPermissionsTest {
         ).build();
     }
 
-    private YamlPermissions permissions() throws IOException {
+    private YamlPermissions permissions() {
         return new YamlPermissions(
-            Yaml.createYamlInput(
-                String.join(
-                    "\n",
-                    "admin:",
-                    "  - \"*\"",
-                    "john:",
-                    "  - delete",
-                    "  - deploy",
-                    "\"*\":",
-                    "  - download"
+            new RepoPerms(
+                new ListOf<>(
+                    new RepoPermissions.PermissionItem("admin", "*"),
+                    new RepoPermissions.PermissionItem("*", "download"),
+                    new RepoPermissions.PermissionItem("john", new ListOf<>("delete", "deploy"))
                 )
-            ).readYamlMapping()
+            ).permsYaml()
         );
     }
 
-    private YamlPermissions allAllowedPermissions() throws IOException {
-        return new YamlPermissions(Yaml.createYamlInput("\"*\":\n  - \"*\"").readYamlMapping());
+    private YamlPermissions allAllowedPermissions() {
+        return new YamlPermissions(new RepoPerms("*", "*").permsYaml());
     }
 
 }

--- a/src/test/java/com/artipie/docker/DockerOnPortIT.java
+++ b/src/test/java/com/artipie/docker/DockerOnPortIT.java
@@ -23,8 +23,8 @@
  */
 package com.artipie.docker;
 
-import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.ArtipieServer;
+import com.artipie.RepoConfigYaml;
 import com.artipie.docker.junit.DockerClient;
 import com.artipie.docker.junit.DockerClientSupport;
 import java.io.IOException;
@@ -71,21 +71,12 @@ final class DockerOnPortIT {
     @BeforeEach
     void setUp(@TempDir final Path root) throws Exception {
         final int port = freePort();
-        final String config = Yaml.createYamlMappingBuilder().add(
-            "repo",
-            Yaml.createYamlMappingBuilder()
-                .add("type", "docker")
-                .add(
-                    "storage",
-                    Yaml.createYamlMappingBuilder()
-                        .add("type", "fs")
-                        .add("path", root.resolve("data").toString())
-                        .build()
-                )
-                .add("port", String.valueOf(port))
-                .build()
-        ).build().toString();
-        this.server = new ArtipieServer(root, "my-docker", config);
+        this.server = new ArtipieServer(
+            root, "my-docker",
+            new RepoConfigYaml("docker")
+                .withFileStorage(root.resolve("data"))
+                .withPort(port)
+        );
         this.server.start();
         this.repository = String.format("localhost:%d", port);
         this.image = this.prepareImage();

--- a/src/test/java/com/artipie/docker/DockerProxyIT.java
+++ b/src/test/java/com/artipie/docker/DockerProxyIT.java
@@ -25,6 +25,7 @@ package com.artipie.docker;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.ArtipieServer;
+import com.artipie.RepoConfigYaml;
 import com.artipie.docker.junit.DockerClient;
 import com.artipie.docker.junit.DockerClientSupport;
 import com.artipie.docker.proxy.ProxyDocker;
@@ -86,28 +87,22 @@ final class DockerProxyIT {
 
     @BeforeEach
     void setUp(@TempDir final Path root) throws Exception {
-        final String config = Yaml.createYamlMappingBuilder().add(
-            "repo",
-            Yaml.createYamlMappingBuilder()
-                .add("type", "docker-proxy")
-                .add(
-                    "remotes",
-                    Yaml.createYamlSequenceBuilder()
-                        .add(
-                            Yaml.createYamlMappingBuilder()
-                                .add("url", "registry-1.docker.io")
-                                .build()
-                        )
-                        .add(
-                            Yaml.createYamlMappingBuilder()
-                                .add("url", "mcr.microsoft.com")
-                                .build()
-                        )
-                        .build()
-                )
-                .build()
-        ).build().toString();
-        this.server = new ArtipieServer(root, "my-docker", config);
+        this.server = new ArtipieServer(
+            root, "my-docker",
+            new RepoConfigYaml("docker-proxy").withRemotes(
+                Yaml.createYamlSequenceBuilder()
+                    .add(
+                        Yaml.createYamlMappingBuilder()
+                            .add("url", "registry-1.docker.io")
+                            .build()
+                    )
+                    .add(
+                        Yaml.createYamlMappingBuilder()
+                            .add("url", "mcr.microsoft.com")
+                            .build()
+                    )
+            )
+        );
         final int port = this.server.start();
         this.repository = String.format("localhost:%d", port);
         this.image = new Image.ForOs();


### PR DESCRIPTION
Part of #660 
Extended `RepoConfigYaml` and used it in various test classes to create repo config. 
Decided to leave `DockerProxyTest` as is as (its config is large and such configuration is used only once).