### PR TITLE
Removed not actual @todo

### DIFF
--- a/src/test/java/com/artipie/ArtipieServer.java
+++ b/src/test/java/com/artipie/ArtipieServer.java
@@ -186,13 +186,6 @@ public class ArtipieServer {
      *
      * @return Port the servers listening on.
      * @throws IOException In case of error creating configs or running the server.
-     * @todo #449:30min Extract class for building settings in YAML format.
-     *  Building of settings YAML for usage in tests occurs more the once.
-     *  It is used to build setting in `ArtipieServer`
-     *  and in `YamlSettingsTest` to create settings examples in unit tests.
-     *  Some examples in `YamlSettingsTest` are just string constants.
-     *  It would be nice to extract a class for building settings in YAML format
-     *  for usage in all these places.
      */
     public int start() throws IOException {
         final Path repos = this.root.resolve("repos");


### PR DESCRIPTION
Closes #470 
I do not think refactoring from this `todo` is actually required: as there are basically only two places in test code where `artipie.yaml` is created - `ArtipieServer` and test for settings `YamlSettingsTest`. `YamlSettingsTest` has a lot of different variants of artipie.yaml (to test that in all cases settings are read correctly) and for test it's ok (and even better in my opinion) to have all these variants as string stabs.