### PR TITLE
#738 - Fix path handling for NpmProxySlice

### DIFF
--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -250,16 +250,13 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "npm-proxy":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new NpmProxySlice(
+                slice = new NpmProxySlice(
                         cfg.path(),
                         new NpmProxy(
                             new NpmProxyConfig(cfg.settings().orElseThrow()),
                             Vertx.vertx(),
                             cfg.storage()
                         )
-                    )
                 );
                 break;
             case "pypi":

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -129,6 +129,9 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @todo #90:30min This method still needs more refactoring.
      *  We should test if the type exist in the constructed map. If the type does not exist,
      *  we should throw an IllegalStateException with the message "Unsupported repository type '%s'"
+     * @todo #738:30min Remove creating a Vert.x instance in npm-proxy case.
+     *  Vertx.vertx() call creates a Vert.x instance, a very heavy object. It should be
+     *  created only once for whole application on start and reused everywhere.
      * @checkstyle LineLengthCheck (150 lines)
      * @checkstyle ExecutableStatementCountCheck (100 lines)
      * @checkstyle JavaNCSSCheck (500 lines)

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -251,12 +251,12 @@ public final class SliceFromConfig extends Slice.Wrap {
                 break;
             case "npm-proxy":
                 slice = new NpmProxySlice(
-                        cfg.path(),
-                        new NpmProxy(
-                            new NpmProxyConfig(cfg.settings().orElseThrow()),
-                            Vertx.vertx(),
-                            cfg.storage()
-                        )
+                    cfg.path(),
+                    new NpmProxy(
+                        new NpmProxyConfig(cfg.settings().orElseThrow()),
+                        Vertx.vertx(),
+                        cfg.storage()
+                    )
                 );
                 break;
             case "pypi":

--- a/src/test/java/com/artipie/npm/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/NpmProxyITCase.java
@@ -43,7 +43,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;

--- a/src/test/java/com/artipie/npm/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/NpmProxyITCase.java
@@ -96,12 +96,11 @@ final class NpmProxyITCase {
     private TestContainer cntn;
 
     @Test
-    @Disabled
     void installFromProxy() throws Exception {
         final boolean anonymous = true;
         this.init(anonymous);
         MatcherAssert.assertThat(
-            this.cntn.execStdErr(
+            this.cntn.execStdout(
                 "npm", "install", NpmProxyITCase.PROJ,
                 "--registry",
                 new RepositoryUrl(this.proxy.port(), NpmProxyITCase.PROXY).string(anonymous)


### PR DESCRIPTION
Closes #738 
The problem was that the `TrimPathSlice` cut off repository name from the request therefore patterns that were created before in `NpmProxySlice` became invalid. Refusing to use `trimIfNotStandalone` in `SliceFromConfig` for `npm-proxy` helped to solve this problem.