### PR TITLE
#722 - Add UrlHelper for url with user credentials

### DIFF
--- a/src/test/java/com/artipie/npm/NpmITCase.java
+++ b/src/test/java/com/artipie/npm/NpmITCase.java
@@ -87,7 +87,7 @@ final class NpmITCase {
     private Storage storage;
 
     /**
-     * Helper for url that may contains user credentials.
+     * Repository url.
      */
     private RepositoryUrl url;
 

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -30,8 +30,8 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.test.RepositoryUrl;
 import com.artipie.test.TestContainer;
-import com.artipie.test.UrlCredsHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.list.ListOf;
@@ -86,7 +86,7 @@ final class PypiITCase {
     /**
      * Helper for url that may contains user credentials.
      */
-    private UrlCredsHelper urlraw;
+    private RepositoryUrl url;
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
@@ -100,7 +100,7 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--no-deps", "--trusted-host", PypiITCase.HOST,
-                "--index-url", this.urlraw.url(anonymous),
+                "--index-url", this.url.string(anonymous),
                 "alarmtime==0.1.5"
             ),
             new StringContains("Successfully installed alarmtime-0.1.5")
@@ -120,7 +120,7 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             "Packages should be uploaded",
             this.cntn.execStdout(
-                "python3", "-m", "twine", "upload", "--repository-url", this.urlraw.url(),
+                "python3", "-m", "twine", "upload", "--repository-url", this.url.string(),
                 "-u", ArtipieServer.ALICE.name(), "-p", this.pswd(anonymous),
                 "pypi-repo/example-pckg/*"
             ),
@@ -145,11 +145,11 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--verbose", "--no-deps", "--trusted-host", PypiITCase.HOST,
-                "--index-url", this.urlraw.url(ArtipieServer.BOB), "anypackage"
+                "--index-url", this.url.string(ArtipieServer.BOB), "anypackage"
             ),
             new StringContains(
                 String.format(
-                    "403 Client Error: Forbidden for url: %spip/", this.urlraw.url()
+                    "403 Client Error: Forbidden for url: %spip/", this.url.string()
                 )
             )
         );
@@ -168,7 +168,7 @@ final class PypiITCase {
             "Packages should not be uploaded",
             this.cntn.execStdErr(
                 "python3", "-m", "twine", "upload", "--verbose",
-                "--repository-url", this.urlraw.url(),
+                "--repository-url", this.url.string(),
                 "-u", ArtipieServer.BOB.name(), "-p", ArtipieServer.BOB.password(),
                 "pypi-repo/example-pckg/*"
             ),
@@ -194,7 +194,7 @@ final class PypiITCase {
             this.tmp, "my-pypi", this.config(anonymous)
         );
         final int port = this.server.start();
-        this.urlraw = new UrlCredsHelper(port, "my-pypi");
+        this.url = new RepositoryUrl(port, "my-pypi");
         this.cntn = new TestContainer("python:3", this.tmp);
         this.cntn.start(port);
     }

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -31,9 +31,9 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.test.TestContainer;
+import com.artipie.test.UrlCredsHelper;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Optional;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.12
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})
 final class PypiITCase {
 
@@ -84,14 +84,9 @@ final class PypiITCase {
     private Storage storage;
 
     /**
-     * URL 'http://host:port/my-pypi/'.
+     * Helper for url that may contains user credentials.
      */
-    private String url;
-
-    /**
-     * Artipie server port.
-     */
-    private int port;
+    private UrlCredsHelper urlraw;
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
@@ -105,7 +100,8 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--no-deps", "--trusted-host", PypiITCase.HOST,
-                "--index-url", this.urlCntn(this.userOpt(anonymous)), "alarmtime==0.1.5"
+                "--index-url", this.urlraw.url(anonymous),
+                "alarmtime==0.1.5"
             ),
             new StringContains("Successfully installed alarmtime-0.1.5")
         );
@@ -124,7 +120,7 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             "Packages should be uploaded",
             this.cntn.execStdout(
-                "python3", "-m", "twine", "upload", "--repository-url", this.url,
+                "python3", "-m", "twine", "upload", "--repository-url", this.urlraw.url(),
                 "-u", ArtipieServer.ALICE.name(), "-p", this.pswd(anonymous),
                 "pypi-repo/example-pckg/*"
             ),
@@ -149,11 +145,11 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--verbose", "--no-deps", "--trusted-host", PypiITCase.HOST,
-                "--index-url", this.urlCntn(Optional.of(ArtipieServer.BOB)), "anypackage"
+                "--index-url", this.urlraw.url(ArtipieServer.BOB), "anypackage"
             ),
             new StringContains(
                 String.format(
-                    "403 Client Error: Forbidden for url: %spip/", this.url
+                    "403 Client Error: Forbidden for url: %spip/", this.urlraw.url()
                 )
             )
         );
