### PR TITLE
#730 - storage and repo API

### DIFF
--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -306,7 +306,7 @@ public final class SliceFromConfig extends Slice.Wrap {
         if (standalone) {
             result = origin;
         } else {
-            result = new TrimPathSlice(origin, new PathPattern(settings).pattern());
+            result = new TrimPathSlice(origin, new PathPattern(settings.layout()).pattern());
         }
         return result;
     }

--- a/src/main/java/com/artipie/api/ArtipieApi.java
+++ b/src/main/java/com/artipie/api/ArtipieApi.java
@@ -53,6 +53,7 @@ import com.artipie.http.rt.ByMethodsRule;
 import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
+import com.artipie.repo.PathPattern;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.nio.charset.StandardCharsets;
@@ -165,7 +166,7 @@ public final class ArtipieApi extends Slice.Wrap {
                                     new RtRule.ByPath(Pattern.compile("/api/repositories/.*")),
                                     new ByMethodsRule(RqMethod.PUT)
                                 ),
-                                new CreateRepoSlice(settings)
+                                new CreateRepoSlice(settings.storage())
                             ),
                             new RtRulePath(
                                 new RtRule.All(
@@ -231,7 +232,9 @@ public final class ArtipieApi extends Slice.Wrap {
                                     new RtRule.ByPath(GetStorageSlice.Request.PATH),
                                     new ByMethodsRule(RqMethod.GET)
                                 ),
-                                new GetStorageSlice(settings)
+                                new GetStorageSlice(
+                                    settings.storage(), new PathPattern(settings.layout()).pattern()
+                                )
                             )
                         )
                     )

