### PR TITLE
#722 - Create a separate class for test container

### DIFF
--- a/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -81,8 +81,8 @@ final class FileProxyAuthIT {
     void setUp() throws Exception {
         this.startOrigin();
         this.startProxy();
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.proxy.port());
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.proxy.port());
         this.cntn.execStdout("yum", "-y", "install", "curl");
     }
 

--- a/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -30,7 +30,7 @@ import com.artipie.RepoPerms;
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
-import com.jcabi.log.Logger;
+import com.artipie.test.TestContainer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -43,8 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.GenericContainer;
 
 /**
  * Integration test for files proxy.
@@ -77,19 +75,15 @@ final class FileProxyAuthIT {
     /**
      * Container for local server.
      */
-    private GenericContainer<?> cntn;
+    private TestContainer cntn;
 
     @BeforeEach
     void setUp() throws Exception {
         this.startOrigin();
         this.startProxy();
-        this.cntn = new GenericContainer<>("centos:centos8")
-            .withCommand("tail", "-f", "/dev/null")
-            .withWorkingDirectory("/home/")
-            .withFileSystemBind(this.tmp.toString(), "/home");
-        Testcontainers.exposeHostPorts(this.proxy.port());
+        this.cntn = new TestContainer("centos:centos8", this.tmp, this.proxy.port());
         this.cntn.start();
-        this.cntn.execInContainer("yum", "-y", "install", "curl");
+        this.cntn.execStdout("yum", "-y", "install", "curl");
     }
 
     @AfterEach
@@ -102,7 +96,7 @@ final class FileProxyAuthIT {
     @Test
     void shouldGetFile() throws Exception {
         MatcherAssert.assertThat(
-            this.exec(
+            this.cntn.execStdout(
                 "curl", "-i", "-X",
                 "GET",
                 String.format(
@@ -112,11 +106,6 @@ final class FileProxyAuthIT {
             ),
             new StringContains("HTTP/1.1 200 OK")
         );
-    }
-
-    private String exec(final String... command) throws Exception {
-        Logger.debug(this, "Command:\n%s", String.join(" ", command));
-        return this.cntn.execInContainer(command).getStdout();
     }
 
     private void startOrigin() throws IOException {

--- a/src/test/java/com/artipie/file/FilesRepoITCase.java
+++ b/src/test/java/com/artipie/file/FilesRepoITCase.java
@@ -178,8 +178,8 @@ final class FilesRepoITCase {
         this.server = new ArtipieServer(this.tmp, "my-file", config);
         this.port = this.server.start();
         this.server.start();
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.port);
         this.cntn.execStdout("yum", "-y", "install", "curl");
     }
 

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -99,8 +99,8 @@ final class MavenITCase {
         final Path setting = this.tmp.resolve("settings.xml");
         setting.toFile().createNewFile();
         Files.write(setting, this.settings());
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.port);
         this.cntn.execStdout("yum", "-y", "install", "maven");
     }
 

--- a/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
@@ -90,8 +90,8 @@ final class MavenMultiProxyIT {
         final Path setting = this.tmp.resolve("settings.xml");
         setting.toFile().createNewFile();
         Files.write(setting, this.settings());
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.proxy.port());
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.proxy.port());
         this.cntn.execStdout("yum", "-y", "install", "maven");
     }
 

--- a/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
@@ -86,8 +86,8 @@ final class MavenProxyAuthIT {
         final Path setting = this.tmp.resolve("settings.xml");
         setting.toFile().createNewFile();
         Files.write(setting, this.settings());
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.proxy.port());
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.proxy.port());
         this.cntn.execStdout("yum", "-y", "install", "maven");
     }
 

--- a/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
@@ -30,7 +30,7 @@ import com.artipie.RepoPerms;
 import com.artipie.asto.Key;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
-import com.jcabi.log.Logger;
+import com.artipie.test.TestContainer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.GenericContainer;
 
 /**
  * Integration test for {@link com.artipie.maven.http.MavenProxySlice}.
@@ -79,7 +77,7 @@ final class MavenProxyAuthIT {
     /**
      * Container for local server.
      */
