### PR TITLE
feat: use `CachedStorages`

### DIFF
--- a/src/main/java/com/artipie/CachedStorages.java
+++ b/src/main/java/com/artipie/CachedStorages.java
@@ -46,7 +46,9 @@ final class CachedStorages implements StorageConfigCache {
                 new CacheLoader<>() {
                     @Override
                     public Storage load(final Metadata meta) {
-                        return meta.settings().storage();
+                        return new MeasuredStorage(
+                            new YamlStorage(meta.storageMeta()).storage()
+                        );
                     }
                 }
             );
@@ -98,10 +100,7 @@ final class CachedStorages implements StorageConfigCache {
                 res = false;
             } else {
                 final Metadata meta = (Metadata) obj;
-                res = Objects.equals(
-                    this.storageMeta(),
-                    meta.settings().meta().yamlMapping("storage")
-                );
+                res = Objects.equals(this.storageMeta(), meta.storageMeta());
             }
             return res;
         }

--- a/src/main/java/com/artipie/SettingsCaches.java
+++ b/src/main/java/com/artipie/SettingsCaches.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie;
+
+import com.artipie.auth.AuthCache;
+import com.artipie.auth.CachedUsers;
+
+/**
+ * Encapsulates caches which are possible to use in settings of Artipie server.
+ * @since 0.23
+ */
+interface SettingsCaches {
+    /**
+     * Obtains cache for configurations of storages.
+     * @return Cache for configurations of storages.
+     */
+    StorageConfigCache storageConfig();
+
+    /**
+     * Obtains cache for user logins.
+     * @return Cache for user logins.
+     */
+    AuthCache auth();
+
+    /**
+     * Implementation with all real instances of caches.
+     * @since 0.23
+     */
+    class All implements SettingsCaches {
+        /**
+         * Cache for user logins.
+         */
+        private final AuthCache authcache;
+
+        /**
+         * Cache for configurations of storages.
+         */
+        private final StorageConfigCache strgcache;
+
+        /**
+         * Ctor with all initialized caches.
+         */
+        All() {
+            this.authcache = new CachedUsers();
+            this.strgcache = new CachedStorages();
+        }
+
+        @Override
+        public StorageConfigCache storageConfig() {
+            return this.strgcache;
+        }
+
+        @Override
+        public AuthCache auth() {
+            return this.authcache;
+        }
+    }
+
+    /**
+     * Implementation with fake instances of caches.
+     * @since 0.23
+     */
+    class Fake implements SettingsCaches {
+        /**
+         * Cache for user logins.
+         */
+        private final AuthCache authcache;
+
+        /**
+         * Cache for configurations of storages.
+         */
+        private final StorageConfigCache strgcache;
+
+        /**
+         * Ctor with all fake initialized caches.
+         */
+        Fake() {
+            this.authcache = new AuthCache.Fake();
+            this.strgcache = new StorageConfigCache.Fake();
+        }
+
+        @Override
+        public StorageConfigCache storageConfig() {
+            return this.strgcache;
+        }
+
+        @Override
+        public AuthCache auth() {
+            return this.authcache;
+        }
+    }
+}

--- a/src/main/java/com/artipie/SettingsFromPath.java
+++ b/src/main/java/com/artipie/SettingsFromPath.java
@@ -7,7 +7,6 @@ package com.artipie;
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
-import com.artipie.auth.CachedUsers;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -49,7 +48,7 @@ public final class SettingsFromPath {
         }
         final Settings settings = new YamlSettings(
             Yaml.createYamlInput(this.path.toFile()).readYamlMapping(),
-            new CachedUsers()
+            new SettingsCaches.All()
         );
         final BlockingStorage bsto = new BlockingStorage(settings.storage());
         final Key init = new Key.From(".artipie", "initialized");

--- a/src/main/java/com/artipie/StorageConfigCache.java
+++ b/src/main/java/com/artipie/StorageConfigCache.java
@@ -5,6 +5,7 @@
 package com.artipie;
 
 import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
 
 /**
  * Cache for storages with similar configurations in Artipie settings.
@@ -23,4 +24,33 @@ interface StorageConfigCache {
      * Invalidate all items in cache.
      */
     void invalidateAll();
