### PR TITLE
Creating GitHub release after deploy to registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Docker Release and Run Benchmarks
+name: Release Docker images
 on:
   create:
     tags:
@@ -28,6 +28,16 @@ jobs:
       - run: mvn -B deploy -Pdocker -Ddocker.image.name=${{ secrets.DOCKERHUB_REPO }}
       - run: mvn versions:set -DnewVersion=latest
       - run: mvn -B deploy -Pdocker -Ddocker.image.name=${{ secrets.DOCKERHUB_REPO }}
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
   # run-benchmarks:
   #   runs-on: ubuntu-latest
   #   needs: docker-publish


### PR DESCRIPTION
Fixes #655 - create GitHub release based on tag
after deploying Docker image to DockerHub.
Release is not a draft or pre-release, it contains
tag annotation message as body.