### PR TITLE
#797 - Get value for different extensions 

### DIFF
--- a/src/main/java/com/artipie/RepoPermissionsFromStorage.java
+++ b/src/main/java/com/artipie/RepoPermissionsFromStorage.java
@@ -34,6 +34,7 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.management.RepoPermissions;
 import com.artipie.management.api.ContentAsYaml;
+import com.artipie.repo.ConfigFile;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -84,9 +85,8 @@ public final class RepoPermissionsFromStorage implements RepoPermissions {
         return this.storage.list(Key.ROOT)
             .thenApply(
                 list -> list.stream()
-                    .map(Key::string)
-                    .filter(key -> key.contains("yaml"))
-                    .map(key -> key.replace(".yaml", ""))
+                    .filter(name -> new ConfigFile(name).isYamlOrYml())
+                    .map(name -> new ConfigFile(name).name())
                     .collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -25,6 +25,7 @@ package com.artipie;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.repo.ConfigFile;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.util.concurrent.CompletionStage;
@@ -52,13 +53,14 @@ public final class RepositoriesFromStorage implements Repositories {
 
     @Override
     public CompletionStage<RepoConfig> config(final String name) {
+        final Key keyname = new Key.From(name);
         return Single.zip(
             SingleInterop.fromFuture(
-                this.storage.value(new Key.From(String.format("%s.yaml", name)))
+                new ConfigFile(keyname).valueFrom(this.storage)
             ),
-            SingleInterop.fromFuture(StorageAliases.find(this.storage, new Key.From(name))),
+            SingleInterop.fromFuture(StorageAliases.find(this.storage, keyname)),
             (data, aliases) -> SingleInterop.fromFuture(
-                RepoConfig.fromPublisher(aliases, new Key.From(name), data)
+                RepoConfig.fromPublisher(aliases, keyname, data)
             )
         ).flatMap(self -> self).to(SingleInterop.get());
     }

--- a/src/main/java/com/artipie/StorageAliases.java
+++ b/src/main/java/com/artipie/StorageAliases.java
@@ -73,14 +73,14 @@ public interface StorageAliases {
             found -> {
                 final CompletableFuture<StorageAliases> res;
                 if (found) {
-                    res = new ConfigFile(key).valueFrom(storage).thenCompose(
+                    res = new ConfigFile(key).valueFrom(storage).<StorageAliases>thenCompose(
                         pub -> new Concatenation(pub).single()
                             .map(buf -> new Remaining(buf).bytes())
                             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
                             .map(cnt -> Yaml.createYamlInput(cnt).readYamlMapping())
                             .to(SingleInterop.get())
                             .thenApply(FromYaml::new)
-                    );
+                    ).toCompletableFuture();
                 } else {
                     res = repo.parent()
                         .map(parent -> StorageAliases.find(storage, parent))
@@ -88,7 +88,7 @@ public interface StorageAliases {
                 }
                 return res;
             }
-        );
+        ).toCompletableFuture();
     }
 
     /**

--- a/src/main/java/com/artipie/StorageAliases.java
+++ b/src/main/java/com/artipie/StorageAliases.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Concatenation;
 import com.artipie.asto.Key;
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
+import com.artipie.repo.ConfigFile;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -68,11 +69,11 @@ public interface StorageAliases {
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     static CompletableFuture<StorageAliases> find(final Storage storage, final Key repo) {
         final Key.From key = new Key.From(repo, StorageAliases.FILE_NAME);
-        return storage.exists(key).thenCompose(
+        return new ConfigFile(key).existsIn(storage).thenCompose(
             found -> {
                 final CompletableFuture<StorageAliases> res;
                 if (found) {
-                    res = storage.value(key).thenCompose(
+                    res = new ConfigFile(key).valueFrom(storage).thenCompose(
                         pub -> new Concatenation(pub).single()
                             .map(buf -> new Remaining(buf).bytes())
                             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))

--- a/src/test/java/com/artipie/RepoConfigYaml.java
+++ b/src/test/java/com/artipie/RepoConfigYaml.java
@@ -193,7 +193,7 @@ public final class RepoConfigYaml {
      * @param name Name to save with
      */
     public void saveTo(final Storage storage, final String name) {
-        storage.save(new Key.From(String.format("%s.yaml", name)), this.toContent()).join();
+        storage.save(new Key.From(String.format("%s.yml", name)), this.toContent()).join();
     }
 
     /**

--- a/src/test/java/com/artipie/RepoConfigYaml.java
+++ b/src/test/java/com/artipie/RepoConfigYaml.java
@@ -193,7 +193,7 @@ public final class RepoConfigYaml {
      * @param name Name to save with
      */
     public void saveTo(final Storage storage, final String name) {
-        storage.save(new Key.From(String.format("%s.yml", name)), this.toContent()).join();
+        storage.save(new Key.From(String.format("%s.yaml", name)), this.toContent()).join();
     }
 
     /**

--- a/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
+++ b/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
@@ -68,10 +68,11 @@ class RepoPermissionsFromSettingsTest {
         this.storage.save(new Key.From("two.yaml"), Content.EMPTY).join();
         this.storage.save(new Key.From("abc"), Content.EMPTY).join();
         this.storage.save(new Key.From("three.yaml"), Content.EMPTY).join();
+        this.storage.save(new Key.From("four.yml"), Content.EMPTY).join();
         MatcherAssert.assertThat(
             new RepoPermissionsFromStorage(this.storage).repositories()
                 .toCompletableFuture().join(),
-            Matchers.containsInAnyOrder("one", "two", "three")
+            Matchers.containsInAnyOrder("one", "two", "three", "four")
         );
     }
 

--- a/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
+++ b/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class RepoPermissionsFromSettingsTest {
 
     /**

--- a/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
+++ b/src/test/java/com/artipie/RepoPermissionsFromSettingsTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class RepoPermissionsFromSettingsTest {
 
     /**

--- a/src/test/java/com/artipie/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageTest.java
@@ -37,6 +37,8 @@ import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link RepositoriesFromStorage}.
@@ -66,28 +68,14 @@ final class RepositoriesFromStorageTest {
         this.storage = new InMemoryStorage();
     }
 
-    @Test
-    void findRepoSettingAndCreateRepoConfigWithStorageAliasFromYaml() {
+    @ParameterizedTest
+    @CsvSource({"_storages.yaml", "_storages.yml"})
+    void findRepoSettingAndCreateRepoConfigWithStorageAlias(final String filename) {
         final String alias = "default";
         new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
             .withStorageAlias(alias)
             .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
-        this.saveAliasConfig(alias);
-        MatcherAssert.assertThat(
-            this.repoConfig()
-                .storageOpt()
-                .isPresent(),
-            new IsEqual<>(true)
-        );
-    }
-
-    @Test
-    void findRepoSettingAndCreateRepoConfigWithStorageAliasForYml() {
-        final String alias = "default";
-        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
-            .withStorageAlias(alias)
-            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
-        this.saveAliasConfig(alias, "_storages.yml");
+        this.saveAliasConfig(alias, filename);
         MatcherAssert.assertThat(
             this.repoConfig()
                 .storageOpt()
@@ -175,7 +163,7 @@ final class RepositoriesFromStorageTest {
 
     @Test
     void throwsExceptionForUnknownAlias() {
-        this.saveAliasConfig("some alias");
+        this.saveAliasConfig("some alias", StorageAliases.FILE_NAME);
         new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
             .withStorageAlias("unknown alias")
             .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
@@ -190,10 +178,6 @@ final class RepositoriesFromStorageTest {
         return new RepositoriesFromStorage(this.storage)
             .config(RepositoriesFromStorageTest.REPO)
             .toCompletableFuture().join();
-    }
-
-    private void saveAliasConfig(final String alias) {
-        this.saveAliasConfig(alias, "_storages.yaml");
     }
 
     private void saveAliasConfig(final String alias, final String filename) {

--- a/src/test/java/com/artipie/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  *
  * @since 0.14
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class RepositoriesFromStorageTest {
 
     /**

--- a/src/test/java/com/artipie/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.14
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class RepositoriesFromStorageTest {
 
     /**
@@ -67,12 +67,27 @@ final class RepositoriesFromStorageTest {
     }
 
     @Test
-    void findRepoSettingAndCreateRepoConfigWithStorageAlias() {
+    void findRepoSettingAndCreateRepoConfigWithStorageAliasFromYaml() {
         final String alias = "default";
         new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
             .withStorageAlias(alias)
             .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
         this.saveAliasConfig(alias);
+        MatcherAssert.assertThat(
+            this.repoConfig()
+                .storageOpt()
+                .isPresent(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void findRepoSettingAndCreateRepoConfigWithStorageAliasForYml() {
+        final String alias = "default";
+        new RepoConfigYaml(RepositoriesFromStorageTest.TYPE)
+            .withStorageAlias(alias)
+            .saveTo(this.storage, RepositoriesFromStorageTest.REPO);
+        this.saveAliasConfig(alias, "_storages.yml");
         MatcherAssert.assertThat(
             this.repoConfig()
                 .storageOpt()
@@ -178,8 +193,12 @@ final class RepositoriesFromStorageTest {
     }
 
     private void saveAliasConfig(final String alias) {
+        this.saveAliasConfig(alias, "_storages.yaml");
+    }
+
+    private void saveAliasConfig(final String alias, final String filename) {
         this.storage.save(
-            new Key.From(StorageAliases.FILE_NAME),
+            new Key.From(filename),
             new Content.From(
                 Yaml.createYamlMappingBuilder().add(
                     "storages", Yaml.createYamlMappingBuilder()

--- a/src/test/java/com/artipie/repo/ConfigFileTest.java
+++ b/src/test/java/com/artipie/repo/ConfigFileTest.java
@@ -26,7 +26,9 @@ package com.artipie.repo;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
+import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +40,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  * Test cases for {@link ConfigFile}.
  * @since 0.14
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class ConfigFileTest {
 
     /**
@@ -45,16 +48,54 @@ final class ConfigFileTest {
      */
     private static final String NAME = "my-file";
 
+    /**
+     * Content.
+     */
+    private static final byte[] CONTENT = "content from config file".getBytes();
+
     @ParameterizedTest
     @CsvSource({".yaml", ".yml", "''"})
-    void existInStorageReturnsWhenYamlExist(final String extension) {
+    void existInStorageReturnsTrueWhenYamlExist(final String extension) {
         final Storage storage = new InMemoryStorage();
         this.saveByKey(storage, ".yaml");
         MatcherAssert.assertThat(
             new ConfigFile(new Key.From(ConfigFileTest.NAME + extension))
                 .existsIn(storage)
-                .toCompletableFuture().join(),
+                .join(),
             new IsEqual<>(true)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({".yaml", ".yml", "''"})
+    void valueFromStorageReturnsContentWhenYamlExist(final String extension) {
+        final Storage storage = new InMemoryStorage();
+        this.saveByKey(storage, ".yml");
+        MatcherAssert.assertThat(
+            new PublisherAs(
+                new ConfigFile(new Key.From(ConfigFileTest.NAME + extension))
+                    .valueFrom(storage)
+                    .join()
+            ).bytes()
+            .toCompletableFuture().join(),
+            new IsEqual<>(ConfigFileTest.CONTENT)
+        );
+    }
+
+    @Test
+    void valueFromStorageReturnsYamlWhenBothExist() {
+        final Storage storage = new InMemoryStorage();
+        final String yaml = String.join("", Arrays.toString(ConfigFileTest.CONTENT), "some");
+        this.saveByKey(storage, ".yml");
+        this.saveByKey(storage, ".yaml", yaml.getBytes());
+        MatcherAssert.assertThat(
+            new PublisherAs(
+                new ConfigFile(new Key.From(ConfigFileTest.NAME))
+                    .valueFrom(storage)
+                    .join()
+            ).asciiString()
+            .toCompletableFuture().join(),
+            new IsEqual<>(yaml)
         );
     }
 
@@ -77,11 +118,19 @@ final class ConfigFileTest {
     }
 
     @Test
+    void valueFromFailsForNotYamlOrYmlOrWithoutExtensionFiles() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new ConfigFile("name.json").valueFrom(new InMemoryStorage())
+        );
+    }
+
+    @Test
     void returnFalseForConfigFileWithBadExtension() {
         MatcherAssert.assertThat(
             new ConfigFile("filename.jar")
                 .existsIn(new InMemoryStorage())
-                .toCompletableFuture().join(),
+                .join(),
             new IsEqual<>(false)
         );
     }
@@ -102,9 +151,13 @@ final class ConfigFileTest {
     }
 
     private void saveByKey(final Storage storage, final String extension) {
+        this.saveByKey(storage, extension, ConfigFileTest.CONTENT);
+    }
+
+    private void saveByKey(final Storage storage, final String extension, final byte[] content) {
         storage.save(
             new Key.From(String.format("%s%s", ConfigFileTest.NAME, extension)),
-            Content.EMPTY
+            new Content.From(content)
         );
     }
 


### PR DESCRIPTION
Part of #797 
Implemented `valueFrom` to get content from file with either of two extensions (`yaml` and `yml`). Added tests.