@@ -171,7 +167,8 @@ final class PypiITCase {
         MatcherAssert.assertThat(
             "Packages should not be uploaded",
             this.cntn.execStdErr(
-                "python3", "-m", "twine", "upload", "--verbose", "--repository-url", this.url,
+                "python3", "-m", "twine", "upload", "--verbose",
+                "--repository-url", this.urlraw.url(),
                 "-u", ArtipieServer.BOB.name(), "-p", ArtipieServer.BOB.password(),
                 "pypi-repo/example-pckg/*"
             ),
@@ -196,10 +193,10 @@ final class PypiITCase {
         this.server = new ArtipieServer(
             this.tmp, "my-pypi", this.config(anonymous)
         );
-        this.port = this.server.start();
-        this.url = String.format("http://%s:%d/my-pypi/", PypiITCase.HOST, this.port);
+        final int port = this.server.start();
+        this.urlraw = new UrlCredsHelper(port, "my-pypi");
         this.cntn = new TestContainer("python:3", this.tmp);
-        this.cntn.start(this.port);
+        this.cntn.start(port);
     }
 
     private String pswd(final boolean anonymous) {
@@ -208,19 +205,6 @@ final class PypiITCase {
             pass = ArtipieServer.ALICE.password();
         }
         return pass;
-    }
-
-    private String urlCntn(final Optional<ArtipieServer.User> user) {
-        final String urlcntn;
-        if (user.isEmpty()) {
-            urlcntn = this.url;
-        } else {
-            urlcntn = String.format(
-                "http://%s:%s@%s:%d/my-pypi/",
-                user.get().name(), user.get().password(), PypiITCase.HOST, this.port
-            );
-        }
-        return urlcntn;
     }
 
     private RepoConfigYaml config(final boolean anonymous) {
@@ -240,13 +224,4 @@ final class PypiITCase {
         ).join();
     }
 
-    private Optional<ArtipieServer.User> userOpt(final boolean anonymous) {
-        final Optional<ArtipieServer.User> user;
-        if (anonymous) {
-            user = Optional.empty();
-        } else {
-            user = Optional.of(ArtipieServer.ALICE);
-        }
-        return user;
-    }
 }

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -84,7 +84,7 @@ final class PypiITCase {
     private Storage storage;
 
     /**
-     * Helper for url that may contains user credentials.
+     * Repository url.
      */
     private RepositoryUrl url;
 

--- a/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -30,8 +30,8 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.test.RepositoryUrl;
 import com.artipie.test.TestContainer;
-import com.artipie.test.UrlCredsHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
@@ -100,7 +100,8 @@ public final class PypiProxyITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--no-deps", "--trusted-host", PypiProxyITCase.HOST,
-                "--index-url", new UrlCredsHelper(this.port, "my-pypi").url(anonymous), "alarmtime"
+                "--index-url", new RepositoryUrl(this.port, "my-pypi").string(anonymous),
+                "alarmtime"
             ),
             Matchers.containsString("Successfully installed alarmtime-0.1.5")
         );

--- a/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Test to pypi proxy.
  * @since 0.12
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -31,6 +31,7 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.test.TestContainer;
+import com.artipie.test.UrlCredsHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
@@ -98,7 +99,7 @@ public final class PypiProxyITCase {
         MatcherAssert.assertThat(
             this.cntn.execStdout(
                 "pip", "install", "--no-deps", "--trusted-host", PypiProxyITCase.HOST,
-                "--index-url", this.url(anonymous), "alarmtime"
+                "--index-url", new UrlCredsHelper(this.port, "my-pypi").url(anonymous), "alarmtime"
             ),
             Matchers.containsString("Successfully installed alarmtime-0.1.5")
         );
@@ -151,17 +152,4 @@ public final class PypiProxyITCase {
         return yaml;
     }
 
-    private String url(final boolean anonymous) {
-        final String urlcntn;
-        if (anonymous) {
-            urlcntn = String.format("http://%s:%d/my-pypi/", PypiProxyITCase.HOST, this.port);
-        } else {
-            urlcntn = String.format(
-                "http://%s:%s@%s:%d/my-pypi/",
-                ArtipieServer.ALICE.name(), ArtipieServer.ALICE.password(),
-                PypiProxyITCase.HOST, this.port
-            );
-        }
-        return urlcntn;
-    }
 }

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -33,6 +33,7 @@ import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.test.TestContainer;
+import com.artipie.test.UrlCredsHelper;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -198,8 +199,7 @@ public final class RpmITCase {
                 "[example]",
                 "name=Example Repository",
                 String.format(
-                    "baseurl=http://%shost.testcontainers.internal:%d/%s", this.auth(anonymous),
-                    this.port, RpmITCase.REPO
+                    "baseurl=%s", new UrlCredsHelper(this.port, RpmITCase.REPO).url(anonymous)
                 ),
                 "enabled=1",
                 "gpgcheck=0"
@@ -218,16 +218,6 @@ public final class RpmITCase {
             storage,
             new RepoConfig.Simple(Digest.SHA256, new NamingPolicy.HashPrefixed(Digest.SHA1), true)
         ).batchUpdate(new Key.From(RpmITCase.REPO)).blockingAwait();
-    }
-
-    private String auth(final boolean anonymous) {
-        String res = "";
-        if (!anonymous) {
-            res = String.format(
-                "%s:%s@", ArtipieServer.ALICE.name(), ArtipieServer.ALICE.password()
-            );
-        }
-        return res;
     }
 
 }

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -32,8 +32,8 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.test.RepositoryUrl;
 import com.artipie.test.TestContainer;
