### PR TITLE
#820 - docker-adapter upgraded to 0.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.17.1</version>
+      <version>0.17.5</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -291,7 +291,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>docker-adapter</artifactId>
-      <version>0.6</version>
+      <version>0.9.3</version>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -42,6 +42,7 @@ import com.artipie.http.GoSlice;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncSlice;
 import com.artipie.http.auth.Authentication;
+import com.artipie.http.auth.BasicAuthScheme;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.http.group.GroupSlice;
@@ -279,13 +280,13 @@ public final class SliceFromConfig extends Slice.Wrap {
                     new SubStorage(RegistryRoot.V2, cfg.storage())
                 );
                 if (standalone) {
-                    slice = new DockerSlice(docker, permissions, auth);
+                    slice = new DockerSlice(docker, permissions, new BasicAuthScheme(auth));
                 } else {
                     slice = new DockerRoutingSlice.Reverted(
                         new DockerSlice(
                             new TrimmedDocker(docker, cfg.name()),
                             permissions,
-                            auth
+                            new BasicAuthScheme(auth)
                         )
                     );
                 }

--- a/src/main/java/com/artipie/docker/DockerProxy.java
+++ b/src/main/java/com/artipie/docker/DockerProxy.java
@@ -37,6 +37,7 @@ import com.artipie.http.DockerRoutingSlice;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Authentication;
+import com.artipie.http.auth.BasicAuthScheme;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.auth.AuthClientSlice;
@@ -135,7 +136,7 @@ public final class DockerProxy implements Slice {
         if (!this.standalone) {
             docker = new TrimmedDocker(docker, this.cfg.name());
         }
-        Slice slice = new DockerSlice(docker, this.perms, this.auth);
+        Slice slice = new DockerSlice(docker, this.perms, new BasicAuthScheme(this.auth));
         if (!this.standalone) {
             slice = new DockerRoutingSlice.Reverted(slice);
         }


### PR DESCRIPTION
Closes #820 
`docker-adapter` upgraded to `0.9.3`