### PR TITLE
Moved `ContainerResultMatcher` to a separate file

### DIFF
--- a/src/test/java/com/artipie/debian/DebianGpgITCase.java
+++ b/src/test/java/com/artipie/debian/DebianGpgITCase.java
@@ -4,7 +4,7 @@
  */
 package com.artipie.debian;
 
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.IOException;
 import org.cactoos.list.ListOf;
@@ -55,22 +55,22 @@ public final class DebianGpgITCase {
     void setUp() throws IOException {
         this.containers.assertExec(
             "Apt-get update failed",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "update"
         );
         this.containers.assertExec(
             "Failed to install curl",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "install", "-y", "curl"
         );
         this.containers.assertExec(
             "Failed to install gnupg",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "install", "-y", "gnupg"
         );
         this.containers.assertExec(
             "Failed to add public key to apt-get",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-key", "add", "/w/public-key.asc"
         );
         this.containers.putBinaryToClient(
@@ -83,13 +83,13 @@ public final class DebianGpgITCase {
     void pushAndInstallWorks() throws Exception {
         this.containers.assertExec(
             "Failed to upload deb package",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "curl", "http://artipie:8080/my-debian/main/aglfn_1.7-3_amd64.deb",
             "--upload-file", "/w/aglfn_1.7-3_amd64.deb"
         );
         this.containers.assertExec(
             "Apt-get update failed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new AllOf<String>(
                     new ListOf<Matcher<? super String>>(
@@ -107,7 +107,7 @@ public final class DebianGpgITCase {
         );
         this.containers.assertExec(
             "Package was not downloaded and unpacked",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(new ListOf<>("Unpacking aglfn", "Setting up aglfn"))
             ),

--- a/src/test/java/com/artipie/debian/DebianITCase.java
+++ b/src/test/java/com/artipie/debian/DebianITCase.java
@@ -4,7 +4,7 @@
  */
 package com.artipie.debian;
 
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.IOException;
 import org.cactoos.list.ListOf;
@@ -48,17 +48,17 @@ public final class DebianITCase {
     void setUp() throws IOException {
         this.containers.assertExec(
             "Apt-get update failed",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "update"
         );
         this.containers.assertExec(
             "Failed to install curl",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "install", "-y", "curl"
         );
         this.containers.assertExec(
             "Failed to move debian sources.list",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "mv", "/w/sources.list", "/etc/apt/"
         );
     }
@@ -67,18 +67,18 @@ public final class DebianITCase {
     void pushAndInstallWorks() throws Exception {
         this.containers.assertExec(
             "Failed to upload deb package",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "curl", "http://artipie:8080/my-debian/main/aglfn_1.7-3_amd64.deb",
             "--upload-file", "/w/aglfn_1.7-3_amd64.deb"
         );
         this.containers.assertExec(
             "Apt-get update failed",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apt-get", "update"
         );
         this.containers.assertExec(
             "Package was not downloaded and unpacked",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(new ListOf<>("Unpacking aglfn", "Setting up aglfn"))
             ),

--- a/src/test/java/com/artipie/file/FileITCase.java
+++ b/src/test/java/com/artipie/file/FileITCase.java
@@ -5,7 +5,7 @@
 
 package com.artipie.file;
 
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +35,7 @@ final class FileITCase {
     void setUp() throws Exception {
         this.deployment.assertExec(
             "Failed to install deps",
-            new MavenITCase.ContainerResultMatcher(Matchers.is(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "apk", "add", "--no-cache", "curl"
         );
     }
@@ -46,7 +46,7 @@ final class FileITCase {
         this.deployment.putBinaryToArtipie(target, "/var/artipie/data/bin/target");
         this.deployment.assertExec(
             "Failed to download artifact",
-            new MavenITCase.ContainerResultMatcher(Matchers.is(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "curl", "-X", "GET", "http://artipie:8080/bin/target"
         );
     }
@@ -55,7 +55,7 @@ final class FileITCase {
     void canUpload() throws Exception {
         this.deployment.assertExec(
             "Failed to upload",
-            new MavenITCase.ContainerResultMatcher(Matchers.is(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "curl", "-X", "PUT", "--data-binary", "123", "http://artipie:8080/bin/test"
         );
         this.deployment.assertArtipieContent(

--- a/src/test/java/com/artipie/file/FileITCase.java
+++ b/src/test/java/com/artipie/file/FileITCase.java
@@ -35,7 +35,7 @@ final class FileITCase {
     void setUp() throws Exception {
         this.deployment.assertExec(
             "Failed to install deps",
-            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
+            new ContainerResultMatcher(),
             "apk", "add", "--no-cache", "curl"
         );
     }

--- a/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -4,7 +4,7 @@
  */
 package com.artipie.file;
 
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
@@ -52,7 +52,7 @@ final class FileProxyAuthIT {
     void setUp() throws Exception {
         this.containers.assertExec(
             "Failed to install deps",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "apk", "add", "--no-cache", "curl"
         );
     }
@@ -66,7 +66,7 @@ final class FileProxyAuthIT {
         );
         this.containers.assertExec(
             "File was not downloaded",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0), new StringContains("HTTP/1.1 200 OK")
             ),
             "curl", "-i", "-X", "GET", "http://artipie-proxy:8080/my-bin-proxy/foo/bar.txt"

--- a/src/test/java/com/artipie/gem/GemITCase.java
+++ b/src/test/java/com/artipie/gem/GemITCase.java
@@ -5,7 +5,7 @@
 package com.artipie.gem;
 
 import com.artipie.asto.test.TestResource;
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.IOException;
 import org.cactoos.list.ListOf;
@@ -51,7 +51,7 @@ final class GemITCase {
     void gemPushAndInstallWorks() throws IOException {
         this.containers.assertExec(
             "Packages was not pushed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(
                     new ListOf<String>("POST http://artipie:8080/my-gem/api/v1/gems", "200 OK")
@@ -67,12 +67,12 @@ final class GemITCase {
         );
         this.containers.assertExec(
             "rubygems.org was not removed from sources",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "gem", "sources", "--remove", "https://rubygems.org/"
         );
         this.containers.assertExec(
             "Package was not installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(
                     new ListOf<String>(

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -5,6 +5,7 @@
 package com.artipie.maven;
 
 import com.artipie.asto.test.TestResource;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,19 +15,12 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.Container.ExecResult;
 
 /**
  * Integration tests for Maven repository.
@@ -67,7 +61,7 @@ public final class MavenITCase {
         );
         this.containers.assertExec(
             "Failed to get dependency",
-            new ContainerResultMatcher(Matchers.equalTo(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "mvn", "-B", "-q", "-s", "settings.xml", "-e", "dependency:get",
             String.format("-Dartifact=com.artipie:%s:%s", type, vers)
         );
@@ -81,13 +75,13 @@ public final class MavenITCase {
         );
         this.containers.assertExec(
             "Deploy failed",
-            new ContainerResultMatcher(Matchers.is(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "mvn", "-B", "-q", "-s", "settings.xml",
             "deploy", "-Dmaven.install.skip=true"
         );
         this.containers.assertExec(
             "Download failed",
-            new ContainerResultMatcher(Matchers.is(0)),
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
             "mvn", "-B", "-q", "-s", "settings.xml", "-U", "dependency:get",
             String.format("-Dartifact=com.artipie:%s:%s", type, vers)
         );
@@ -132,72 +126,4 @@ public final class MavenITCase {
         );
     }
 
-    /**
-     * Container exec result matcher.
-     * @since 0.16
-     * @todo #855:30min Move this class to test sources,
-     *  add additional constructors for int status and default to expect zero status.
-     *  Consider creating standard enum or public static fields for
-     *  `SUCCESS` - exit code is `0` and
-     *  `ERROR` - exit code is greater than `0`
-     */
-    public static final class ContainerResultMatcher extends TypeSafeMatcher<ExecResult> {
-
-        /**
-         * Expected status matcher.
-         */
-        private final Matcher<Integer> status;
-
-        /**
-         * Stdout matcher.
-         */
-        private final Matcher<String> stdout;
-
-        /**
-         * New matcher.
-         * @param status Expected status
-         * @param stdout Expected message in stdout
-         */
-        public ContainerResultMatcher(final Matcher<Integer> status, final Matcher<String> stdout) {
-            this.status = status;
-            this.stdout = stdout;
-        }
-
-        /**
-         * New matcher.
-         * @param status Expected status
-         */
-        public ContainerResultMatcher(final Matcher<Integer> status) {
-            this(status, new StringContains(""));
-        }
-
-        /**
-         * New default matcher with expected status 0.
-         */
-        public ContainerResultMatcher() {
-            this(new IsEqual<>(0), new StringContains(""));
-        }
-
-        @Override
-        public void describeTo(final Description description) {
-            description.appendText("status ").appendDescriptionOf(this.status)
-            .appendText("stdout ").appendDescriptionOf(this.stdout);
-        }
-
-        @Override
-        public boolean matchesSafely(final ExecResult item) {
-            return this.status.matches(item.getExitCode()) && this.stdout.matches(item.getStdout());
-        }
-
-        @Override
-        public void describeMismatchSafely(final ExecResult res, final Description desc) {
-            desc.appendText("failed with status:\n")
-                .appendValue(res.getExitCode())
-                .appendText("\nSTDOUT: ")
-                .appendText(res.getStdout())
-                .appendText("\nSTDERR: ")
-                .appendText(res.getStderr())
-                .appendText("\n");
-        }
-    }
 }

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -61,7 +61,7 @@ public final class MavenITCase {
         );
         this.containers.assertExec(
             "Failed to get dependency",
-            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
+            new ContainerResultMatcher(),
             "mvn", "-B", "-q", "-s", "settings.xml", "-e", "dependency:get",
             String.format("-Dartifact=com.artipie:%s:%s", type, vers)
         );

--- a/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
@@ -5,6 +5,7 @@
 package com.artipie.maven;
 
 import com.artipie.asto.test.TestResource;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
@@ -68,7 +69,7 @@ final class MavenProxyAuthIT {
             );
         this.containers.assertExec(
             "Helloworld was not installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContains("BUILD SUCCESS")
             ),

--- a/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.maven;
 
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
@@ -43,7 +44,7 @@ final class MavenProxyIT {
     void shouldGetArtifactFromCentralAndSaveInCache() throws Exception {
         this.containers.assertExec(
             "Artifact wasn't downloaded",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0), new StringContains("BUILD SUCCESS")
             ),
             "mvn", "-s", "settings.xml", "dependency:get", "-Dartifact=args4j:args4j:2.32:jar"

--- a/src/test/java/com/artipie/npm/NpmITCase.java
+++ b/src/test/java/com/artipie/npm/NpmITCase.java
@@ -5,7 +5,7 @@
 package com.artipie.npm;
 
 import com.artipie.asto.test.TestResource;
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
@@ -72,7 +72,7 @@ final class NpmITCase {
         );
         this.containers.assertExec(
             "Package was not installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(
                     Arrays.asList(NpmITCase.ADDED_PROJ, "added 1 package")
@@ -82,7 +82,7 @@ final class NpmITCase {
         );
         this.containers.assertExec(
             "Package was installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0), new StringContains("@hello/simple-npm-project@1.0.1")
             ),
             "npm", "list"
@@ -102,7 +102,7 @@ final class NpmITCase {
         );
         this.containers.assertExec(
             "Package was published",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContains(NpmITCase.ADDED_PROJ)
             ),

--- a/src/test/java/com/artipie/npm/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/NpmProxyITCase.java
@@ -5,7 +5,7 @@
 package com.artipie.npm;
 
 import com.artipie.asto.test.TestResource;
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.util.Arrays;
 import org.cactoos.map.MapEntry;
@@ -79,7 +79,7 @@ final class NpmProxyITCase {
         );
         this.containers.assertExec(
             "Package was not installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(
                     Arrays.asList(NpmProxyITCase.ADDED_PROJ, "added 1 package")

--- a/src/test/java/com/artipie/nuget/NugetITCase.java
+++ b/src/test/java/com/artipie/nuget/NugetITCase.java
@@ -5,7 +5,7 @@
 package com.artipie.nuget;
 
 import com.artipie.asto.test.TestResource;
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.util.Arrays;
 import java.util.UUID;
@@ -62,7 +62,7 @@ final class NugetITCase {
         );
         this.containers.assertExec(
             "Package was not pushed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContains("Your package was pushed.")
             ),
@@ -70,12 +70,12 @@ final class NugetITCase {
         );
         this.containers.assertExec(
             "New project was not created",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "dotnet", "new", "console", "-n", "TestProj"
         );
         this.containers.assertExec(
             "Package was not added",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(
                     Arrays.asList(

--- a/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -5,7 +5,7 @@
 package com.artipie.pypi;
 
 import com.artipie.asto.test.TestResource;
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
@@ -59,7 +59,7 @@ public final class PypiProxyITCase {
         );
         this.containers.assertExec(
             "Package was not installed",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 Matchers.containsString("Successfully installed alarmtime-0.1.5")
             ),

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -4,7 +4,7 @@
  */
 package com.artipie.rpm;
 
-import com.artipie.maven.MavenITCase;
+import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
 import java.io.IOException;
 import org.cactoos.list.ListOf;
@@ -44,7 +44,7 @@ public final class RpmITCase {
     void setUp() throws IOException {
         this.containers.assertExec(
             "Yum install curl failed",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "yum", "-y", "install", "curl"
         );
         this.containers.putBinaryToClient(
@@ -63,13 +63,13 @@ public final class RpmITCase {
     void uploadsAndInstallsThePackage() throws Exception {
         this.containers.assertExec(
             "Failed to upload rpm package",
-            new MavenITCase.ContainerResultMatcher(),
+            new ContainerResultMatcher(),
             "curl", "http://artipie:8080/my-rpm/time-1.7-45.el7.x86_64.rpm",
             "--upload-file", "/w/time-1.7-45.el7.x86_64.rpm"
         );
         this.containers.assertExec(
             "Failed to install time package",
-            new MavenITCase.ContainerResultMatcher(
+            new ContainerResultMatcher(
                 new IsEqual<>(0),
                 new StringContainsInOrder(new ListOf<>("time-1.7-45.el7.x86_64", "Complete!"))
             ),

--- a/src/test/java/com/artipie/test/ContainerResultMatcher.java
+++ b/src/test/java/com/artipie/test/ContainerResultMatcher.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.test;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
+import org.testcontainers.containers.Container;
+
+/**
+ * Container exec result matcher.
+ * @since 0.16
+ */
+public final class ContainerResultMatcher extends TypeSafeMatcher<Container.ExecResult> {
+
+    /**
+     * Success exit code.
+     */
+    public static final int SUCCESS = 0;
+
+    /**
+     * Expected status matcher.
+     */
+    private final Matcher<Integer> status;
+
+    /**
+     * Stdout matcher.
+     */
+    private final Matcher<String> stdout;
+
+    /**
+     * New matcher.
+     * @param status Expected status
+     * @param stdout Expected message in stdout
+     */
+    public ContainerResultMatcher(final Matcher<Integer> status, final Matcher<String> stdout) {
+        this.status = status;
+        this.stdout = stdout;
+    }
+
+    /**
+     * New matcher.
+     * @param status Expected status
+     */
+    public ContainerResultMatcher(final Matcher<Integer> status) {
+        this(status, new StringContains(""));
+    }
+
+    /**
+     * New matcher.
+     * @param status Expected status
+     */
+    public ContainerResultMatcher(final Integer status) {
+        this(new IsEqual<>(status), new StringContains(""));
+    }
+
+    /**
+     * New matcher.
+     * @param status Expected status
+     * @param stdout Expected message in stdout
+     */
+    public ContainerResultMatcher(final Integer status, final Matcher<String> stdout) {
+        this(new IsEqual<>(status), stdout);
+    }
+
+    /**
+     * New default matcher with expected status 0.
+     */
+    public ContainerResultMatcher() {
+        this(new IsEqual<>(ContainerResultMatcher.SUCCESS), new StringContains(""));
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("status ").appendDescriptionOf(this.status)
+        .appendText("stdout ").appendDescriptionOf(this.stdout);
+    }
+
+    @Override
+    public boolean matchesSafely(final Container.ExecResult item) {
+        return this.status.matches(item.getExitCode()) && this.stdout.matches(item.getStdout());
+    }
+
+    @Override
+    public void describeMismatchSafely(final Container.ExecResult res, final Description desc) {
+        desc.appendText("failed with status:\n")
+            .appendValue(res.getExitCode())
+            .appendText("\nSTDOUT: ")
+            .appendText(res.getStdout())
+            .appendText("\nSTDERR: ")
+            .appendText(res.getStderr())
+            .appendText("\n");
+    }
+}

--- a/src/test/java/com/artipie/test/ContainerResultMatcher.java
+++ b/src/test/java/com/artipie/test/ContainerResultMatcher.java
@@ -13,7 +13,7 @@ import org.testcontainers.containers.Container;
 
 /**
  * Container exec result matcher.
- * @since 0.16
+ * @since 0.20
  */
 public final class ContainerResultMatcher extends TypeSafeMatcher<Container.ExecResult> {
 


### PR DESCRIPTION
Closes #862 
Moved `ContainerResultMatcher` to a separate file, added several ctors and constant for success status.