### PR TITLE
#693 - Docker upgraded to 0.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.16.2</version>
+      <version>0.16.5</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -258,7 +258,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>docker-adapter</artifactId>
-      <version>0.4.7</version>
+      <version>0.4.8</version>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -72,7 +72,9 @@ import java.util.stream.Collectors;
  * @checkstyle CyclomaticComplexityCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.StaticAccessToStaticFields"})
+@SuppressWarnings(
+    {"PMD.AvoidCatchingGenericException", "PMD.StaticAccessToStaticFields", "deprecation"}
+)
 public final class SliceFromConfig extends Slice.Wrap {
 
     /**

--- a/src/main/java/com/artipie/api/ArtipieApi.java
+++ b/src/main/java/com/artipie/api/ArtipieApi.java
@@ -70,7 +70,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @checkstyle MethodLengthCheck (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveMethodLength"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveMethodLength", "deprecation"})
 public final class ArtipieApi extends Slice.Wrap {
 
     /**

--- a/src/main/java/com/artipie/api/AuthApi.java
+++ b/src/main/java/com/artipie/api/AuthApi.java
@@ -51,6 +51,7 @@ import org.apache.commons.codec.binary.Hex;
  * API authentication wrapper.
  * @since 0.6
  */
+@SuppressWarnings("deprecation")
 public final class AuthApi implements Identities {
 
     /**

--- a/src/main/java/com/artipie/dashboard/DashboardSlice.java
+++ b/src/main/java/com/artipie/dashboard/DashboardSlice.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("deprecation")
 public final class DashboardSlice extends Slice.Wrap {
 
     /**

--- a/src/main/java/com/artipie/http/DockerRoutingSlice.java
+++ b/src/main/java/com/artipie/http/DockerRoutingSlice.java
@@ -26,7 +26,8 @@ package com.artipie.http;
 import com.artipie.Settings;
 import com.artipie.docker.http.BaseEntity;
 import com.artipie.http.async.AsyncResponse;
-import com.artipie.http.auth.BasicIdentities;
+import com.artipie.http.auth.BasicAuthSlice;
+import com.artipie.http.auth.Permissions;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RequestLineFrom;
 import java.nio.ByteBuffer;
@@ -84,8 +85,11 @@ public final class DockerRoutingSlice implements Slice {
             if (group.isEmpty() || group.equals("/")) {
                 rsp = new AsyncResponse(
                     this.settings.auth().thenApply(
-                        auth -> new BaseEntity(new BasicIdentities(auth))
-                            .response(line, headers, body)
+                        auth -> new BasicAuthSlice(
+                            new BaseEntity(),
+                            auth,
+                            user -> !user.equals(Permissions.ANY_USER)
+                        ).response(line, headers, body)
                     )
                 );
             } else {

--- a/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
+++ b/src/test/java/com/artipie/auth/AuthAndPermissionsTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.9
  * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods", "deprecation"})
 public class AuthAndPermissionsTest {
 
     @Test


### PR DESCRIPTION
Part of #693
Docker upgraded to 0.4.8 and HTTP to 0.16.5
In many places deprecation warning were suppressed. Should be fixed later