-    private GenericContainer<?> cntn;
+    private TestContainer cntn;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -88,13 +86,9 @@ final class MavenProxyAuthIT {
         final Path setting = this.tmp.resolve("settings.xml");
         setting.toFile().createNewFile();
         Files.write(setting, this.settings());
-        this.cntn = new GenericContainer<>("centos:centos8")
-            .withCommand("tail", "-f", "/dev/null")
-            .withWorkingDirectory("/home/")
-            .withFileSystemBind(this.tmp.toString(), "/home");
-        Testcontainers.exposeHostPorts(this.proxy.port());
+        this.cntn = new TestContainer("centos:centos8", this.tmp, this.proxy.port());
         this.cntn.start();
-        this.exec("yum", "-y", "install", "maven");
+        this.cntn.execStdout("yum", "-y", "install", "maven");
     }
 
     @AfterEach
@@ -107,18 +101,13 @@ final class MavenProxyAuthIT {
     @Test
     void shouldGetDependency() throws Exception {
         MatcherAssert.assertThat(
-            this.exec(
+            this.cntn.execStdout(
                 "mvn",
                 "-s", "/home/settings.xml",
                 "dependency:get", "-Dartifact=com.artipie:helloworld:0.1:jar"
-            ).replaceAll("\n", ""),
+            ),
             new StringContains("BUILD SUCCESS")
         );
-    }
-
-    private String exec(final String... command) throws Exception {
-        Logger.debug(this, "Command:\n%s", String.join(" ", command));
-        return this.cntn.execInContainer(command).getStdout();
     }
 
     private void startOrigin() throws IOException {

--- a/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -109,8 +109,8 @@ final class MavenProxyIT {
         final Path setting = this.tmp.resolve("settings.xml");
         setting.toFile().createNewFile();
         Files.write(setting, this.settings());
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.port);
         this.cntn.execStdout("yum", "-y", "install", "maven");
     }
 

--- a/src/test/java/com/artipie/npm/NpmITCase.java
+++ b/src/test/java/com/artipie/npm/NpmITCase.java
@@ -206,8 +206,8 @@ final class NpmITCase {
             this.tmp, "my-npm", this.config(anonymous).toString(), this.port
         );
         this.server.start();
-        this.cntn = new TestContainer("node:14-alpine", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("node:14-alpine", this.tmp);
+        this.cntn.start(this.port);
     }
 
     private void saveFilesToStrg(final String proj) {

--- a/src/test/java/com/artipie/nuget/NugetITCase.java
+++ b/src/test/java/com/artipie/nuget/NugetITCase.java
@@ -93,8 +93,8 @@ final class NugetITCase {
         this.server.start();
         Testcontainers.exposeHostPorts(this.port);
         this.createNugetConfig();
-        this.cntn = new TestContainer("mcr.microsoft.com/dotnet/sdk:5.0", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("mcr.microsoft.com/dotnet/sdk:5.0", this.tmp);
+        this.cntn.start(this.port);
     }
 
     @AfterEach

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -198,8 +198,8 @@ final class PypiITCase {
         );
         this.port = this.server.start();
         this.url = String.format("http://%s:%d/my-pypi/", PypiITCase.HOST, this.port);
-        this.cntn = new TestContainer("python:3", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("python:3", this.tmp);
+        this.cntn.start(this.port);
     }
 
     private String pswd(final boolean anonymous) {

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -30,15 +30,13 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
-import com.jcabi.log.Logger;
+import com.artipie.test.TestContainer;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
@@ -48,8 +46,6 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.GenericContainer;
 
 /**
  * Integration tests for Pypi repository.
@@ -80,7 +76,7 @@ final class PypiITCase {
     /**
      * Container.
      */
-    private GenericContainer<?> cntn;
+    private TestContainer cntn;
 
     /**
      * Storage.
@@ -107,11 +103,11 @@ final class PypiITCase {
                 new Key.From("repos", "my-pypi", "alarmtime", "alarmtime-0.1.5.tar.gz")
         );
         MatcherAssert.assertThat(
-            this.exec(
+            this.cntn.execStdout(
                 "pip", "install", "--no-deps", "--trusted-host", PypiITCase.HOST,
                 "--index-url", this.urlCntn(this.userOpt(anonymous)), "alarmtime==0.1.5"
             ),
-            Matchers.containsString("Successfully installed alarmtime-0.1.5")
+            new StringContains("Successfully installed alarmtime-0.1.5")
         );
     }
 
@@ -124,10 +120,10 @@ final class PypiITCase {
                 this.storage,
                 new Key.From("pypi-repo", "example-pckg")
         );
-        this.exec("python3", "-m", "pip", "install", "--user", "--upgrade", "twine");
+        this.cntn.execStdout("python3", "-m", "pip", "install", "--user", "--upgrade", "twine");
         MatcherAssert.assertThat(
             "Packages should be uploaded",
-            this.exec(
+            this.cntn.execStdout(
                 "python3", "-m", "twine", "upload", "--repository-url", this.url,
                 "-u", ArtipieServer.ALICE.name(), "-p", this.pswd(anonymous),
                 "pypi-repo/example-pckg/*"
@@ -151,7 +147,7 @@ final class PypiITCase {
     void pypiInstallShouldFailWithForbidden() throws Exception {
         this.init(false);
         MatcherAssert.assertThat(
-            this.exec(
+            this.cntn.execStdout(
                 "pip", "install", "--verbose", "--no-deps", "--trusted-host", PypiITCase.HOST,
                 "--index-url", this.urlCntn(Optional.of(ArtipieServer.BOB)), "anypackage"
             ),
@@ -171,22 +167,15 @@ final class PypiITCase {
                 this.storage,
                 new Key.From("pypi-repo", "example-pckg")
         );
-        this.exec("python3", "-m", "pip", "install", "--user", "--upgrade", "twine");
+        this.cntn.execStdout("python3", "-m", "pip", "install", "--user", "--upgrade", "twine");
         MatcherAssert.assertThat(
             "Packages should not be uploaded",
-            this.exec(
+            this.cntn.execStdErr(
                 "python3", "-m", "twine", "upload", "--verbose", "--repository-url", this.url,
                 "-u", ArtipieServer.BOB.name(), "-p", ArtipieServer.BOB.password(),
                 "pypi-repo/example-pckg/*"
             ),
-            new IsNot<>(
-                new StringContainsInOrder(
-                    new ListOf<String>(
-                        "Uploading artipietestpkg-0.0.3-py2-none-any.whl", "100%",
-                        "Uploading artipietestpkg-0.0.3.tar.gz", "100%"
-                    )
-                )
-            )
+            new StringContains("HTTPError: 403 Forbidden")
         );
         MatcherAssert.assertThat(
             "Packages should not be saved in storage",
@@ -199,7 +188,7 @@ final class PypiITCase {
     @AfterEach
     void tearDown() {
         this.server.stop();
-        this.cntn.stop();
+        this.cntn.close();
     }
 
     private void init(final boolean anonymous) throws IOException {
@@ -209,17 +198,8 @@ final class PypiITCase {
         );
         this.port = this.server.start();
         this.url = String.format("http://%s:%d/my-pypi/", PypiITCase.HOST, this.port);
-        Testcontainers.exposeHostPorts(this.port);
-        this.cntn = new GenericContainer<>("python:3")
-            .withCommand("tail", "-f", "/dev/null")
-            .withWorkingDirectory("/home/")
-            .withFileSystemBind(this.tmp.toString(), "/home");
+        this.cntn = new TestContainer("python:3", this.tmp, this.port);
         this.cntn.start();
-    }
-
-    private String exec(final String... command) throws Exception {
-        Logger.debug(this, "Command:\n%s", String.join(" ", command));
-        return this.cntn.execInContainer(command).getStdout();
     }
 
     private String pswd(final boolean anonymous) {

--- a/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -120,8 +120,8 @@ public final class PypiProxyITCase {
             this.tmp, "my-pypi-proxy", this.proxyConfig(anonymous, this.origin.start())
         );
         this.port = this.proxy.start();
-        this.cntn = new TestContainer("python:3", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("python:3", this.tmp);
+        this.cntn.start(this.port);
     }
 
     private RepoConfigYaml originConfig(final boolean anonymous) {

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -205,8 +205,8 @@ public final class RpmITCase {
                 "gpgcheck=0"
             )
         );
-        this.cntn = new TestContainer("centos:centos8", this.tmp, this.port);
-        this.cntn.start();
+        this.cntn = new TestContainer("centos:centos8", this.tmp);
+        this.cntn.start(this.port);
         this.cntn.execStdout("mv", "/home/example.repo", "/etc/yum.repos.d/");
     }
 

--- a/src/test/java/com/artipie/test/TestContainer.java
+++ b/src/test/java/com/artipie/test/TestContainer.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.test;
+
+import com.jcabi.log.Logger;
+import java.nio.file.Path;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Class for creating test container and for executing queries in it.
+ * @since 0.12
+ */
+public final class TestContainer implements AutoCloseable {
+
+    /**
+     * Container.
+     */
+    private final GenericContainer<?> cntn;
+
+    /**
+     * Ctor.
+     * @param image Docker image
+     * @param path Path for binding file system
+     * @param port Port for exposing
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public TestContainer(final String image, final Path path, final int port) {
+        this.cntn = new GenericContainer<>(image)
+            .withCommand("tail", "-f", "/dev/null")
+            .withWorkingDirectory("/home/")
+            .withFileSystemBind(path.toString(), "/home");
+        Testcontainers.exposeHostPorts(port);
+    }
+
+    /**
+     * Start container.
+     */
+    public void start() {
+        this.cntn.start();
+    }
+
+    /**
+     * Stderr result of the command execution.
+     * @param command Command for execution in container
+     * @return Stderr result of the execution.
+     * @throws Exception In case of exception during execution command in container.
+     */
+    public String execStdErr(final String... command) throws Exception {
+        return this.exec(command).getStderr().replace("\n", "");
+    }
+
+    /**
+     * Stdout result of the command execution.
+     * @param command Command for execution in container
+     * @return Stdout result of the execution.
+     * @throws Exception In case of exception during execution command in container.
+     */
+    public String execStdout(final String... command) throws Exception {
+        return this.exec(command).getStdout().replace("\n", "");
+    }
+
+    @Override
+    public void close() {
+        this.cntn.stop();
+    }
+
+    /**
+     * Result of the command execution.
+     * @param command Command for execution in container
+     * @return Result of the execution.
+     * @throws Exception In case of exception during execution command in container.
+     */
+    private Container.ExecResult exec(final String... command) throws Exception {
+        Logger.debug(this, "Command:\n%s", String.join(" ", command));
+        return this.cntn.execInContainer(command);
+    }
+}

--- a/src/test/java/com/artipie/test/TestContainer.java
+++ b/src/test/java/com/artipie/test/TestContainer.java
@@ -44,21 +44,20 @@ public final class TestContainer implements AutoCloseable {
      * Ctor.
      * @param image Docker image
      * @param path Path for binding file system
-     * @param port Port for exposing
      */
-    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public TestContainer(final String image, final Path path, final int port) {
+    public TestContainer(final String image, final Path path) {
         this.cntn = new GenericContainer<>(image)
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(path.toString(), "/home");
-        Testcontainers.exposeHostPorts(port);
     }
 
     /**
-     * Start container.
+     * Start container exposing specified port.
+     * @param port Port for exposing
      */
-    public void start() {
+    public void start(final int port) {
+        Testcontainers.exposeHostPorts(port);
         this.cntn.start();
     }
 

--- a/src/test/java/com/artipie/test/package-info.java
+++ b/src/test/java/com/artipie/test/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Auxiliary classes for tests.
+ *
+ * @since 0.12
+ */
+package com.artipie.test;


### PR DESCRIPTION
Part of #722
Extract to a separate class creating a test container. Also use path `tmp` instead of `subir` in `MavenITCase`.