### PR TITLE
ci: bump qulice and enabled for CI pipeline

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-jdk-17-maven-
       - name: Build it with Maven
-        run: mvn -B verify
+        run: mvn -B verify -Pqulice
   xcop-lint:
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,7 @@ SOFTWARE.
         <plugin>
           <groupId>com.qulice</groupId>
           <artifactId>qulice-maven-plugin</artifactId>
+          <version>0.19.0</version>
           <configuration>
             <excludes combine.children="append">
               <exclude>checkstyle:.*/src/test/resources/.*</exclude>

--- a/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/src/test/java/com/artipie/helm/HelmITCase.java
@@ -47,7 +47,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})
-@Disabled(value = "FIXME: migrate artipie to testonctainers")
+@Disabled("FIXME: migrate artipie to testonctainers")
 final class HelmITCase {
 
     /**


### PR DESCRIPTION
Updated qulice to `0.19.0` with fix yegor256/qulice#1095
Enabled it in CI pipeline.