### PR TITLE
#679 - NuGet upgraded to 0.4, tests enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>nuget-adapter</artifactId>
-      <version>0.3.3</version>
+      <version>0.4</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/test/java/com/artipie/nuget/NugetITCase.java
+++ b/src/test/java/com/artipie/nuget/NugetITCase.java
@@ -35,7 +35,6 @@ import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -48,14 +47,9 @@ import org.testcontainers.Testcontainers;
  * @since 0.12
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
- * @todo #602:60min Fix and enable NugetITCase.
- *  Tests in `NugetITCase` often hang or make tests after them hang.
- *  That might be caused by NuGet adapter being blocking or some other reason.
- *  Tests are disabled for a time to prevent whole CI pipeline to be blocked by these issues.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})
-@Disabled
 final class NugetITCase {
 
     /**


### PR DESCRIPTION
Closes #679 
NuGet upgraded to `0.4`, tests enabled