-import com.artipie.test.UrlCredsHelper;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -199,7 +199,7 @@ public final class RpmITCase {
                 "[example]",
                 "name=Example Repository",
                 String.format(
-                    "baseurl=%s", new UrlCredsHelper(this.port, RpmITCase.REPO).url(anonymous)
+                    "baseurl=%s", new RepositoryUrl(this.port, RpmITCase.REPO).string(anonymous)
                 ),
                 "enabled=1",
                 "gpgcheck=0"

--- a/src/test/java/com/artipie/test/RepositoryUrl.java
+++ b/src/test/java/com/artipie/test/RepositoryUrl.java
@@ -27,7 +27,7 @@ import com.artipie.ArtipieServer;
 
 /**
  * Class to simplify working with url that may contains user credentials.
- * @since 0.12
+ * @since 0.13
  */
 public final class RepositoryUrl {
 

--- a/src/test/java/com/artipie/test/RepositoryUrl.java
+++ b/src/test/java/com/artipie/test/RepositoryUrl.java
@@ -29,7 +29,7 @@ import com.artipie.ArtipieServer;
  * Class to simplify working with url that may contains user credentials.
  * @since 0.12
  */
-public final class UrlCredsHelper {
+public final class RepositoryUrl {
 
     /**
      * Host, port, repo.
@@ -41,7 +41,7 @@ public final class UrlCredsHelper {
      * @param port Port
      * @param reponame Reponame for url path
      */
-    public UrlCredsHelper(final int port, final String reponame) {
+    public RepositoryUrl(final int port, final String reponame) {
         this.hostportrepo = String.format("host.testcontainers.internal:%d/%s/", port, reponame);
     }
 
@@ -49,7 +49,7 @@ public final class UrlCredsHelper {
      * Simple url.
      * @return Simple url.
      */
-    public String url() {
+    public String string() {
         return String.format("http://%s", this.hostportrepo);
     }
 
@@ -58,13 +58,13 @@ public final class UrlCredsHelper {
      * @param anonymous Add credentials tor url or not
      * @return Url with credentials for default user.
      */
-    public String url(final boolean anonymous) {
+    public String string(final boolean anonymous) {
         final ArtipieServer.User user = ArtipieServer.ALICE;
         final String res;
         if (anonymous) {
-            res = this.url();
+            res = this.string();
         } else {
-            res = this.url(user);
+            res = this.string(user);
         }
         return res;
     }
@@ -74,12 +74,9 @@ public final class UrlCredsHelper {
      * @param user User with name and password
      * @return Url with credentials for specified user.
      */
-    public String url(final ArtipieServer.User user) {
-        final String creds = String.format(
-            "%s:%s@", user.name(), user.password()
-        );
+    public String string(final ArtipieServer.User user) {
         return String.format(
-            "http://%s%s", creds, this.hostportrepo
+            "http://%s:%s@%s",  user.name(), user.password(), this.hostportrepo
         );
     }
 }

--- a/src/test/java/com/artipie/test/UrlCredsHelper.java
+++ b/src/test/java/com/artipie/test/UrlCredsHelper.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.test;
+
+import com.artipie.ArtipieServer;
+
+/**
+ * Class to simplify working with url that may contains user credentials.
+ * @since 0.12
+ */
+public final class UrlCredsHelper {
+
+    /**
+     * Host, port, repo.
+     */
+    private final String hostportrepo;
+
+    /**
+     * Ctor.
+     * @param port Port
+     * @param reponame Reponame for url path
+     */
+    public UrlCredsHelper(final int port, final String reponame) {
+        this.hostportrepo = String.format("host.testcontainers.internal:%d/%s/", port, reponame);
+    }
+
+    /**
+     * Simple url.
+     * @return Simple url.
+     */
+    public String url() {
+        return String.format("http://%s", this.hostportrepo);
+    }
+
+    /**
+     * Url with or without user credentials.
+     * @param anonymous Add credentials tor url or not
+     * @return Url with credentials for default user.
+     */
+    public String url(final boolean anonymous) {
+        final ArtipieServer.User user = ArtipieServer.ALICE;
+        final String res;
+        if (anonymous) {
+            res = this.url();
+        } else {
+            res = this.url(user);
+        }
+        return res;
+    }
+
+    /**
+     * Url with credentials.
+     * @param user User with name and password
+     * @return Url with credentials for specified user.
+     */
+    public String url(final ArtipieServer.User user) {
+        final String creds = String.format(
+            "%s:%s@", user.name(), user.password()
+        );
+        return String.format(
+            "http://%s%s", creds, this.hostportrepo
+        );
+    }
+}


### PR DESCRIPTION
Closes #722 
Add `UrlCredsHelper` to simplify working with url that may contains user credentials.