### PR TITLE
Examples scripts

### DIFF
--- a/examples/npm/run.sh
+++ b/examples/npm/run.sh
@@ -1,25 +1,12 @@
-set -x
-set -e
+basedir="$(dirname $(readlink -f $0))"
+source "${basedir}/../utils.sh"
 
 image="$1"
-if [[ -z "$image" ]]; then
-  image="artipie/artipie:latest"
-fi
-basedir="$(dirname $(readlink -f $0))"
+port=8080
 
-# Start artipie.
-docker run --rm --detach --name artipie \
-  -v "${basedir}/artipie.yaml:/etc/artipie/artipie.yml" \
-  -v "${basedir}:/var/artipie" \
-  -p 8080:80 "$image"
+opts="--registry=http://localhost:${port}/npm_repo"
 
-# Publish the sample-npm-project.
-cd "${basedir}/sample-npm-project"
-npm publish --registry http://localhost:8080/npm_repo/
-
-# Install the sample-npm-project.
-cd "${basedir}/sample-consumer"
-npm install sample-npm-project --registry http://localhost:8080/npm_repo/
-
-# Stop and remove container.
-docker stop artipie
+start_artipie "$image" "$port"
+cd "${basedir}/sample-npm-project" && npm publish "$opts"
+cd "${basedir}/sample-consumer" && npm install "$opts"
+cd "${basedir}/sample-npm-project" && npm unpublish "$opts" "sample-npm-project@1.0.0"

--- a/examples/utils.sh
+++ b/examples/utils.sh
@@ -1,0 +1,72 @@
+set -e
+
+function die {
+  printf "FATAL: %s\n" "$1"
+  exit 1
+}
+
+function require_env {
+  local name="$1"
+  local val=$(eval "echo \${$name}")
+  if [[ -z "$val" ]]; then
+    die "${name} env should be set"
+  fi
+}
+
+require_env basedir
+
+# set debug on CI builds
+if [[ -n "$CI" ]]; then
+  export DEBUG=true
+fi
+
+function log_debug {
+  if [[ -n "$DEBUG" ]]; then
+    printf "DEBUG: %s\n" "$1"
+  fi
+}
+
+function assert {
+  [[ "$1" -ne "$2" ]] && die "assertion failed: ${1} != ${2}"
+}
+
+if [[ -n "$DEBUG" ]]; then
+  [[ -z "$DEBUG_NOX" ]] && set -x
+  log_debug "debug enabled"
+fi
+
+function start_artipie {
+  local image="$1"
+  if [[ -z "$image" ]]; then
+    image=$ARTIPIE_IMAGE
+  fi
+  if [[ -z "$image" ]]; then
+    image="artipie/artipie:latest"
+  fi
+  local port="$2"
+  if [[ -z "$port" ]]; then
+    port=8080
+  fi
+  log_debug "using image: '${image}'"
+  log_debug "using port:  '${port}'"
+  [[ -z "$image" || -z "$port" ]] && die "invalid image or port params"
+  stop_artipie
+  docker run --rm --detach --name artipie \
+    -v "${basedir}/artipie.yaml:/etc/artipie/artipie.yml" \
+    -v "${basedir}:/var/artipie" \
+    -p "${port}:80" "$image"
+  log_debug "artipie started"
+  # stop artipie docker container on script exit
+  if [[ -z "$ARTIPIE_NOSTOP" ]]; then
+    trap stop_artipie EXIT
+  fi
+}
+
+function stop_artipie {
+  local container=$(docker ps --filter name=artipie -q 2> /dev/null)
+  if [[ -n "$container" ]]; then
+    log_debug "stopping artipie container ${container}"
+    docker stop "$container"
+  fi
+}
+


### PR DESCRIPTION
#847 - added common bash utils for all examples, refactored npm to use it, added `trap` to stop artipie container in any case