### PR TITLE
artipie/management-api#15 - prepare to transfer GetStorageSlice

### DIFF
--- a/src/main/java/com/artipie/Repositories.java
+++ b/src/main/java/com/artipie/Repositories.java
@@ -23,6 +23,7 @@
  */
 package com.artipie;
 
+import com.artipie.asto.Storage;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -39,4 +40,12 @@ public interface Repositories {
      * @return Repository config
      */
     CompletionStage<RepoConfig> config(String name);
+
+    /**
+     * Get storage by repo name.
+     *
+     * @param name Repository name.
+     * @return Repository storage.
+     */
+    CompletionStage<Storage> repoStorage(String name);
 }

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -62,4 +62,9 @@ public final class RepositoriesFromStorage implements Repositories {
             )
         ).flatMap(self -> self).to(SingleInterop.get());
     }
+
+    @Override
+    public CompletionStage<Storage> repoStorage(final String name) {
+        return this.config(name).thenApply(RepoConfig::storage);
+    }
 }

--- a/src/main/java/com/artipie/api/ArtipieApi.java
+++ b/src/main/java/com/artipie/api/ArtipieApi.java
@@ -25,6 +25,7 @@ package com.artipie.api;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.RepoPermissionsFromStorage;
+import com.artipie.RepositoriesFromStorage;
 import com.artipie.Settings;
 import com.artipie.YamlPermissions;
 import com.artipie.api.artifactory.GetStorageSlice;
@@ -252,7 +253,8 @@ public final class ArtipieApi extends Slice.Wrap {
                                     new ByMethodsRule(RqMethod.GET)
                                 ),
                                 new GetStorageSlice(
-                                    settings.storage(), settings.layout().pattern()
+                                    new RepositoriesFromStorage(settings.storage()),
+                                    settings.layout().pattern()
                                 )
                             )
                         ),

--- a/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
+++ b/src/test/java/com/artipie/api/artifactory/GetStorageSliceTest.java
@@ -25,6 +25,7 @@ package com.artipie.api.artifactory;
 
 import com.artipie.IsJson;
 import com.artipie.RepoConfigYaml;
+import com.artipie.RepositoriesFromStorage;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.LoggingStorage;
@@ -76,7 +77,9 @@ class GetStorageSliceTest {
     void shouldReturnExpectedData(final String layout, final String repo) {
         final Storage storage = this.example(this.tmp, repo);
         MatcherAssert.assertThat(
-            new GetStorageSlice(storage, new PathPattern(layout).pattern()),
+            new GetStorageSlice(
+                new RepositoriesFromStorage(storage), new PathPattern(layout).pattern()
+            ),
             new SliceHasResponse(
                 new AllOf<>(
                     Arrays.asList(


### PR DESCRIPTION
Part of artipie/management-api#15
I've extended `Repositories` interface with the method to get storage by repo name. The interface will be moved to `management-api` along with the slice.