### PR TITLE
#608 - Using RepoConfig in MavenProxy

### DIFF
--- a/src/main/resources/dashboard/repo.hbs
+++ b/src/main/resources/dashboard/repo.hbs
@@ -17,9 +17,11 @@
 repo:
   type: {{type}}
   storage: default{{#eq type "maven-proxy"}}
-  settings:
-    # proxy for Apache Maven central
-    remote_uri: https://repo.maven.apache.org/maven2{{/eq}}{{#eq type "maven-group"}}
+  # proxy for Apache Maven central
+  remotes:
+    - uri: https://repo.maven.apache.org/maven2
+      cache:
+        storage: default{{/eq}}{{#eq type "maven-group"}}
   settings:
     repositories:
       - {{user}}/mprivate1

--- a/src/main/resources/example/repo/test/maven-proxy.yaml
+++ b/src/main/resources/example/repo/test/maven-proxy.yaml
@@ -1,8 +1,7 @@
 repo:
   type: maven-proxy
-  storage: default
   settings:
-    remote_uri: https://repo.maven.apache.org/maven2
-  permissions:
-    "*":
-      - "*"
+    remotes:
+      - uri: https://repo.maven.apache.org/maven2
+        cache:
+          - storage: default

--- a/src/test/java/com/artipie/RepoConfigYaml.java
+++ b/src/test/java/com/artipie/RepoConfigYaml.java
@@ -100,14 +100,16 @@ public final class RepoConfigYaml {
     }
 
     /**
-     * Adds remote uri to config.
-     * @param uri URI
+     * Adds remote to config.
+     * @param url URL
      * @return Itself
      */
-    public RepoConfigYaml withRemoteUri(final String uri) {
+    public RepoConfigYaml withRemote(final String url) {
         this.builder = this.builder.add(
-            "settings",
-            Yaml.createYamlMappingBuilder().add("remote_uri", uri).build()
+            "remotes",
+            Yaml.createYamlSequenceBuilder().add(
+                Yaml.createYamlMappingBuilder().add("url", url).build()
+            ).build()
         );
         return this;
     }
@@ -123,24 +125,26 @@ public final class RepoConfigYaml {
     }
 
     /**
-     * Adds remote uri with authentication to config.
-     * @param uri URI
+     * Adds remote with authentication to config.
+     * @param url URL
      * @param username Username
      * @param password Password
      * @return Itself
      */
-    public RepoConfigYaml withRemoteUri(
-        final String uri,
+    public RepoConfigYaml withRemote(
+        final String url,
         final String username,
         final String password
     ) {
         this.builder = this.builder.add(
-            "settings",
-            Yaml.createYamlMappingBuilder()
-                .add("remote_uri", uri)
-                .add("remote_username", username)
-                .add("remote_password", password)
-                .build()
+            "remotes",
+            Yaml.createYamlSequenceBuilder().add(
+                Yaml.createYamlMappingBuilder()
+                    .add("url", url)
+                    .add("username", username)
+                    .add("password", password)
+                    .build()
+            ).build()
         );
         return this;
     }

--- a/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
@@ -152,7 +152,7 @@ final class MavenProxyAuthIT {
             "my-maven",
             new RepoConfigYaml("maven-proxy")
                 .withFileStorage(root.resolve("repos"))
-                .withRemoteUri(
+                .withRemote(
                     String.format("http://localhost:%s/maven-origin", this.origin.port()),
                     ArtipieServer.ALICE.name(),
                     ArtipieServer.ALICE.password()

--- a/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -89,7 +89,7 @@ final class MavenProxyIT {
             this.tmp, "my-maven",
             new RepoConfigYaml("maven-proxy")
                 .withFileStorage(this.tmp.resolve("repos"))
-                .withRemoteUri("https://repo.maven.apache.org/maven2")
+                .withRemote("https://repo.maven.apache.org/maven2")
         );
         this.port = this.server.start();
         final Path setting = this.tmp.resolve("settings.xml");


### PR DESCRIPTION
Part of #608 
Using `RepoConfig` in `MavenProxy`. Format for `maven-proxy` repository changed