### PR TITLE
#768 - Support Basic auth for Gem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.16.8</version>
+      <version>0.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -256,7 +256,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>gem-adapter</artifactId>
-      <version>0.5.1</version>
+      <version>0.5.3</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/test/java/com/artipie/gem/GemITCase.java
+++ b/src/test/java/com/artipie/gem/GemITCase.java
@@ -50,10 +50,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Integration tests for Gem repository.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #768:30min Disable IT case for install with Basic authentication.
- *  It is necessary to add `false` in the `ValueSource` for method
- *  `GemITCase#gemInstallPushedGemWorks` when `Basic` authentication
- *  would be supported in the Gem repository.
  * @since 0.13
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -111,7 +107,7 @@ final class GemITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true})
+    @ValueSource(booleans = {true, false})
     void gemInstallPushedGemWorks(final boolean anonymous) throws Exception {
         this.init(anonymous);
         this.push(anonymous);


### PR DESCRIPTION
Part of #768 
Updated version of gem-adapter and http module. Enabled test for this feature.