### PR TITLE
#797 - Support both extensions for ArtipieApi and DashboardSlice

### DIFF
--- a/src/main/java/com/artipie/api/DashboardSlice.java
+++ b/src/main/java/com/artipie/api/DashboardSlice.java
@@ -24,7 +24,6 @@
 package com.artipie.api;
 
 import com.amihaiemil.eoyaml.Yaml;
-import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.Settings;
 import com.artipie.YamlPermissions;
 import com.artipie.asto.Concatenation;
@@ -35,7 +34,6 @@ import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
 import com.artipie.management.api.ApiAuthSlice;
-import com.artipie.management.api.ContentAsYaml;
 import com.artipie.management.api.CookiesAuthScheme;
 import com.artipie.management.dashboard.PageSlice;
 import com.artipie.management.dashboard.RepoPage;

--- a/src/main/java/com/artipie/api/DashboardSlice.java
+++ b/src/main/java/com/artipie/api/DashboardSlice.java
@@ -65,7 +65,7 @@ public final class DashboardSlice extends Slice.Wrap {
      * Primary ctor.
      * @param settings Settings
      * @param tpl Template loader for pages
-     * @todo #730:30min When `ContentAs` is used here instead of `Concatenation` and
+     * @todo #797:30min When `ContentAs` is used here instead of `Concatenation` and
      *  `Remaining` `ArtipieApiITCase` get stuck on github actions (this does not happen
      *  locally on windows os), figure out why, make necessary corrections and
      *  use `ContentAs` here. Probably this problem is similar to artipie/artipie#790.


### PR DESCRIPTION
Closes #797 
Support both extensions `.yaml` and `.yml` for `ArtipieApi` and `DashboardSlice`.