--- a/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/AddUpdatePermissionSlice.java
@@ -83,7 +83,7 @@ public final class AddUpdatePermissionSlice implements Slice {
 
     /**
      * Ctor.
-     * @param storage Setting
+     * @param storage Artipie settings storage
      */
     public AddUpdatePermissionSlice(final Storage storage) {
         this.storage = storage;

--- a/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/CreateRepoSlice.java
@@ -25,10 +25,10 @@ package com.artipie.api.artifactory;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.artipie.Settings;
 import com.artipie.api.ContentAs;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
@@ -62,16 +62,16 @@ public final class CreateRepoSlice implements Slice {
         Pattern.compile("/api/repositories/(?<first>[^/.]+)(?<second>/[^/.]+)?/?");
 
     /**
-     * Artipie settings.
+     * Artipie settings storage.
      */
-    private final Settings settings;
+    private final Storage storage;
 
     /**
      * Ctor.
-     * @param settings Artipie settings
+     * @param storage Artipie settings storage
      */
-    public CreateRepoSlice(final Settings settings) {
-        this.settings = settings;
+    public CreateRepoSlice(final Storage storage) {
+        this.storage = storage;
     }
 
     @Override
@@ -87,7 +87,7 @@ public final class CreateRepoSlice implements Slice {
                     valid(json).map(
                         name -> {
                             final Key key = CreateRepoSlice.yamlKey(line, name);
-                            return this.settings.storage().exists(key)
+                            return this.storage.exists(key)
                                 .thenCompose(
                                     exists -> {
                                         final CompletionStage<Response> res;
@@ -96,7 +96,7 @@ public final class CreateRepoSlice implements Slice {
                                                 new RsWithStatus(RsStatus.BAD_REQUEST)
                                             );
                                         } else {
-                                            res = this.settings.storage().save(
+                                            res = this.storage.save(
                                                 key,
                                                 new Content.From(
                                                     CreateRepoSlice.yaml().toString()

--- a/src/main/java/com/artipie/api/artifactory/DeletePermissionSlice.java
+++ b/src/main/java/com/artipie/api/artifactory/DeletePermissionSlice.java
@@ -55,7 +55,7 @@ public final class DeletePermissionSlice implements Slice {
 
     /**
      * Ctor.
-     * @param storage Setting
+     * @param storage Artipie settings storage
      */
     public DeletePermissionSlice(final Storage storage) {
         this.storage = storage;

--- a/src/main/java/com/artipie/repo/PathPattern.java
+++ b/src/main/java/com/artipie/repo/PathPattern.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.repo;
 
-import com.artipie.Settings;
 import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -48,16 +47,16 @@ public final class PathPattern {
     );
 
     /**
-     * Artipie settings.
+     * Artipie layout.
      */
-    private final Settings settings;
+    private final String layout;
 
     /**
      * New layout pattern from settings.
-     * @param settings Settings
+     * @param layout Artipie layout
      */
-    public PathPattern(final Settings settings) {
-        this.settings = settings;
+    public PathPattern(final String layout) {
+        this.layout = layout;
     }
 
     /**
@@ -65,7 +64,7 @@ public final class PathPattern {
      * @return Regex pattern
      */
     public Pattern pattern() {
-        String name = this.settings.layout();
+        String name = this.layout;
         if (name == null) {
             name = "flat";
         }

--- a/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/CreateRepoSliceTest.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.api.artifactory;
 
-import com.artipie.Settings;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
@@ -52,7 +51,7 @@ class CreateRepoSliceTest {
         final Storage storage = new InMemoryStorage();
         MatcherAssert.assertThat(
             "Returns 200 OK",
-            new CreateRepoSlice(new Settings.Fake(storage)).response(
+            new CreateRepoSlice(storage).response(
                 new RequestLine("PUT", "/api/repositories/username/my_repo").toString(),
                 Collections.emptyList(),
                 this.jsonBody()
@@ -71,7 +70,7 @@ class CreateRepoSliceTest {
         final Storage storage = new InMemoryStorage();
         MatcherAssert.assertThat(
             "Returns 200 OK",
-            new CreateRepoSlice(new Settings.Fake(storage)).response(
+            new CreateRepoSlice(storage).response(
                 new RequestLine("PUT", "/api/repositories/my_repo").toString(),
                 Collections.emptyList(),
                 this.jsonBody()
@@ -90,7 +89,7 @@ class CreateRepoSliceTest {
         final Storage storage = new InMemoryStorage();
         storage.save(new Key.From("my_repo.yaml"), new Content.From(new byte[]{}));
         MatcherAssert.assertThat(
-            new CreateRepoSlice(new Settings.Fake(storage)).response(
+            new CreateRepoSlice(storage).response(
                 new RequestLine("PUT", "/api/repositories/my_repo").toString(),
                 Collections.emptyList(),
                 this.jsonBody()
@@ -102,7 +101,7 @@ class CreateRepoSliceTest {
     @Test
     void returnsBadRequestIfJsonIsNotValid() {
         MatcherAssert.assertThat(
-            new CreateRepoSlice(new Settings.Fake()).response(
+            new CreateRepoSlice(new InMemoryStorage()).response(
                 new RequestLine("PUT", "/api/repositories/my_repo").toString(),
                 Collections.emptyList(),
                 Flowable.fromArray(

--- a/src/test/java/com/artipie/api/artifactory/GetStorageSliceRequestTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetStorageSliceRequestTest.java
@@ -23,9 +23,9 @@
  */
 package com.artipie.api.artifactory;
 
-import com.artipie.Settings;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
+import com.artipie.repo.PathPattern;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +49,7 @@ class GetStorageSliceRequestTest {
         final String repo
     ) {
         final GetStorageSlice.Request request = new GetStorageSlice.Request(
-            new Settings.Fake(layout),
+            new PathPattern(layout).pattern(),
             new RequestLine(RqMethod.GET, path).toString()
         );
         MatcherAssert.assertThat(
@@ -69,7 +69,7 @@ class GetStorageSliceRequestTest {
         final String root
     ) {
         final GetStorageSlice.Request request = new GetStorageSlice.Request(
-            new Settings.Fake(layout),
+            new PathPattern(layout).pattern(),
             new RequestLine(RqMethod.GET, path).toString()
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
@@ -25,7 +25,6 @@ package com.artipie.api.artifactory;
 
 import com.artipie.IsJson;
 import com.artipie.RepoConfigYaml;
-import com.artipie.Settings;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.LoggingStorage;
@@ -39,6 +38,7 @@ import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.repo.PathPattern;
 import java.nio.file.Path;
 import java.util.Arrays;
 import javax.json.JsonValue;
@@ -76,7 +76,7 @@ class GetStorageSliceTest {
     void shouldReturnExpectedData(final String layout, final String repo) {
         final Storage storage = this.example(this.tmp, repo);
         MatcherAssert.assertThat(
-            new GetStorageSlice(new Settings.Fake(storage, layout)),
+            new GetStorageSlice(storage, new PathPattern(layout).pattern()),
             new SliceHasResponse(
                 new AllOf<>(
                     Arrays.asList(


### PR DESCRIPTION
Part of #730 
Changed `PathPattern` to accept `layout` instead of `settings` and made `CreateRepoSlice` and `GetStorageSlice` do not depend on `settings`.