### PR TITLE
Added cache for configuration files

### DIFF
--- a/src/main/java/com/artipie/ArtipieProperties.java
+++ b/src/main/java/com/artipie/ArtipieProperties.java
@@ -20,6 +20,11 @@ public final class ArtipieProperties {
     public static final String VERSION_KEY = "artipie.version";
 
     /**
+     * Expiration time for cache of configuration files.
+     */
+    static final String CONFIG_TIMEOUT = "artipie.config.cache.timeout";
+
+    /**
      * Name of file with properties.
      */
     private final String filename;
@@ -58,15 +63,8 @@ public final class ArtipieProperties {
      * Obtains timeout of caching configuration files in milliseconds.
      * @return Timeout of caching files with configuration.
      */
-    public int configCacheTimeout() {
-        int time;
-        try {
-            time = Integer.parseInt(this.properties.getProperty("artipie.config.cache.timeout"));
-        } catch (final NumberFormatException exc) {
-            // @checkstyle MagicNumberCheck (1 line)
-            time = 2 * 60 * 1000;
-        }
-        return time;
+    public String configCacheTimeout() {
+        return this.properties.getProperty(ArtipieProperties.CONFIG_TIMEOUT);
     }
 
     /**

--- a/src/main/java/com/artipie/ArtipieProperties.java
+++ b/src/main/java/com/artipie/ArtipieProperties.java
@@ -55,6 +55,21 @@ public final class ArtipieProperties {
     }
 
     /**
+     * Obtains timeout of caching configuration files in milliseconds.
+     * @return Timeout of caching files with configuration.
+     */
+    public int configCacheTimeout() {
+        int time;
+        try {
+            time = Integer.parseInt(this.properties.getProperty("artipie.config.cache.timeout"));
+        } catch (final NumberFormatException exc) {
+            // @checkstyle MagicNumberCheck (1 line)
+            time = 2 * 60 * 1000;
+        }
+        return time;
+    }
+
+    /**
      * Load content of file.
      */
     private void loadProperties() {

--- a/src/main/java/com/artipie/RepoConfig.java
+++ b/src/main/java/com/artipie/RepoConfig.java
@@ -202,6 +202,11 @@ public final class RepoConfig {
         return new YamlProxyConfig(this.storages, this.prefix, this.repoConfig());
     }
 
+    @Override
+    public String toString() {
+        return this.yaml.toString();
+    }
+
     /**
      * Reads string by key from repo part of YAML.
      *

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -27,12 +27,12 @@ public final class RepositoriesFromStorage implements Repositories {
     /**
      * Cache for config files.
      */
-    private static LoadingCache<KeyAndStorage, Single<String>> configs;
+    private static LoadingCache<FilesContent, Single<String>> configs;
 
     /**
      * Cache for aliases.
      */
-    private static LoadingCache<KeyAndStorage, Single<StorageAliases>> aliases;
+    private static LoadingCache<FilesContent, Single<StorageAliases>> aliases;
 
     static {
         System.setProperty(
@@ -46,7 +46,7 @@ public final class RepositoriesFromStorage implements Repositories {
             .build(
                 new CacheLoader<>() {
                     @Override
-                    public Single<String> load(final KeyAndStorage config) {
+                    public Single<String> load(final FilesContent config) {
                         return config.configContent();
                     }
                 }
@@ -57,7 +57,7 @@ public final class RepositoriesFromStorage implements Repositories {
             .build(
                 new CacheLoader<>() {
                     @Override
-                    public Single<StorageAliases> load(final KeyAndStorage alias) {
+                    public Single<StorageAliases> load(final FilesContent alias) {
                         return alias.aliases();
                     }
                 }
@@ -80,7 +80,7 @@ public final class RepositoriesFromStorage implements Repositories {
 
     @Override
     public CompletionStage<RepoConfig> config(final String name) {
-        final KeyAndStorage pair = new KeyAndStorage(new Key.From(name), this.storage);
+        final FilesContent pair = new FilesContent(new Key.From(name), this.storage);
         return Single.zip(
             RepositoriesFromStorage.configs.getUnchecked(pair),
             RepositoriesFromStorage.aliases.getUnchecked(pair),
@@ -94,7 +94,7 @@ public final class RepositoriesFromStorage implements Repositories {
      * Extra class for obtaining aliases content of configuration file.
      * @since 0.22
      */
-    private static final class KeyAndStorage {
+    private static final class FilesContent {
         /**
          * Key.
          */
@@ -110,7 +110,7 @@ public final class RepositoriesFromStorage implements Repositories {
          * @param key Key
          * @param storage Storage
          */
-        private KeyAndStorage(final Key key, final Storage storage) {
+        private FilesContent(final Key key, final Storage storage) {
             this.key = key;
             this.storage = storage;
         }
@@ -125,8 +125,8 @@ public final class RepositoriesFromStorage implements Repositories {
             final boolean res;
             if (obj == this) {
                 res = true;
-            } else if (obj instanceof KeyAndStorage) {
-                final KeyAndStorage data = (KeyAndStorage) obj;
+            } else if (obj instanceof FilesContent) {
+                final FilesContent data = (FilesContent) obj;
                 res = Objects.equals(this.key, data.key)
                     && Objects.equals(data.storage, this.storage);
             } else {

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -14,6 +14,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
@@ -90,8 +91,7 @@ public final class RepositoriesFromStorage implements Repositories {
     }
 
     /**
-     * Extra class for passing pair of values. The equality of these objects
-     * should be checked against the comparison of keys.
+     * Extra class for passing pair of values.
      * @since 0.22
      */
     private static final class KeyAndStorage {
@@ -127,7 +127,7 @@ public final class RepositoriesFromStorage implements Repositories {
                 res = true;
             } else if (obj instanceof KeyAndStorage) {
                 final KeyAndStorage data = (KeyAndStorage) obj;
-                res = this.key.equals(data.key);
+                res = this.key.equals(data.key) && Objects.equals(data.storage, this.storage);
             } else {
                 res = false;
             }

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -57,10 +57,10 @@ public final class RepositoriesFromStorage implements Repositories {
         };
         final int timeout = new ArtipieProperties().configCacheTimeout();
         RepositoriesFromStorage.configs = CacheBuilder.newBuilder()
-            .expireAfterAccess(timeout, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(timeout, TimeUnit.MILLISECONDS)
             .softValues().build(ldrconfigs);
         RepositoriesFromStorage.aliases = CacheBuilder.newBuilder()
-            .expireAfterAccess(timeout, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(timeout, TimeUnit.MILLISECONDS)
             .softValues().build(ldralias);
     }
 

--- a/src/main/resources/artipie.properties
+++ b/src/main/resources/artipie.properties
@@ -1,1 +1,2 @@
 artipie.version=${project.version}
+artipie.config.cache.timeout=120000

--- a/src/test/java/com/artipie/RepositoriesFromStorageCacheTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageCacheTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for cache of files with configuration in {@link RepositoriesFromStorage}.
+ *
+ * @since 0.22
+ */
+final class RepositoriesFromStorageCacheTest {
+    /**
+     * Storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @Test
+    void readConfigFromCacheAfterSavingNewValueInStorage() {
+        final Key key = new Key.From("some-repo.yaml");
+        final byte[] old = "some: data".getBytes();
+        final byte[] upd = "some: new data".getBytes();
+        new BlockingStorage(this.storage).save(key, old);
+        new RepositoriesFromStorage(this.storage).config(key.string())
+            .toCompletableFuture().join();
+        new BlockingStorage(this.storage).save(key, upd);
+        MatcherAssert.assertThat(
+            new RepositoriesFromStorage(this.storage).config(key.string())
+                .toCompletableFuture().join()
+                .toString(),
+            new IsEqual<>(new String(old))
+        );
+    }
+
+    @Test
+    void readAliasesFromCache() {
+        final Key alias = new Key.From("_storages.yaml");
+        final Key config = new Key.From("bin.yaml");
+        new TestResource(alias.string()).saveTo(this.storage);
+        new BlockingStorage(this.storage).save(config, "repo:\n  storage: default".getBytes());
+        new RepositoriesFromStorage(this.storage).config(config.string())
+            .toCompletableFuture().join();
+        this.storage.save(alias, Content.EMPTY).join();
+        MatcherAssert.assertThat(
+            new RepositoriesFromStorage(this.storage).config(config.string())
+                .toCompletableFuture().join()
+                .storageOpt().isPresent(),
+            new IsEqual<>(true)
+        );
+    }
+}

--- a/src/test/java/com/artipie/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/RepositoriesFromStorageTest.java
@@ -85,7 +85,7 @@ final class RepositoriesFromStorageTest {
             this::repoConfig
         );
         MatcherAssert.assertThat(
-            result.getCause(),
+            result.getCause().getCause(),
             new IsInstanceOf(ValueNotFoundException.class)
         );
     }

--- a/src/test/resources/_storages.yaml
+++ b/src/test/resources/_storages.yaml
@@ -1,0 +1,4 @@
+storages:
+  default:
+    type: fs
+    path: ./.storage/data


### PR DESCRIPTION
Closes #195 
Added cache with soft references with eviction which is equal to two minutes for repository configuration files and for aliases with configs of storage.