### PR TITLE
#829 - docker-adapter upgraded to 0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>docker-adapter</artifactId>
-      <version>0.9.3</version>
+      <version>0.10</version>
     </dependency>
     <dependency>
       <groupId>com.github.jknack</groupId>


### PR DESCRIPTION
Closes #829 
`docker-adapter` upgraded to `0.10`