+
+    /**
+     * Fake implementation of {@link StorageConfigCache} which
+     * always return in-memory storage.
+     * @since 0.22
+     */
+    class Fake implements StorageConfigCache {
+        /**
+         * Storage.
+         */
+        private final Storage storage;
+
+        /**
+         * Ctor.
+         */
+        Fake() {
+            this.storage = new InMemoryStorage();
+        }
+
+        @Override
+        public Storage storage(final Settings ignored) {
+            return this.storage;
+        }
+
+        @Override
+        public void invalidateAll() {
+            // do nothing
+        }
+    }
 }

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -38,26 +38,23 @@ public final class YamlSettings implements Settings {
     private final YamlMapping content;
 
     /**
-     * Authentication cache.
+     * A set of caches for settings.
      */
-    private final AuthCache authcache;
+    private final SettingsCaches caches;
 
     /**
      * Ctor.
      * @param content YAML file content.
-     * @param authcache Auth cache
+     * @param caches Settings caches
      */
-    public YamlSettings(final YamlMapping content, final AuthCache authcache) {
+    public YamlSettings(final YamlMapping content, final SettingsCaches caches) {
         this.content = content;
-        this.authcache = authcache;
+        this.caches = caches;
     }
 
     @Override
     public Storage storage() {
-        return new MeasuredStorage(
-            new YamlStorage(this.meta().yamlMapping("storage"))
-                .storage()
-        );
+        return this.caches.storageConfig().storage(this);
     }
 
     @Override
@@ -66,7 +63,7 @@ public final class YamlSettings implements Settings {
             Users::auth
         ).thenApply(
             auth -> new Authentication.Joined(
-                new Cached(this.authcache, new GithubAuth()),
+                new Cached(this.caches.auth(), new GithubAuth()),
                 auth
             )
         );

--- a/src/test/java/com/artipie/CachedStoragesTest.java
+++ b/src/test/java/com/artipie/CachedStoragesTest.java
@@ -6,7 +6,6 @@ package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Storage;
-import com.artipie.auth.CachedUsers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
@@ -67,13 +66,13 @@ final class CachedStoragesTest {
                     Yaml.createYamlMappingBuilder()
                         .add("meta", Yaml.createYamlMappingBuilder().build())
                         .build(),
-                    new CachedUsers()
+                    new SettingsCaches.Fake()
                 )
             )
         );
     }
 
-    private static YamlSettings config(final String stpath) {
+    private static Settings config(final String stpath) {
         return new YamlSettings(
             Yaml.createYamlMappingBuilder()
                 .add(
@@ -85,7 +84,7 @@ final class CachedStoragesTest {
                             .add("path", stpath).build()
                     ).build()
                 ).build(),
-            new CachedUsers()
+            new SettingsCaches.Fake()
         );
     }
 }

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -8,7 +8,6 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
 import com.artipie.asto.SubStorage;
-import com.artipie.auth.AuthCache;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +44,7 @@ class YamlSettingsTest {
                     "  storage:\n"
                 )
             ).readYamlMapping(),
-            new AuthCache.Fake()
+            new SettingsCaches.Fake()
         );
         MatcherAssert.assertThat(
             settings.layout(),
@@ -64,7 +63,7 @@ class YamlSettingsTest {
                     "  layout: org\n"
                 )
             ).readYamlMapping(),
-            new AuthCache.Fake()
+            new SettingsCaches.Fake()
         );
         MatcherAssert.assertThat(
             settings.layout(),
@@ -76,7 +75,7 @@ class YamlSettingsTest {
     void shouldBuildFileStorageFromSettings() throws Exception {
         final YamlSettings settings = new YamlSettings(
             this.config("some/path", "env", Optional.empty()),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
             settings.storage(),
@@ -102,7 +101,7 @@ class YamlSettingsTest {
                     "      secretAccessKey: ***"
                 )
             ).readYamlMapping(),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
             settings.storage(),
@@ -114,7 +113,7 @@ class YamlSettingsTest {
     void shouldCreateAuthFromEnv() throws Exception {
         final YamlSettings settings = new YamlSettings(
             this.config("some/path", "env", Optional.empty()),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
             settings.auth().toCompletableFuture().get().toString(),
@@ -134,7 +133,7 @@ class YamlSettingsTest {
                         .add("path", "path/storage").build()
                 ).build()
             ).build(),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
             settings.auth().toCompletableFuture().get()
@@ -150,7 +149,7 @@ class YamlSettingsTest {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
             this.config(tmp.toString(), "file", Optional.of(fname)),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         final Path yaml = tmp.resolve(fname);
         Files.writeString(yaml, this.credentials());
@@ -165,7 +164,7 @@ class YamlSettingsTest {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
             this.config(tmp.toString(), "file", Optional.of(fname)),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         final Path yaml = tmp.resolve(fname);
         Files.writeString(yaml, this.credentials());
@@ -180,7 +179,7 @@ class YamlSettingsTest {
         MatcherAssert.assertThat(
             new YamlSettings(
                 this.config(tmp.toString(), "file", Optional.empty()),
-                new AuthCache.Fake()
+                new SettingsCaches.Fake()
             ).repoConfigsStorage(),
             new IsInstanceOf(SubStorage.class)
         );
@@ -190,7 +189,7 @@ class YamlSettingsTest {
     void shouldThrowExceptionWhenPathIsNotSet() {
         final YamlSettings settings = new YamlSettings(
             this.config("some/path", "file", Optional.empty()),
-            new AuthCache.Fake()
+            new SettingsCaches.Fake()
         );
         MatcherAssert.assertThat(
             Assertions.assertThrows(
@@ -206,7 +205,7 @@ class YamlSettingsTest {
     void shouldFailProvideStorageFromBadYaml(final String yaml) throws IOException {
         final YamlSettings settings = new YamlSettings(
             Yaml.createYamlInput(yaml).readYamlMapping(),
-            new AuthCache.Fake()
+            new SettingsCaches.All()
         );
         Assertions.assertThrows(RuntimeException.class, settings::storage);
     }


### PR DESCRIPTION
Part of #87 
Used `CachedStorages` in `YamlSettings`.
I am not sure about passing `Settings` to `CachedStorages#storage(Settings)` because in `Settings` `CachedStorages` is used. Probably it would be better to pass `YamlMapping` because it is necessary to use only one section from the whole setting but in this case we would depend more on yaml format 