### PR TITLE
#660 - use RepoConfigYaml instead of RepoPerms

### DIFF
--- a/src/test/java/com/artipie/RepoPerms.java
+++ b/src/test/java/com/artipie/RepoPerms.java
@@ -26,14 +26,8 @@ package com.artipie;
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
-import com.amihaiemil.eoyaml.YamlNode;
 import com.amihaiemil.eoyaml.YamlSequence;
 import com.amihaiemil.eoyaml.YamlSequenceBuilder;
-import com.artipie.asto.Content;
-import com.artipie.asto.Key;
-import com.artipie.asto.Storage;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -42,12 +36,7 @@ import java.util.List;
  * Class for generating repo permissions.
  * @since 0.10
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RepoPerms {
-    /**
-     * Permissions section name.
-     */
-    private static final String PERMISSIONS = "permissions";
 
     /**
      * Collection with user permissions.
@@ -114,30 +103,6 @@ public final class RepoPerms {
     }
 
     /**
-     * Save to the storage repo with map with users and permissions.
-     * @param storage Storage
-     * @param repo Repo
-     */
-    public void saveSettings(final Storage storage, final String repo) {
-        final YamlMappingBuilder root = RepoPerms.repoSectionAsBuilder(
-            Yaml.createYamlMappingBuilder().add("type", "any").build()
-        );
-        storage.save(
-            new Key.From(String.format("%s.yaml", repo)),
-            new Content.From(
-                Yaml.createYamlMappingBuilder().add(
-                    "repo",
-                    root.add(
-                        RepoPerms.PERMISSIONS, this.permsYaml()
-                    ).add(
-                        "permissions_include_patterns", this.patternsYaml()
-                    ).build()
-                ).build().toString().getBytes(StandardCharsets.UTF_8)
-            )
-        ).join();
-    }
-
-    /**
      * Build YAML sequence of patterns.
      *
      * @return YAML sequence of patterns.
@@ -162,19 +127,5 @@ public final class RepoPerms {
             }
         }
         return perms.build();
-    }
-
-    /**
-     * Copy `repo` section from existing yaml setting.
-     * @param mapping Repo section mapping
-     * @return YamlMappingBuilder from existing yaml setting.
-     */
-    private static YamlMappingBuilder repoSectionAsBuilder(final YamlMapping mapping) {
-        YamlMappingBuilder res = Yaml.createYamlMappingBuilder();
-        final List<YamlNode> nodes = new ArrayList<>(mapping.keys());
-        for (final YamlNode node : nodes) {
-            res = res.add(node, mapping.value(node));
-        }
-        return res;
     }
 }

--- a/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
@@ -25,7 +25,7 @@ package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.RepoPerms;
+import com.artipie.RepoConfigYaml;
 import com.artipie.Settings;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
@@ -81,8 +81,7 @@ class AddUpdatePermissionSliceTest {
     @Test
     void updatesPermissionsAndPatterns() throws IOException {
         final String repo = "maven";
-        final RepoPerms perm = new RepoPerms();
-        perm.saveSettings(this.storage, repo);
+        new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             "Returns 200 OK",
             new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),
@@ -128,8 +127,7 @@ class AddUpdatePermissionSliceTest {
     @Test
     void validatesPatterns() {
         final String repo = "docker";
-        final RepoPerms perm = new RepoPerms();
-        perm.saveSettings(this.storage, repo);
+        new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),
             new SliceHasResponse(
@@ -155,8 +153,7 @@ class AddUpdatePermissionSliceTest {
     @Test
     void doesNotAddReadersGroupTwice() {
         final String repo = "maven";
-        final RepoPerms perm = new RepoPerms();
-        perm.saveSettings(this.storage, repo);
+        new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             "Returns 200 OK",
             new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.api.artifactory;
 
+import com.artipie.RepoConfigYaml;
 import com.artipie.RepoPermissions;
 import com.artipie.RepoPerms;
 import com.artipie.Settings;
@@ -88,8 +89,7 @@ class GetPermissionSliceTest {
     @Test
     void returnsEmptyUsersIfNoPermissionsSet() {
         final String repo = "docker";
-        final RepoPerms perm = new RepoPerms();
-        perm.saveSettings(this.storage, repo);
+        new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             new GetPermissionSlice(new Settings.Fake(this.storage)),
             new SliceHasResponse(
@@ -113,20 +113,19 @@ class GetPermissionSliceTest {
         final String readers = "readers";
         final String team = "team";
         final String mark = "mark";
-        final RepoPerms perm = new RepoPerms(
-            List.of(
-                new RepoPermissions.PermissionItem(john, new ListOf<>("read", "write")),
-                new RepoPermissions.PermissionItem(mark, new ListOf<>("*")),
-                new RepoPermissions.PermissionItem(
-                    String.format("/%s", readers), new ListOf<>("read")
+        new RepoConfigYaml(repo).withPermissions(
+            new RepoPerms(
+                List.of(
+                    new RepoPermissions.PermissionItem(john, new ListOf<>("read", "write")),
+                    new RepoPermissions.PermissionItem(mark, "*"),
+                    new RepoPermissions.PermissionItem(String.format("/%s", readers), "read"),
+                    new RepoPermissions.PermissionItem(
+                        String.format("/%s", team), new ListOf<>("write", "delete")
+                    )
                 ),
-                new RepoPermissions.PermissionItem(
-                    String.format("/%s", team), new ListOf<>("write", "delete")
-                )
-            ),
-            Collections.singletonList("**/*")
-        );
-        perm.saveSettings(this.storage, repo);
+                Collections.singletonList("**/*")
+            )
+        ).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             new GetPermissionSlice(new Settings.Fake(this.storage)),
             new SliceHasResponse(


### PR DESCRIPTION
Closes #660 
Used `RepoConfigYaml.saveTo` instead of `RepoPerms.saveSettings` and removed not needed any more methods.