### PR TITLE
#822 - Fix HelmIT

### DIFF
--- a/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/src/test/java/com/artipie/helm/HelmITCase.java
@@ -49,7 +49,6 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -68,7 +67,6 @@ import org.testcontainers.containers.GenericContainer;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})
-@Disabled
 final class HelmITCase {
 
     /**
@@ -119,7 +117,11 @@ final class HelmITCase {
             con.getResponseCode(),
             new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
         );
-        this.cntn.execStdout("helm", "init", "--client-only");
+        this.cntn.execStdout(
+            "helm", "init",
+            "--stable-repo-url", this.url.string(anonymous),
+            "--client-only"
+        );
         MatcherAssert.assertThat(
             "Chart repository was added",
             this.helmRepoAdd(anonymous, chartrepo),


### PR DESCRIPTION
Closes #822 
The problem is related to the fact that https://kubernetes-charts.storage.googleapis.com/index.yaml as default stable repository is no longer allowed (https://stackoverflow.com/a/65404574/14676855).
Fix this problem by adding local repository which contains `index.yaml` file.