### PR TITLE
#813 - Try to fix as 3.2.3 was released

### DIFF
--- a/.github/workflows/proof-gem.yml
+++ b/.github/workflows/proof-gem.yml
@@ -19,4 +19,4 @@ jobs:
         run: |
           cd examples/gem
           sed -i 's+artipie/artipie:latest+artipie+' run.sh
-#          ./run.sh
+          ./run.sh


### PR DESCRIPTION
`3.2.2` was released on 17.12.20 and test started to fail, `3.2.3` was released on 22.12.20