### PR TITLE
Specify expiration time and refactor `CachedAuth`

### DIFF
--- a/src/main/java/com/artipie/ArtipieProperties.java
+++ b/src/main/java/com/artipie/ArtipieProperties.java
@@ -22,7 +22,7 @@ public final class ArtipieProperties {
     /**
      * Expiration time for cached auth.
      */
-    public static final String AUTH_TIMEOUT = "artipie.cached.auth.timeout=";
+    public static final String AUTH_TIMEOUT = "artipie.cached.auth.timeout";
 
     /**
      * Expiration time for cache of configuration files.

--- a/src/main/java/com/artipie/ArtipieProperties.java
+++ b/src/main/java/com/artipie/ArtipieProperties.java
@@ -20,6 +20,11 @@ public final class ArtipieProperties {
     public static final String VERSION_KEY = "artipie.version";
 
     /**
+     * Expiration time for cached auth.
+     */
+    public static final String AUTH_TIMEOUT = "artipie.cached.auth.timeout=";
+
+    /**
      * Expiration time for cache of configuration files.
      */
     static final String CONFIG_TIMEOUT = "artipie.config.cache.timeout";
@@ -65,6 +70,14 @@ public final class ArtipieProperties {
      */
     public String configCacheTimeout() {
         return this.properties.getProperty(ArtipieProperties.CONFIG_TIMEOUT);
+    }
+
+    /**
+     * Obtains timeout of caching users in milliseconds.
+     * @return Timeout of caching users.
+     */
+    public String cachedAuthTimeout() {
+        return this.properties.getProperty(ArtipieProperties.AUTH_TIMEOUT);
     }
 
     /**

--- a/src/main/java/com/artipie/RepositoriesFromStorage.java
+++ b/src/main/java/com/artipie/RepositoriesFromStorage.java
@@ -91,7 +91,7 @@ public final class RepositoriesFromStorage implements Repositories {
     }
 
     /**
-     * Extra class for obtaining aliases content of configuration file.
+     * Extra class for obtaining aliases and content of configuration file.
      * @since 0.22
      */
     private static final class FilesContent {

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -9,6 +9,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.auth.CachedAuth;
 import com.artipie.http.ArtipieRepositories;
 import com.artipie.http.BaseSlice;
 import com.artipie.http.MainSlice;
@@ -154,7 +155,8 @@ public final class VertxMain {
             initialize = true;
         }
         final Settings settings = new YamlSettings(
-            Yaml.createYamlInput(path.toFile()).readYamlMapping()
+            Yaml.createYamlInput(path.toFile()).readYamlMapping(),
+            new CachedAuth()
         );
         final BlockingStorage bsto = new BlockingStorage(settings.storage());
         final Key init = new Key.From(".artipie", "initialized");

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -9,7 +9,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
-import com.artipie.auth.CachedAuth;
+import com.artipie.auth.CachedUsers;
 import com.artipie.http.ArtipieRepositories;
 import com.artipie.http.BaseSlice;
 import com.artipie.http.MainSlice;
@@ -156,7 +156,7 @@ public final class VertxMain {
         }
         final Settings settings = new YamlSettings(
             Yaml.createYamlInput(path.toFile()).readYamlMapping(),
-            new CachedAuth()
+            new CachedUsers()
         );
         final BlockingStorage bsto = new BlockingStorage(settings.storage());
         final Key init = new Key.From(".artipie", "initialized");

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -66,7 +66,7 @@ public final class YamlSettings implements Settings {
             Users::auth
         ).thenApply(
             auth -> new Authentication.Joined(
-                new CachedAuthWrap(this.authcache, new GithubAuth()),
+                new Cached(this.authcache, new GithubAuth()),
                 auth
             )
         );
@@ -141,7 +141,7 @@ public final class YamlSettings implements Settings {
      * Wrapping for auth cache.
      * @since 0.22
      */
-    private static final class CachedAuthWrap implements Authentication {
+    private static final class Cached implements Authentication {
         /**
          * Auth cache.
          */
@@ -157,7 +157,7 @@ public final class YamlSettings implements Settings {
          * @param cache Auth cache
          * @param origin Auth provider
          */
-        CachedAuthWrap(final AuthCache cache, final Authentication origin) {
+        Cached(final AuthCache cache, final Authentication origin) {
             this.cache = cache;
             this.origin = origin;
         }

--- a/src/main/java/com/artipie/auth/AuthCache.java
+++ b/src/main/java/com/artipie/auth/AuthCache.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.auth;
+
+import com.artipie.http.auth.Authentication;
+import java.util.Optional;
+
+/**
+ * Cache for user logins which were found by credentials.
+ * @since 0.22
+ */
+public interface AuthCache {
+    /**
+     * Find user by credentials.
+     * @param username Username
+     * @param password Password
+     * @param origin Auth provider
+     * @return User login if found
+     */
+    Optional<Authentication.User> user(String username, String password, Authentication origin);
+
+    /**
+     * Invalidate all items in cache.
+     */
+    void invalidateAll();
+
+    /**
+     * Fake implementation of {@link AuthCache}.
+     * @since 0.22
+     */
+    class Fake implements AuthCache {
+        @Override
+        public Optional<Authentication.User> user(
+            final String username,
+            final String password,
+            final Authentication origin
+        ) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void invalidateAll() {
+            // do nothing
+        }
+    }
+}

--- a/src/main/java/com/artipie/auth/CachedUsers.java
+++ b/src/main/java/com/artipie/auth/CachedUsers.java
@@ -19,9 +19,9 @@ import java.util.concurrent.TimeUnit;
  * It remembers the result of decorated authentication provider and returns it
  * instead of calling origin authentication.
  * </p>
- * @since 0.10
+ * @since 0.22
  */
-public final class CachedAuth implements AuthCache {
+public final class CachedUsers implements AuthCache {
     /**
      * Cache for users.
      */
@@ -33,7 +33,7 @@ public final class CachedAuth implements AuthCache {
             new ArtipieProperties().cachedAuthTimeout()
         );
         final int timeout = Integer.getInteger(ArtipieProperties.AUTH_TIMEOUT, 5 * 60 * 1000);
-        CachedAuth.users = CacheBuilder.newBuilder()
+        CachedUsers.users = CacheBuilder.newBuilder()
             .expireAfterAccess(timeout, TimeUnit.MILLISECONDS)
             .softValues()
             .build(
@@ -52,21 +52,21 @@ public final class CachedAuth implements AuthCache {
         final String password,
         final Authentication origin
     ) {
-        return CachedAuth.users.getUnchecked(
+        return CachedUsers.users.getUnchecked(
             new Data(username, password, origin)
         );
     }
 
     @Override
     public void invalidateAll() {
-        CachedAuth.users.invalidateAll();
+        CachedUsers.users.invalidateAll();
     }
 
     @Override
     public String toString() {
         return String.format(
             "%s(size=%d)",
-            this.getClass().getSimpleName(), CachedAuth.users.size()
+            this.getClass().getSimpleName(), CachedUsers.users.size()
         );
     }
 

--- a/src/main/resources/artipie.properties
+++ b/src/main/resources/artipie.properties
@@ -1,2 +1,3 @@
 artipie.version=${project.version}
 artipie.config.cache.timeout=120000
+artipie.cached.auth.timeout=300000

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -8,6 +8,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
 import com.artipie.asto.SubStorage;
+import com.artipie.auth.AuthCache;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,7 +43,8 @@ class YamlSettingsTest {
                     "meta:\n",
                     "  storage:\n"
                 )
-            ).readYamlMapping()
+            ).readYamlMapping(),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             settings.layout(),
@@ -60,7 +62,8 @@ class YamlSettingsTest {
                     "  storage: []\n",
                     "  layout: org\n"
                 )
-            ).readYamlMapping()
+            ).readYamlMapping(),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             settings.layout(),
@@ -71,7 +74,8 @@ class YamlSettingsTest {
     @Test
     void shouldBuildFileStorageFromSettings() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", "env", Optional.empty())
+            this.config("some/path", "env", Optional.empty()),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             settings.storage(),
@@ -96,7 +100,8 @@ class YamlSettingsTest {
                     "      accessKeyId: ***\n",
                     "      secretAccessKey: ***"
                 )
-            ).readYamlMapping()
+            ).readYamlMapping(),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             settings.storage(),
@@ -107,7 +112,8 @@ class YamlSettingsTest {
     @Test
     void shouldCreateAuthFromEnv() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", "env", Optional.empty())
+            this.config("some/path", "env", Optional.empty()),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             settings.auth().toCompletableFuture().get().toString(),
@@ -120,7 +126,8 @@ class YamlSettingsTest {
         throws Exception {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), "file", Optional.of(fname))
+            this.config(tmp.toString(), "file", Optional.of(fname)),
+            new AuthCache.Fake()
         );
         final Path yaml = tmp.resolve(fname);
         Files.writeString(yaml, this.credentials());
@@ -134,7 +141,8 @@ class YamlSettingsTest {
     void returnsCredentials(@TempDir final Path tmp) throws IOException {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), "file", Optional.of(fname))
+            this.config(tmp.toString(), "file", Optional.of(fname)),
+            new AuthCache.Fake()
         );
         final Path yaml = tmp.resolve(fname);
         Files.writeString(yaml, this.credentials());
@@ -147,8 +155,10 @@ class YamlSettingsTest {
     @Test
     void returnsRepoConfigs(@TempDir final Path tmp) {
         MatcherAssert.assertThat(
-            new YamlSettings(this.config(tmp.toString(), "file", Optional.empty()))
-                .repoConfigsStorage(),
+            new YamlSettings(
+                this.config(tmp.toString(), "file", Optional.empty()),
+                new AuthCache.Fake()
+            ).repoConfigsStorage(),
             new IsInstanceOf(SubStorage.class)
         );
     }
@@ -156,7 +166,8 @@ class YamlSettingsTest {
     @Test
     void shouldThrowExceptionWhenPathIsNotSet() {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", "file", Optional.empty())
+            this.config("some/path", "file", Optional.empty()),
+            new AuthCache.Fake()
         );
         MatcherAssert.assertThat(
             Assertions.assertThrows(
@@ -171,7 +182,8 @@ class YamlSettingsTest {
     @MethodSource("badYamls")
     void shouldFailProvideStorageFromBadYaml(final String yaml) throws IOException {
         final YamlSettings settings = new YamlSettings(
-            Yaml.createYamlInput(yaml).readYamlMapping()
+            Yaml.createYamlInput(yaml).readYamlMapping(),
+            new AuthCache.Fake()
         );
         Assertions.assertThrows(RuntimeException.class, settings::storage);
     }

--- a/src/test/java/com/artipie/auth/CachedAuthTest.java
+++ b/src/test/java/com/artipie/auth/CachedAuthTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -16,27 +17,70 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.10
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class CachedAuthTest {
+    /**
+     * Cached authentication.
+     */
+    private CachedAuth target;
+
+    @BeforeEach
+    void setUp() {
+        this.target = new CachedAuth();
+        this.target.invalidateAll();
+    }
 
     @Test
     void callsOriginOnlyOnce() {
         final String username = "usr";
         final AtomicInteger counter = new AtomicInteger();
-        final CachedAuth target = new CachedAuth(
-            (usr, pass) -> Optional.of(
-                new Authentication.User(String.format("%s-%d", usr, counter.incrementAndGet()))
-            )
-        );
         final String expected = "usr-1";
         MatcherAssert.assertThat(
             "Wrong user on first cache call",
-            target.user(username, "").orElseThrow().name(),
+            this.target.user(
+                username,
+                "",
+                (usr, pass) -> Optional.of(
+                    new Authentication.User(String.format("%s-%d", usr, counter.incrementAndGet()))
+                )
+            ).orElseThrow().name(),
             new IsEqual<>(expected)
         );
         MatcherAssert.assertThat(
             "Wrong user on second cache call",
-            target.user(username, "").orElseThrow().name(),
+            this.target.user(
+                username,
+                "",
+                (usr, pass) -> Optional.of(
+                    new Authentication.User(String.format("%s-%d", usr, counter.incrementAndGet()))
+                )
+            ).orElseThrow().name(),
             new IsEqual<>(expected)
+        );
+    }
+
+    @Test
+    void failsToGetUserWhenCacheContainsAnotherUser() {
+        final String absent = "absent_user";
+        final String cached = "cached_user";
+        this.target.user(
+            cached, "", (usr, pass) -> Optional.of(new Authentication.User(cached))
+        );
+        MatcherAssert.assertThat(
+            this.target.user(absent, "", (usr, pass) -> Optional.empty()).isPresent(),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void getsUserFromCache() {
+        final String user = "super_user";
+        this.target.user(
+            user, "", (usr, pass) -> Optional.of(new Authentication.User(user))
+        );
+        MatcherAssert.assertThat(
+            this.target.user(user, "", (usr, pass) -> Optional.empty()).isPresent(),
+            new IsEqual<>(true)
         );
     }
 }

--- a/src/test/java/com/artipie/auth/CachedAuthTest.java
+++ b/src/test/java/com/artipie/auth/CachedAuthTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -19,25 +18,16 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class CachedAuthTest {
-    /**
-     * Cached authentication.
-     */
-    private CachedAuth target;
-
-    @BeforeEach
-    void setUp() {
-        this.target = new CachedAuth();
-        this.target.invalidateAll();
-    }
-
     @Test
     void callsOriginOnlyOnce() {
         final String username = "usr";
         final AtomicInteger counter = new AtomicInteger();
         final String expected = "usr-1";
+        final CachedAuth target = new CachedAuth();
+        target.invalidateAll();
         MatcherAssert.assertThat(
             "Wrong user on first cache call",
-            this.target.user(
+            target.user(
                 username,
                 "",
                 (usr, pass) -> Optional.of(
@@ -48,7 +38,7 @@ final class CachedAuthTest {
         );
         MatcherAssert.assertThat(
             "Wrong user on second cache call",
-            this.target.user(
+            target.user(
                 username,
                 "",
                 (usr, pass) -> Optional.of(
@@ -63,11 +53,13 @@ final class CachedAuthTest {
     void failsToGetUserWhenCacheContainsAnotherUser() {
         final String absent = "absent_user";
         final String cached = "cached_user";
-        this.target.user(
+        final CachedAuth target = new CachedAuth();
+        target.invalidateAll();
+        target.user(
             cached, "", (usr, pass) -> Optional.of(new Authentication.User(cached))
         );
         MatcherAssert.assertThat(
-            this.target.user(absent, "", (usr, pass) -> Optional.empty()).isPresent(),
+            target.user(absent, "", (usr, pass) -> Optional.empty()).isPresent(),
             new IsEqual<>(false)
         );
     }
@@ -75,11 +67,13 @@ final class CachedAuthTest {
     @Test
     void getsUserFromCache() {
         final String user = "super_user";
-        this.target.user(
+        final CachedAuth target = new CachedAuth();
+        target.invalidateAll();
+        target.user(
             user, "", (usr, pass) -> Optional.of(new Authentication.User(user))
         );
         MatcherAssert.assertThat(
-            this.target.user(user, "", (usr, pass) -> Optional.empty()).isPresent(),
+            target.user(user, "", (usr, pass) -> Optional.empty()).isPresent(),
             new IsEqual<>(true)
         );
     }

--- a/src/test/java/com/artipie/auth/CachedUsersTest.java
+++ b/src/test/java/com/artipie/auth/CachedUsersTest.java
@@ -12,18 +12,18 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link CachedAuth}.
+ * Test case for {@link CachedUsers}.
  *
- * @since 0.10
+ * @since 0.22
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class CachedAuthTest {
+final class CachedUsersTest {
     @Test
     void callsOriginOnlyOnce() {
         final String username = "usr";
         final AtomicInteger counter = new AtomicInteger();
         final String expected = "usr-1";
-        final CachedAuth target = new CachedAuth();
+        final CachedUsers target = new CachedUsers();
         target.invalidateAll();
         MatcherAssert.assertThat(
             "Wrong user on first cache call",
@@ -53,7 +53,7 @@ final class CachedAuthTest {
     void failsToGetUserWhenCacheContainsAnotherUser() {
         final String absent = "absent_user";
         final String cached = "cached_user";
-        final CachedAuth target = new CachedAuth();
+        final CachedUsers target = new CachedUsers();
         target.invalidateAll();
         target.user(
             cached, "", (usr, pass) -> Optional.of(new Authentication.User(cached))
@@ -67,7 +67,7 @@ final class CachedAuthTest {
     @Test
     void getsUserFromCache() {
         final String user = "super_user";
-        final CachedAuth target = new CachedAuth();
+        final CachedUsers target = new CachedUsers();
         target.invalidateAll();
         target.user(
             user, "", (usr, pass) -> Optional.of(new Authentication.User(user))


### PR DESCRIPTION
Closes #339 #460 
Specify expiration time for auth, used guava implementation.
Extracted `AuthCache` interface for creating instance of `CachedAuth` only once. Created `CachedAuthWrap` for using passed instance of `AuthCache` in `YamlSettings#auth` . 