### PR TITLE
#597 - Add negative tests to RepositoriesFromStorage

### DIFF
--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -33,9 +33,6 @@ import java.util.concurrent.CompletionStage;
  * Artipie repositories created from {@link Settings}.
  *
  * @since 0.13
- * @todo #597:30min Add unit tests for RepositoriesFromStorage class.
- *  `RepositoriesFromStorage` class was extracted from existing code and lacks test coverage.
- *  It's methods should be tested for all important execution paths.
  */
 public final class RepositoriesFromStorage implements Repositories {
 

--- a/src/main/java/com/artipie/StorageAliases.java
+++ b/src/main/java/com/artipie/StorageAliases.java
@@ -123,7 +123,9 @@ public interface StorageAliases {
          * @return Illegal state exception.
          */
         private static RuntimeException illegalState() {
-            throw new IllegalStateException("yaml file with aliases is malformed");
+            throw new IllegalStateException(
+                "yaml file with aliases is malformed or alias is absent"
+            );
         }
     }
 }

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -164,7 +164,7 @@ public final class VertxMain {
             new JavaResource("example/artipie.yaml").copy(path);
             Files.createDirectory(Paths.get("./repo"));
             final List<String> resources = Arrays.asList(
-                "_credentials.yaml", "_storages.yaml", "_permissions.yaml"
+                "_credentials.yaml", StorageAliases.FILE_NAME, "_permissions.yaml"
             );
             for (final String res : resources) {
                 new JavaResource(String.format("example/repo/%s", res))

--- a/src/test/java/com/artipie/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageTest.java
@@ -27,10 +27,15 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.memory.InMemoryStorage;
 import java.nio.file.Path;
+import java.util.concurrent.CompletionException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,6 +43,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.14
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class RepositoriesFromStorageTest {
 
     /**
@@ -50,15 +56,130 @@ final class RepositoriesFromStorageTest {
      */
     private static final String TYPE = "maven";
 
+    /**
+     * Storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+    }
+
     @Test
     void findRepoSettingAndCreateRepoConfigWithStorageAlias() {
-        final Storage storage = new InMemoryStorage();
         final String alias = "default";
         new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
             .withStorageAlias(alias)
-            .saveTo(storage, RepositoriesFromStorageTest.REPO);
-        storage.save(
-            new Key.From("_storages.yaml"),
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        this.saveAliasConfig(alias);
+        MatcherAssert.assertThat(
+            this.repoConfig()
+                .storageOpt()
+                .isPresent(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void findRepoSettingAndCreateRepoConfigWithCustomStorage() {
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .withFileStorage(Path.of("some", "somepath"))
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        MatcherAssert.assertThat(
+            this.repoConfig()
+                .storageOpt()
+                .isPresent(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenConfigYamlAbsent() {
+        final CompletionException result = Assertions.assertThrows(
+            CompletionException.class,
+            this::repoConfig
+        );
+        MatcherAssert.assertThat(
+            result.getCause(),
+            new IsInstanceOf(ValueNotFoundException.class)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenConfigYamlMalformedSinceWithoutStorage() {
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.repoConfig()
+                .storage()
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenAliasesConfigAbsent() {
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .withStorageAlias("alias")
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.repoConfig()
+                .storageOpt()
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenAliasConfigMalformedSinceSequenceInsteadMapping() {
+        final String alias = "default";
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .withStorageAlias(alias)
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        this.storage.save(
+            new Key.From(StorageAliases.FILE_NAME),
+            new Content.From(
+                Yaml.createYamlMappingBuilder().add(
+                    "storages", Yaml.createYamlSequenceBuilder()
+                        .add(
+                            Yaml.createYamlMappingBuilder().add(
+                                alias, Yaml.createYamlMappingBuilder()
+                                    .add("type", "fs")
+                                    .add("path", "/some/path")
+                                    .build()
+                        ).build()
+                    ).build()
+                ).build().toString().getBytes()
+            )
+        ).join();
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.repoConfig()
+                .storageOpt()
+        );
+    }
+
+    @Test
+    void throwsExceptionForUnknownAlias() {
+        this.saveAliasConfig("some alias");
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .withStorageAlias("unknown alias")
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.repoConfig()
+                .storageOpt()
+        );
+    }
+
+    private RepoConfig repoConfig() {
+        return new RepositoriesFromStorage(this.storage)
+            .config(RepositoriesFromStorageTest.REPO)
+            .toCompletableFuture().join();
+    }
+
+    private void saveAliasConfig(final String alias) {
+        this.storage.save(
+            new Key.From(StorageAliases.FILE_NAME),
             new Content.From(
                 Yaml.createYamlMappingBuilder().add(
                     "storages", Yaml.createYamlMappingBuilder()
@@ -71,30 +192,6 @@ final class RepositoriesFromStorageTest {
                 ).build().toString().getBytes()
             )
         ).join();
-        MatcherAssert.assertThat(
-            new RepositoriesFromStorage(storage)
-                .config(RepositoriesFromStorageTest.REPO)
-                .toCompletableFuture().join()
-                .storageOpt()
-                .isPresent(),
-            new IsEqual<>(true)
-        );
-    }
-
-    @Test
-    void findRepoSettingAndCreateRepoConfigWithCustomStorage() {
-        final Storage storage = new InMemoryStorage();
-        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
-            .withFileStorage(Path.of("some", "somepath"))
-            .saveTo(storage, RepositoriesFromStorageTest.REPO);
-        MatcherAssert.assertThat(
-            new RepositoriesFromStorage(storage)
-                .config(RepositoriesFromStorageTest.REPO)
-                .toCompletableFuture().join()
-                .storageOpt()
-                .isPresent(),
-            new IsEqual<>(true)
-        );
     }
 
 }


### PR DESCRIPTION
Closes #786 
Added negative tests to `RepositoriesFromStorage`. Fixed `StorageAliases.FromYaml`  implementation for the cases when yaml is malformed or alias name is absent.