### PR TITLE
#690 - use CredsConfigYaml

### DIFF
--- a/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
+++ b/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
@@ -24,6 +24,7 @@
 package com.artipie.api;
 
 import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.CredsConfigYaml;
 import com.artipie.Settings;
 import com.artipie.Users;
 import com.artipie.asto.Content;
@@ -39,7 +40,6 @@ import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -75,7 +75,7 @@ class ApiChangeUserPasswordTest {
     void returnsFoundIfUserWasAddedToCredentials() throws IOException {
         final String username = "mike";
         final String pswd = "qwerty123";
-        this.creds("person");
+        new CredsConfigYaml().withUsers("person").saveTo(this.storage, this.key);
         MatcherAssert.assertThat(
             "ApiChangeUserPassword response should be FOUND",
             new ApiChangeUserPassword(
@@ -104,7 +104,7 @@ class ApiChangeUserPasswordTest {
     void returnsFoundIfPasswordWasUpdated() throws IOException {
         final String username = "john";
         final String pswd = "0000";
-        this.creds(username);
+        new CredsConfigYaml().withUsers(username).saveTo(this.storage, this.key);
         MatcherAssert.assertThat(
             "ApiChangeUserPassword response should be FOUND",
             new ApiChangeUserPassword(
@@ -136,21 +136,6 @@ class ApiChangeUserPasswordTest {
         ).readYamlMapping().value("credentials")
             .asMapping().value(username)
             .asMapping().string("pass");
-    }
-
-    private void creds(final String username) {
-        this.storage.save(
-            this.key,
-            new Content.From(Yaml.createYamlMappingBuilder()
-                .add(
-                    "credentials",
-                    Yaml.createYamlMappingBuilder().add(
-                        username,
-                        Yaml.createYamlMappingBuilder().add("pass", "sha265:123").build()
-                    ).build()
-                ).build().toString().getBytes(StandardCharsets.UTF_8)
-            )
-        );
     }
 
     private Content body(final String pswd) {

--- a/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
+++ b/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
@@ -23,8 +23,8 @@
  */
 package com.artipie.auth;
 
-import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.CredsConfigYaml;
 import com.artipie.RepoPermissions;
 import com.artipie.RepoPerms;
 import com.artipie.YamlPermissions;
@@ -213,19 +213,8 @@ public class AuthAndPermissionsTest {
     }
 
     private YamlMapping credentials() {
-        return Yaml.createYamlMappingBuilder().add(
-            "credentials",
-            Yaml.createYamlMappingBuilder()
-                .add(
-                    "john",
-                    Yaml.createYamlMappingBuilder().add("pass", "plain:123").build()
-                )
-                .add(
-                    "admin",
-                    Yaml.createYamlMappingBuilder().add("pass", "plain:abc").build()
-                )
-                .build()
-        ).build();
+        return new CredsConfigYaml().withUserAndPlainPswd("john", "123")
+            .withUserAndPlainPswd("admin", "abc").yaml();
     }
 
     private YamlPermissions permissions() {


### PR DESCRIPTION
Part of #690 
In #203 we introduced config format with separate yaml field for password type: 
```
username:
  type: plain/sha256
  pass: 123
...
``` 
Such format seems more readable, that's why I've corrected `CredsConfigYaml` to use separate field for type and left old format only in `AuthFromYamlTest` to verify it's working. Also added several methods to `CredsConfigYaml` and used it tests. 