### PR TITLE
feat: add TTL and max size for cache storages in proxy repos

### DIFF
--- a/src/main/java/com/artipie/docker/DockerProxy.java
+++ b/src/main/java/com/artipie/docker/DockerProxy.java
@@ -140,9 +140,9 @@ public final class DockerProxy implements Slice {
             new AuthClientSlice(slices.https(remote.url()), remote.auth())
         );
         return remote.cache().<Docker>map(
-            storage -> new CacheDocker(
+            cache -> new CacheDocker(
                 proxy,
-                new AstoDocker(new SubStorage(RegistryRoot.V2, storage))
+                new AstoDocker(new SubStorage(RegistryRoot.V2, cache.storage()))
             )
         ).orElse(proxy);
     }

--- a/src/main/java/com/artipie/maven/MavenProxy.java
+++ b/src/main/java/com/artipie/maven/MavenProxy.java
@@ -58,7 +58,9 @@ public final class MavenProxy implements Slice {
                     this.client,
                     URI.create(remote.url()),
                     remote.auth(),
-                    remote.cache().<Cache>map(FromStorageCache::new).orElse(Cache.NOP)
+                    remote.cache().<Cache>map(
+                        cache -> new FromStorageCache(cache.storage())
+                    ).orElse(Cache.NOP)
                 )
             ).collect(Collectors.toList())
         ).response(line, headers, body);

--- a/src/main/java/com/artipie/php/ComposerProxy.java
+++ b/src/main/java/com/artipie/php/ComposerProxy.java
@@ -58,12 +58,12 @@ public final class ComposerProxy implements Slice {
         }
         final ProxyConfig.Remote remote = remotes.iterator().next();
         return remote.cache().map(
-            storage -> new ComposerProxySlice(
+            cache -> new ComposerProxySlice(
                 this.client,
                 URI.create(remote.url()),
                 new AstoRepository(this.cfg.storage()),
                 remote.auth(),
-                new ComposerStorageCache(new AstoRepository(storage))
+                new ComposerStorageCache(new AstoRepository(cache.storage()))
             )
         ).orElseGet(
             () -> new ComposerProxySlice(

--- a/src/main/java/com/artipie/pypi/PypiProxy.java
+++ b/src/main/java/com/artipie/pypi/PypiProxy.java
@@ -60,7 +60,7 @@ public final class PypiProxy implements Slice {
             remote.auth(),
             remote.cache().orElseThrow(
                 () -> new IllegalStateException("Python proxy requires proxy storage to be set")
-            )
+            ).storage()
         ).response(line, headers, body);
     }
 }

--- a/src/main/java/com/artipie/repo/CacheStorage.java
+++ b/src/main/java/com/artipie/repo/CacheStorage.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.repo;
+
+import com.artipie.asto.Storage;
+import java.time.Duration;
+
+/**
+ * Proxy cache storage config.
+ * @since 0.23
+ */
+public interface CacheStorage {
+    /**
+     * Storage settings of cache.
+     * @return Storage.
+     */
+    Storage storage();
+
+    /**
+     * Max available size of cache storage in bytes.
+     * @return Max available size.
+     */
+    Long maxSize();
+
+    /**
+     * Obtains time to live for cache storage.
+     * @return Time to live for cache storage.
+     */
+    Duration timeToLive();
+}

--- a/src/main/java/com/artipie/repo/ProxyConfig.java
+++ b/src/main/java/com/artipie/repo/ProxyConfig.java
@@ -4,7 +4,6 @@
  */
 package com.artipie.repo;
 
-import com.artipie.asto.Storage;
 import com.artipie.http.client.auth.Authenticator;
 import java.util.Collection;
 import java.util.Optional;
@@ -49,6 +48,6 @@ public interface ProxyConfig {
          *
          * @return Cache storage, empty if not configured.
          */
-        Optional<Storage> cache();
+        Optional<CacheStorage> cache();
     }
 }

