### PR TITLE
#730 - RepoPermissions signature changed

### DIFF
--- a/src/main/java/com/artipie/RepoPermissions.java
+++ b/src/main/java/com/artipie/RepoPermissions.java
@@ -31,6 +31,7 @@ import com.amihaiemil.eoyaml.YamlSequenceBuilder;
 import com.artipie.api.ContentAs;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.asto.rx.RxStorageWrapper;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.nio.charset.StandardCharsets;
@@ -113,21 +114,21 @@ public interface RepoPermissions {
         private static final String REPO = "repo";
 
         /**
-         * Artipie settings.
+         * Artipie settings storage.
          */
-        private final Settings settings;
+        private final Storage storage;
 
         /**
          * Ctor.
-         * @param settings Artipie settings
+         * @param storage Artipie settings storage
          */
-        public FromSettings(final Settings settings) {
-            this.settings = settings;
+        public FromSettings(final Storage storage) {
+            this.storage = storage;
         }
 
         @Override
         public CompletionStage<List<String>> repositories() {
-            return this.settings.storage().list(Key.ROOT)
+            return this.storage.list(Key.ROOT)
                 .thenApply(
                     list -> list.stream()
                         .map(Key::string)
@@ -219,7 +220,7 @@ public interface RepoPermissions {
          * @return Completion action with yaml repo section
          */
         private CompletionStage<YamlMapping> repo(final Key key) {
-            return new RxStorageWrapper(this.settings.storage())
+            return new RxStorageWrapper(this.storage)
                 .value(key)
                 .to(ContentAs.YAML)
                 .map(yaml -> yaml.yamlMapping(FromSettings.REPO))
@@ -233,7 +234,7 @@ public interface RepoPermissions {
          * @return Completable operation
          */
         private CompletableFuture<Void> saveSettings(final Key key, final YamlMapping result) {
-            return this.settings.storage().save(
+            return this.storage.save(
                 key, new Content.From(result.toString().getBytes(StandardCharsets.UTF_8))
             );
         }

--- a/src/main/java/com/artipie/api/ArtipieApi.java
+++ b/src/main/java/com/artipie/api/ArtipieApi.java
@@ -203,28 +203,28 @@ public final class ArtipieApi extends Slice.Wrap {
                                     new RtRule.ByPath(GetPermissionsSlice.PATH),
                                     new ByMethodsRule(RqMethod.GET)
                                 ),
-                                new GetPermissionsSlice(settings)
+                                new GetPermissionsSlice(settings.storage(), settings.meta())
                             ),
                             new RtRulePath(
                                 new RtRule.All(
                                     new RtRule.ByPath(FromRqLine.RqPattern.REPO.pattern()),
                                     new ByMethodsRule(RqMethod.PUT)
                                 ),
-                                new AddUpdatePermissionSlice(settings)
+                                new AddUpdatePermissionSlice(settings.storage())
                             ),
                             new RtRulePath(
                                 new RtRule.All(
                                     new RtRule.ByPath(FromRqLine.RqPattern.REPO.pattern()),
                                     new ByMethodsRule(RqMethod.DELETE)
                                 ),
-                                new DeletePermissionSlice(settings)
+                                new DeletePermissionSlice(settings.storage())
                             ),
                             new RtRulePath(
                                 new RtRule.All(
                                     new RtRule.ByPath(FromRqLine.RqPattern.REPO.pattern()),
                                     new ByMethodsRule(RqMethod.GET)
                                 ),
-                                new GetPermissionSlice(settings)
+                                new GetPermissionSlice(settings.storage())
                             ),
                             new RtRulePath(
                                 new RtRule.All(

--- a/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
@@ -24,7 +24,7 @@
 package com.artipie.api.artifactory;
 
 import com.artipie.RepoPermissions;
-import com.artipie.Settings;
+import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -77,16 +77,16 @@ public final class AddUpdatePermissionSlice implements Slice {
         );
 
     /**
-     * Artipie settings.
+     * Artipie settings storage.
      */
-    private final Settings settings;
+    private final Storage storage;
 
     /**
      * Ctor.
-     * @param settings Setting
+     * @param storage Setting
      */
-    public AddUpdatePermissionSlice(final Settings settings) {
-        this.settings = settings;
+    public AddUpdatePermissionSlice(final Storage storage) {
+        this.storage = storage;
     }
 
     @Override
@@ -149,7 +149,7 @@ public final class AddUpdatePermissionSlice implements Slice {
             .collect(Collectors.toList());
         final CompletionStage<Boolean> result;
         if (patterns.stream().allMatch(ptrn -> ptrn.valid(name))) {
-            result = new RepoPermissions.FromSettings(this.settings)
+            result = new RepoPermissions.FromSettings(this.storage)
                 .update(name, res, patterns)
                 .thenApply(nothing -> true);
         } else {

--- a/src/main/java/com/artipie/api/artifactory/DeletePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/DeletePermissionSlice.java
@@ -24,8 +24,8 @@
 package com.artipie.api.artifactory;
 
 import com.artipie.RepoPermissions;
-import com.artipie.Settings;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -49,16 +49,16 @@ import org.reactivestreams.Publisher;
 public final class DeletePermissionSlice implements Slice {
 
     /**
-     * Artipie settings.
+     * Artipie settings storage.
      */
-    private final Settings settings;
+    private final Storage storage;
 
     /**
      * Ctor.
-     * @param settings Setting
+     * @param storage Setting
      */
-    public DeletePermissionSlice(final Settings settings) {
-        this.settings = settings;
+    public DeletePermissionSlice(final Storage storage) {
+        this.storage = storage;
     }
 
     @Override
@@ -67,13 +67,13 @@ public final class DeletePermissionSlice implements Slice {
         final Optional<String> opt = new FromRqLine(line, FromRqLine.RqPattern.REPO).get();
         return opt.<Response>map(
             repo -> new AsyncResponse(
-                this.settings.storage()
+                this.storage
                     .exists(new Key.From(String.format("%s.yaml", repo)))
                     .thenCompose(
                         exists -> {
                             final CompletionStage<Response> res;
                             if (exists) {
-                                res = new RepoPermissions.FromSettings(this.settings).remove(repo)
+                                res = new RepoPermissions.FromSettings(this.storage).remove(repo)
                                     .thenApply(
                                         ignored -> new RsWithBody(
                                             // @checkstyle LineLengthCheck (2 lines)

--- a/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetPermissionSlice.java
@@ -24,9 +24,9 @@
 package com.artipie.api.artifactory;
 
 import com.artipie.RepoPermissions;
-import com.artipie.Settings;
 import com.artipie.api.RsJson;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -58,14 +58,14 @@ public final class GetPermissionSlice implements Slice {
     /**
      * Artipie settings.
      */
-    private final Settings settings;
+    private final Storage storage;
 
     /**
      * Ctor.
-     * @param settings Artipie settings
+     * @param storage Artipie settings
      */
-    public GetPermissionSlice(final Settings settings) {
-        this.settings = settings;
+    public GetPermissionSlice(final Storage storage) {
+        this.storage = storage;
     }
 
     @Override
@@ -74,13 +74,13 @@ public final class GetPermissionSlice implements Slice {
         final Optional<String> opt = new FromRqLine(line, FromRqLine.RqPattern.REPO).get();
         return opt.<Response>map(
             repo -> new AsyncResponse(
-                this.settings.storage()
+                this.storage
                     .exists(new Key.From(String.format("%s.yaml", repo))).thenCompose(
                         exists -> {
                             final CompletionStage<Response> res;
                             if (exists) {
                                 final RepoPermissions source = new RepoPermissions.FromSettings(
-                                    this.settings
+                                    this.storage
                                 );
                                 res = source.permissions(repo).thenCombine(
                                     source.patterns(repo),

--- a/src/main/java/com/artipie/api/artifactory/GetPermissionsSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/GetPermissionsSlice.java
@@ -23,8 +23,9 @@
  */
 package com.artipie.api.artifactory;
 
+import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.RepoPermissions;
-import com.artipie.Settings;
+import com.artipie.asto.Storage;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -49,24 +50,31 @@ public final class GetPermissionsSlice implements Slice {
     public static final String PATH = "/api/security/permissions";
 
     /**
-     * Artipie settings.
+     * Artipie settings storage.
      */
-    private final Settings settings;
+    private final Storage storage;
+
+    /**
+     * Artipie meta config.
+     */
+    private final YamlMapping meta;
 
     /**
      * Ctor.
-     * @param settings Setting
+     * @param storage Setting
+     * @param meta Artipie meta config
      */
-    public GetPermissionsSlice(final Settings settings) {
-        this.settings = settings;
+    public GetPermissionsSlice(final Storage storage, final YamlMapping meta) {
+        this.storage = storage;
+        this.meta = meta;
     }
 
     @Override
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
-        final String base = this.settings.meta().string("base_url").replaceAll("/$", "");
+        final String base = this.meta.string("base_url").replaceAll("/$", "");
         return new AsyncResponse(
-            new RepoPermissions.FromSettings(this.settings).repositories().<Response>thenApply(
+            new RepoPermissions.FromSettings(this.storage).repositories().<Response>thenApply(
                 list -> {
                     final JsonArrayBuilder json = Json.createArrayBuilder();
                     list.forEach(

--- a/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
+++ b/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
@@ -68,7 +68,7 @@ class RepoPermissionsFromSettingsTest {
         this.storage.save(new Key.From("abc"), Content.EMPTY).join();
         this.storage.save(new Key.From("three.yaml"), Content.EMPTY).join();
         MatcherAssert.assertThat(
-            new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).repositories()
+            new RepoPermissions.FromSettings(this.storage).repositories()
                 .toCompletableFuture().join(),
             Matchers.containsInAnyOrder("one", "two", "three")
         );
@@ -84,7 +84,7 @@ class RepoPermissionsFromSettingsTest {
             new RepoPerms(john, new ListOf<String>(download, upload))
         ).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).permissions(repo)
+            new RepoPermissions.FromSettings(this.storage).permissions(repo)
                 .toCompletableFuture().join(),
             Matchers.contains(
                 new RepoPermissions.PermissionItem(john, new ListOf<String>(download, upload))
@@ -97,7 +97,7 @@ class RepoPermissionsFromSettingsTest {
         final String repo = "pypi";
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).permissions(repo)
+            new RepoPermissions.FromSettings(this.storage).permissions(repo)
                 .toCompletableFuture().join().size(),
             new IsEqual<>(0)
         );
@@ -110,7 +110,7 @@ class RepoPermissionsFromSettingsTest {
             new RepoPerms(Collections.emptyList(), new ListOf<>("**"))
         ).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).patterns(repo)
+            new RepoPermissions.FromSettings(this.storage).patterns(repo)
                 .toCompletableFuture().join()
                 .stream().map(RepoPermissions.PathPattern::string).collect(Collectors.toList()),
             Matchers.contains("**")
@@ -122,7 +122,7 @@ class RepoPermissionsFromSettingsTest {
         final String repo = "gem";
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).patterns(repo)
+            new RepoPermissions.FromSettings(this.storage).patterns(repo)
                 .toCompletableFuture().join()
                 .stream().map(RepoPermissions.PathPattern::string).collect(Collectors.toList()),
             new IsEmptyCollection<>()
@@ -146,7 +146,7 @@ class RepoPermissionsFromSettingsTest {
         final String victor = "victor";
         final String download = "download";
         final String deploy = "deploy";
-        new RepoPermissions.FromSettings(new Settings.Fake(this.storage))
+        new RepoPermissions.FromSettings(this.storage)
             .update(
                 repo,
                 new ListOf<>(
@@ -184,7 +184,7 @@ class RepoPermissionsFromSettingsTest {
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         final String ann = "ann";
         final String download = "download";
-        new RepoPermissions.FromSettings(new Settings.Fake(this.storage))
+        new RepoPermissions.FromSettings(this.storage)
             .update(
                 repo,
                 new ListOf<>(new RepoPermissions.PermissionItem(ann, new ListOf<>(download))),
@@ -209,7 +209,7 @@ class RepoPermissionsFromSettingsTest {
         new RepoConfigYaml(repo).withPermissions(
             new RepoPerms("someone", new ListOf<>("r", "w"))
         ).saveTo(this.storage, repo);
-        new RepoPermissions.FromSettings(new Settings.Fake(this.storage)).remove(repo)
+        new RepoPermissions.FromSettings(this.storage).remove(repo)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Permissions section are empty",

--- a/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/AddUpdatePermissionSliceTest.java
@@ -26,7 +26,6 @@ package com.artipie.api.artifactory;
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.RepoConfigYaml;
-import com.artipie.Settings;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -70,7 +69,7 @@ class AddUpdatePermissionSliceTest {
     @Test
     void returnsBadRequestOnInvalidRequest() {
         MatcherAssert.assertThat(
-            new AddUpdatePermissionSlice(new Settings.Fake()),
+            new AddUpdatePermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(RqMethod.PUT, "/some/api/permissions/maven")
@@ -84,7 +83,7 @@ class AddUpdatePermissionSliceTest {
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             "Returns 200 OK",
-            new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),
+            new AddUpdatePermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.OK),
                 new RequestLine(RqMethod.PUT, String.format("/api/security/permissions/%s", repo)),
@@ -129,7 +128,7 @@ class AddUpdatePermissionSliceTest {
         final String repo = "docker";
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),
+            new AddUpdatePermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(RqMethod.PUT, String.format("/api/security/permissions/%s", repo)),
@@ -156,7 +155,7 @@ class AddUpdatePermissionSliceTest {
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
             "Returns 200 OK",
-            new AddUpdatePermissionSlice(new Settings.Fake(this.storage)),
+            new AddUpdatePermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.OK),
                 new RequestLine(RqMethod.PUT, String.format("/api/security/permissions/%s", repo)),

--- a/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/DeletePermissionSliceTest.java
@@ -27,7 +27,6 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.RepoConfigYaml;
 import com.artipie.RepoPermissions;
 import com.artipie.RepoPerms;
-import com.artipie.Settings;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
@@ -56,7 +55,7 @@ class DeletePermissionSliceTest {
     @Test
     void returnsBadRequestOnInvalidRequest() {
         MatcherAssert.assertThat(
-            new DeletePermissionSlice(new Settings.Fake()),
+            new DeletePermissionSlice(new InMemoryStorage()),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(RqMethod.DELETE, "/some/api/permissions/pypi")
@@ -67,7 +66,7 @@ class DeletePermissionSliceTest {
     @Test
     void returnsNotFoundIfRepositoryDoesNotExists() {
         MatcherAssert.assertThat(
-            new DeletePermissionSlice(new Settings.Fake()),
+            new DeletePermissionSlice(new InMemoryStorage()),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.NOT_FOUND),
                 new RequestLine(RqMethod.DELETE, "/api/security/permissions/pypi")
@@ -91,7 +90,7 @@ class DeletePermissionSliceTest {
         ).saveTo(storage, repo);
         MatcherAssert.assertThat(
             "Returns 200 OK",
-            new DeletePermissionSlice(new Settings.Fake(storage)),
+            new DeletePermissionSlice(storage),
             new SliceHasResponse(
                 Matchers.allOf(
                     new RsHasStatus(RsStatus.OK),

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionSliceTest.java
@@ -26,7 +26,6 @@ package com.artipie.api.artifactory;
 import com.artipie.RepoConfigYaml;
 import com.artipie.RepoPermissions;
 import com.artipie.RepoPerms;
-import com.artipie.Settings;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.hm.RsHasBody;
@@ -67,7 +66,7 @@ class GetPermissionSliceTest {
     @Test
     void returnsBadRequestOnInvalidRequest() {
         MatcherAssert.assertThat(
-            new GetPermissionSlice(new Settings.Fake()),
+            new GetPermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.BAD_REQUEST),
                 new RequestLine(RqMethod.GET, "/some/api/permissions/maven")
@@ -78,7 +77,7 @@ class GetPermissionSliceTest {
     @Test
     void returnsNotFoundIfRepoDoesNotExists() {
         MatcherAssert.assertThat(
-            new GetPermissionSlice(new Settings.Fake(this.storage)),
+            new GetPermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.NOT_FOUND),
                 new RequestLine(RqMethod.GET, "/api/security/permissions/pypi")
@@ -91,7 +90,7 @@ class GetPermissionSliceTest {
         final String repo = "docker";
         new RepoConfigYaml(repo).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new GetPermissionSlice(new Settings.Fake(this.storage)),
+            new GetPermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasBody(
                     this.response(
@@ -127,7 +126,7 @@ class GetPermissionSliceTest {
             )
         ).saveTo(this.storage, repo);
         MatcherAssert.assertThat(
-            new GetPermissionSlice(new Settings.Fake(this.storage)),
+            new GetPermissionSlice(this.storage),
             new SliceHasResponse(
                 new RsHasBody(
                     this.response(

--- a/src/test/java/com/artipie/api/artifactory/GetPermissionsSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetPermissionsSliceTest.java
@@ -25,8 +25,6 @@ package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.Settings;
-import com.artipie.Users;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -68,7 +66,7 @@ final class GetPermissionsSliceTest {
         storage.save(new Key.From(this.nameYaml(cache)), Content.EMPTY).join();
         MatcherAssert.assertThat(
             new GetPermissionsSlice(
-                new Settings.Fake(storage, new Users.FromEnv(), GetPermissionsSliceTest.META)
+                storage, GetPermissionsSliceTest.META
             ),
             new SliceHasResponse(
                 new RsHasBody(


### PR DESCRIPTION
Part of #730 
Changed `RepoPermissions` implementation signature and corresponding API slices.