### PR TITLE
fix: remove printing container logs

### DIFF
--- a/src/test/java/com/artipie/test/TestDeployment.java
+++ b/src/test/java/com/artipie/test/TestDeployment.java
@@ -139,12 +139,7 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
     }
 
     @Override
-    @SuppressWarnings("PMD.SystemPrintln")
-    public void afterEach(final ExtensionContext context) throws Exception {
-        this.aloggers.forEach(
-            (name, log) -> System.out.printf("Artipie '%s' logs:\n%s\n", name, log)
-        );
-        System.out.printf("Client logs:\n%s\n", this.clilogger);
+    public void afterEach(final ExtensionContext context) {
         if (this.artipie != null) {
             this.artipie.values().forEach(GenericContainer::stop);
             this.artipie.values().forEach(Startable::close);


### PR DESCRIPTION
Part of #863 
It is not necessary to print container logs in `afterEach` section because now they are printed on the fly