### PR TITLE
#690 - use CredsConfigYaml, correct Users.FromStorageYaml and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,18 @@ meta:
 
 If the `type` is set to `file`, another YAML file is required in the storage, with
 a list of users who will be allowed to create repos
-(each `pass` is combination or either `plain` or `sha256` and a text):
+(`type` is password format, `plain` and `sha256` types are supported):
 
 ```yaml
 credentials:
   jane:
-    pass: "plain:qwerty"
+    type: plain
+    pass: qwerty
+    email: jane@example.com # Optional
   john:
-    pass: "sha256:xxxxxxxxxxxxxxxxxxxxxxx"
-    groups:
+    type: sha256
+    pass: xxxxxxxxxxxxxxxxxxxxxxx
+    groups: # Optional
       - readers
       - dev-leads
 ```

--- a/src/main/java/com/artipie/Users.java
+++ b/src/main/java/com/artipie/Users.java
@@ -176,10 +176,8 @@ public interface Users {
                 yaml -> {
                     YamlMappingBuilder result = FromStorageYaml.removeUserRecord(user.uname, yaml);
                     YamlMappingBuilder info = Yaml.createYamlMappingBuilder()
-                        .add(
-                            "pass",
-                            String.format("%s:%s", format.name().toLowerCase(Locale.US), pswd)
-                        );
+                        .add("type", format.name().toLowerCase(Locale.US))
+                        .add("pass", pswd);
                     if (user.mail.isPresent()) {
                         info = info.add(FromStorageYaml.EMAIL, user.mail.get());
                     }

--- a/src/test/java/com/artipie/ArtipieServer.java
+++ b/src/test/java/com/artipie/ArtipieServer.java
@@ -24,8 +24,6 @@
 package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.amihaiemil.eoyaml.YamlMapping;
-import com.amihaiemil.eoyaml.YamlMappingBuilder;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -189,7 +187,7 @@ public class ArtipieServer {
         );
         Files.write(
             repos.resolve(ArtipieServer.CREDENTIALS_FILE),
-            credentials().toString().getBytes()
+            credentials().getBytes()
         );
         this.vertx = Vertx.vertx();
         this.server = new VertxMain(cfg, this.vertx, this.freeport);
@@ -219,17 +217,12 @@ public class ArtipieServer {
      *
      * @return Credentials YAML.
      */
-    private static YamlMapping credentials() {
-        YamlMappingBuilder builder = Yaml.createYamlMappingBuilder();
+    private static String credentials() {
+        final CredsConfigYaml cred = new CredsConfigYaml();
         for (final User user : ArtipieServer.USERS) {
-            builder = builder.add(
-                user.name(),
-                Yaml.createYamlMappingBuilder()
-                    .add("pass", String.format("plain:%s", user.password()))
-                    .build()
-            );
+            cred.withUserAndPlainPswd(user.name(), user.password());
         }
-        return Yaml.createYamlMappingBuilder().add("credentials", builder.build()).build();
+        return cred.toString();
     }
 
     /**

--- a/src/test/java/com/artipie/CredsConfigYaml.java
+++ b/src/test/java/com/artipie/CredsConfigYaml.java
@@ -129,6 +129,38 @@ public final class CredsConfigYaml {
     }
 
     /**
+     * Adds user with full info: name, password, email and groups.
+     * @param username Name
+     * @param format Password format
+     * @param pswd Password
+     * @param email Email
+     * @param groups Groups
+     * @return Itself
+     * @checkstyle ParameterNumberCheck (500 lines)
+     */
+    public CredsConfigYaml withFullInfo(final
+        String username, final Users.PasswordFormat format,
+        final String pswd, final String email, final List<String> groups) {
+        String pass = pswd;
+        if (format == Users.PasswordFormat.SHA256) {
+            pass = DigestUtils.sha256Hex(pass);
+        }
+        YamlMappingBuilder user = Yaml.createYamlMappingBuilder()
+            .add("type", format.name().toLowerCase(Locale.US))
+            .add("pass", pass)
+            .add("email", email);
+        if (!groups.isEmpty()) {
+            YamlSequenceBuilder seq = Yaml.createYamlSequenceBuilder();
+            for (final String group : groups) {
+                seq = seq.add(group);
+            }
+            user = user.add("groups", seq.build());
+        }
+        this.builder = this.builder.add(username, user.build());
+        return this;
+    }
+
+    /**
      * Saves credentials config to the provided storage by provided name.
      * @param storage Where to save
      * @param key Storage item name

--- a/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
+++ b/src/test/java/com/artipie/api/ApiChangeUserPasswordTest.java
@@ -96,7 +96,7 @@ class ApiChangeUserPasswordTest {
         MatcherAssert.assertThat(
             "User with correct password should be added",
             this.getPasswordFromYaml(username),
-            new IsEqual<>(this.pswd(pswd))
+            new IsEqual<>(DigestUtils.sha256Hex(pswd))
         );
     }
 
@@ -125,7 +125,7 @@ class ApiChangeUserPasswordTest {
         MatcherAssert.assertThat(
             "User with correct password should be added",
             this.getPasswordFromYaml(username),
-            new IsEqual<>(this.pswd(pswd))
+            new IsEqual<>(DigestUtils.sha256Hex(pswd))
         );
     }
 
@@ -140,10 +140,6 @@ class ApiChangeUserPasswordTest {
 
     private Content body(final String pswd) {
         return new Content.From(String.format("password=%s", pswd).getBytes());
-    }
-
-    private String pswd(final String pswd) {
-        return String.format("sha256:%s", DigestUtils.sha256Hex(pswd));
     }
 
 }

--- a/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdateUserSliceTest.java
@@ -132,7 +132,7 @@ final class AddUpdateUserSliceTest {
         MatcherAssert.assertThat(
             "User with correct password should be added",
             this.readCreds(username).string("pass"),
-            new IsEqual<>(this.shaPswd(pswd))
+            new IsEqual<>(DigestUtils.sha256Hex(pswd))
         );
         MatcherAssert.assertThat(
             "User has groups",
@@ -170,7 +170,7 @@ final class AddUpdateUserSliceTest {
         MatcherAssert.assertThat(
             "User with updated password should return",
             this.readCreds(username).string("pass"),
-            new IsEqual<>(this.shaPswd(newpswd))
+            new IsEqual<>(DigestUtils.sha256Hex(newpswd))
         );
         MatcherAssert.assertThat(
             "Yaml has readers group only",
@@ -190,10 +190,6 @@ final class AddUpdateUserSliceTest {
             json.add("groups", Json.createArrayBuilder(groups).build());
         }
         return Flowable.fromArray(ByteBuffer.wrap(json.build().toString().getBytes()));
-    }
-
-    private String shaPswd(final String pswd) {
-        return String.format("sha256:%s", DigestUtils.sha256Hex(pswd));
     }
 
     private YamlMapping readCreds(final String username) throws IOException {


### PR DESCRIPTION
Closes #690 
Corrected `Users.FromStorageYaml` to save password with format in separate field and used `CredsConfigYaml` in the corresponding test. Also, corrected and extended readme