### PR TITLE
ci: added modernizer plugin into verify pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,23 @@ SOFTWARE.
               <skip>true</skip>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-plugin</artifactId>
+            <version>2.3.0</version>
+            <executions>
+              <execution>
+                <id>modernizer</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>modernizer</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <javaVersion>${maven.compiler.source}</javaVersion>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/src/test/java/com/artipie/helm/HelmITCase.java
@@ -14,8 +14,6 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.nuget.RandomFreePort;
 import com.artipie.test.RepositoryUrl;
 import com.artipie.test.TestContainer;
-import com.google.common.io.ByteStreams;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
@@ -219,12 +217,8 @@ final class HelmITCase {
                 }
             );
         }
-        ByteStreams.copy(
-            new ByteArrayInputStream(
-                new TestResource(String.format("helm/%s", HelmITCase.CHART)).asBytes()
-            ),
-            con.getOutputStream()
-        );
+        new TestResource(String.format("helm/%s", HelmITCase.CHART)).asInputStream()
+            .transferTo(con.getOutputStream());
         return con;
     }
 


### PR DESCRIPTION
Run https://github.com/gaul/modernizer-maven-plugin
on `verify` phase to detect legacy API usages in code.
Fixed `HelmITCase` issue reported by plugin.

@artipie/members you may want to add this plugin to other modules too, see plugin readme for details.