### PR TITLE
Bump composer-adapter and management-api, add composer proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,12 +175,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>management-api</artifactId>
-      <version>0.4.4</version>
+      <version>0.4.5</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -247,7 +247,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>composer-adapter</artifactId>
-      <version>0.3.7</version>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -39,6 +39,7 @@ import com.artipie.npm.proxy.NpmProxy;
 import com.artipie.npm.proxy.NpmProxyConfig;
 import com.artipie.npm.proxy.http.NpmProxySlice;
 import com.artipie.nuget.http.NuGet;
+import com.artipie.php.ComposerProxy;
 import com.artipie.pypi.PypiProxy;
 import com.artipie.pypi.http.PySlice;
 import com.artipie.rpm.http.RpmSlice;
@@ -193,6 +194,13 @@ public final class SliceFromConfig extends Slice.Wrap {
             case "php":
                 slice = trimIfNotStandalone(
                     settings, standalone, new PhpComposer(new AstoRepository(cfg.storage()))
+                );
+                break;
+            case "php-proxy":
+                slice = trimIfNotStandalone(
+                    settings,
+                    standalone,
+                    new ComposerProxy(SliceFromConfig.HTTP, cfg)
                 );
                 break;
             case "nuget":

--- a/src/main/java/com/artipie/php/ComposerProxy.java
+++ b/src/main/java/com/artipie/php/ComposerProxy.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.php;
+
+import com.artipie.RepoConfig;
+import com.artipie.composer.AstoRepository;
+import com.artipie.composer.http.proxy.ComposerProxySlice;
+import com.artipie.composer.http.proxy.ComposerStorageCache;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.client.ClientSlices;
+import com.artipie.repo.ProxyConfig;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import org.reactivestreams.Publisher;
+
+/**
+ * Php Composer proxy slice.
+ * @since 0.20
+ */
+public final class ComposerProxy implements Slice {
+    /**
+     * HTTP client.
+     */
+    private final ClientSlices client;
+
+    /**
+     * Repository configuration.
+     */
+    private final RepoConfig cfg;
+
+    /**
+     * Ctor.
+     * @param client HTTP client
+     * @param cfg Repository configuration
+     */
+    public ComposerProxy(final ClientSlices client, final RepoConfig cfg) {
+        this.client = client;
+        this.cfg = cfg;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        final Collection<? extends ProxyConfig.Remote> remotes = this.cfg.proxy().remotes();
+        if (remotes.isEmpty()) {
+            throw new IllegalArgumentException("No remotes were specified");
+        }
+        if (remotes.size() > 1) {
+            throw new IllegalArgumentException("Only one remote is allowed");
+        }
+        final ProxyConfig.Remote remote = remotes.iterator().next();
+        return remote.cache().map(
+            storage -> new ComposerProxySlice(
+                this.client,
+                URI.create(remote.url()),
+                new AstoRepository(this.cfg.storage()),
+                remote.auth(),
+                new ComposerStorageCache(new AstoRepository(storage))
+            )
+        ).orElseGet(
+            () -> new ComposerProxySlice(
+                this.client,
+                URI.create(remote.url()),
+                new AstoRepository(this.cfg.storage()),
+                remote.auth()
+            )
+        ).response(line, headers, body);
+    }
+}

--- a/src/main/java/com/artipie/php/package-info.java
+++ b/src/main/java/com/artipie/php/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+
+/**
+ * Php Composer repository slices.
+ *
+ * @since 0.20
+ */
+package com.artipie.php;


### PR DESCRIPTION
Closes #895 
Bumped composer adapter to `1.0` to use added functionality. Added composer proxy type of repository
Bumped management-api to `0.4.5` to show absent types of repository in dropdown list