--- a/src/main/java/com/artipie/repo/YamlCacheStorage.java
+++ b/src/main/java/com/artipie/repo/YamlCacheStorage.java
@@ -42,7 +42,7 @@ final class YamlCacheStorage implements CacheStorage {
      * @param storage Cache storage
      */
     YamlCacheStorage(final Storage storage) {
-        this(storage, Long.MAX_VALUE, Duration.ofHours(Long.MAX_VALUE));
+        this(storage, Long.MAX_VALUE, Duration.ofMillis(Long.MAX_VALUE));
     }
 
     /**

--- a/src/main/java/com/artipie/repo/YamlCacheStorage.java
+++ b/src/main/java/com/artipie/repo/YamlCacheStorage.java
@@ -17,12 +17,12 @@ final class YamlCacheStorage implements CacheStorage {
     /**
      * Cache storage.
      */
-    private final Storage cstorage;
+    private final Storage asto;
 
     /**
      * Max available size.
      */
-    private final Long cmaxsize;
+    private final Long size;
 
     /**
      * Time to live.
@@ -47,24 +47,24 @@ final class YamlCacheStorage implements CacheStorage {
 
     /**
      * Ctor.
-     * @param cstorage Cache storage
+     * @param storage Cache storage
      * @param maxsize Max available size
      * @param ttl Time to live
      */
-    YamlCacheStorage(final Storage cstorage, final Long maxsize, final Duration ttl) {
-        this.cstorage = cstorage;
-        this.cmaxsize = maxsize;
+    YamlCacheStorage(final Storage storage, final Long maxsize, final Duration ttl) {
+        this.asto = storage;
+        this.size = maxsize;
         this.ttl = ttl;
     }
 
     @Override
     public Storage storage() {
-        return this.cstorage;
+        return this.asto;
     }
 
     @Override
     public Long maxSize() {
-        return this.cmaxsize;
+        return this.size;
     }
 
     @Override

--- a/src/main/java/com/artipie/repo/YamlCacheStorage.java
+++ b/src/main/java/com/artipie/repo/YamlCacheStorage.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.repo;
+
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.YamlStorage;
+import com.artipie.asto.Storage;
+import java.time.Duration;
+
+/**
+ * Proxy cache storage config from YAML.
+ * @since 0.23
+ */
+final class YamlCacheStorage implements CacheStorage {
+    /**
+     * Cache storage.
+     */
+    private final Storage cstorage;
+
+    /**
+     * Max available size.
+     */
+    private final Long cmaxsize;
+
+    /**
+     * Time to live.
+     */
+    private final Duration ttl;
+
+    /**
+     * Ctor.
+     * @param source Source YAML with only cache section
+     */
+    YamlCacheStorage(final YamlMapping source) {
+        this(new YamlStorage(source).storage());
+    }
+
+    /**
+     * Ctor with default max size and time to live.
+     * @param storage Cache storage
+     */
+    YamlCacheStorage(final Storage storage) {
+        this(storage, Long.MAX_VALUE, Duration.ofHours(Long.MAX_VALUE));
+    }
+
+    /**
+     * Ctor.
+     * @param cstorage Cache storage
+     * @param maxsize Max available size
+     * @param ttl Time to live
+     */
+    YamlCacheStorage(final Storage cstorage, final Long maxsize, final Duration ttl) {
+        this.cstorage = cstorage;
+        this.cmaxsize = maxsize;
+        this.ttl = ttl;
+    }
+
+    @Override
+    public Storage storage() {
+        return this.cstorage;
+    }
+
+    @Override
+    public Long maxSize() {
+        return this.cmaxsize;
+    }
+
+    @Override
+    public Duration timeToLive() {
+        return this.ttl;
+    }
+}

--- a/src/main/java/com/artipie/repo/YamlProxyConfig.java
+++ b/src/main/java/com/artipie/repo/YamlProxyConfig.java
@@ -10,7 +10,6 @@ import com.artipie.MeasuredStorage;
 import com.artipie.SliceFromConfig;
 import com.artipie.StorageAliases;
 import com.artipie.asto.Key;
-import com.artipie.asto.Storage;
 import com.artipie.http.client.auth.Authenticator;
 import com.artipie.http.client.auth.GenericAuthenticator;
 import java.util.Collection;
@@ -130,13 +129,15 @@ public final class YamlProxyConfig implements ProxyConfig {
         }
 
         @Override
-        public Optional<Storage> cache() {
+        public Optional<CacheStorage> cache() {
             return Optional.ofNullable(this.source.yamlMapping("cache")).flatMap(
                 root -> Optional.ofNullable(root.value("storage")).map(
-                    node -> new MeasuredStorage(
-                        new StorageYamlConfig(
-                            node, YamlProxyConfig.this.storages
-                        ).subStorage(YamlProxyConfig.this.prefix)
+                    node -> new YamlCacheStorage(
+                        new MeasuredStorage(
+                            new StorageYamlConfig(
+                                node, YamlProxyConfig.this.storages
+                            ).subStorage(YamlProxyConfig.this.prefix)
+                        )
                     )
                 )
             );


### PR DESCRIPTION
Part of #334 
Added interface for obtaining TTL and max size values from config of repo. In next PR, I'm planning to add some tests