### PR TITLE
#633 - Response 404 to request not related to repos

### DIFF
--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -108,7 +108,7 @@ final class SliceByPath implements Slice {
                 key = new Key.From(split[0], split[1]);
             }
         } else {
-            if (split.length == 1) {
+            if (split.length >= 1) {
                 key = new Key.From(split[0]);
             }
         }

--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import org.reactivestreams.Publisher;
 
 /**
@@ -74,17 +75,17 @@ final class SliceByPath implements Slice {
     @SuppressWarnings("PMD.OnlyOneReturn")
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
-        final Key key;
+        final Optional<Key> key;
         try {
             key = this.keyFromPath(new RequestLineFrom(line).uri().getPath());
-            if (key.equals(Key.ROOT)) {
+            if (key.isEmpty()) {
                 return new RsWithBody(
                     new RsWithStatus(RsStatus.NOT_FOUND),
                     "Failed to find a repository",
                     StandardCharsets.UTF_8
                 );
             }
-            return this.repositories.slice(key, false).response(line, headers, body);
+            return this.repositories.slice(key.get(), false).response(line, headers, body);
         } catch (final IOException err) {
             return new RsWithBody(
                 new RsWithStatus(RsStatus.INTERNAL_ERROR),
@@ -100,17 +101,16 @@ final class SliceByPath implements Slice {
      * @return Key from path.
      * @throws IOException In case of problems with reading settings.
      */
-    private Key keyFromPath(final String path) throws IOException {
+    private Optional<Key> keyFromPath(final String path) throws IOException {
         final String[] split = path.replaceAll("^/+", "").split("/");
-        Key key = Key.ROOT;
-        if (this.settings.layout().equals("org")) {
-            if (split.length >= 2) {
-                key = new Key.From(split[0], split[1]);
-            }
+        final Optional<Key> key;
+        final boolean org = this.settings.layout().equals("org");
+        if (org && split.length >= 2) {
+            key = Optional.of(new Key.From(split[0], split[1]));
+        } else if (!org && split.length >= 1) {
+            key = Optional.of(new Key.From(split[0]));
         } else {
-            if (split.length >= 1) {
-                key = new Key.From(split[0]);
-            }
+            key = Optional.empty();
         }
         return key;
     }

--- a/src/test/java/com/artipie/AllRepositoriesSliceTest.java
+++ b/src/test/java/com/artipie/AllRepositoriesSliceTest.java
@@ -32,6 +32,8 @@ import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link AllRepositoriesSlice}.
@@ -43,9 +45,21 @@ public final class AllRepositoriesSliceTest {
     @Test
     public void unexistingRepoReturnNotFound() {
         MatcherAssert.assertThat(
-            "Must return 404 HTTP status",
             new AllRepositoriesSlice(new Settings.Fake()).response(
                 new RequestLine(RqMethod.GET, "/repo/foo").toString(),
+                Headers.EMPTY,
+                Content.EMPTY
+            ),
+            new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/favicon.ico", "robots.txt"})
+    void requestThatNotDirectedToRepoReturnNotFound(final String uri) {
+        MatcherAssert.assertThat(
+            new AllRepositoriesSlice(new Settings.Fake()).response(
+                new RequestLine(RqMethod.GET, uri).toString(),
                 Headers.EMPTY,
                 Content.EMPTY
             ),


### PR DESCRIPTION
Closes #633 
Respond with 404 to request not related to repositories in `SliceByPath`