### PR TITLE
feat: add cache for credentials configuration

### DIFF
--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -12,7 +12,6 @@ import com.artipie.auth.GithubAuth;
 import com.artipie.cache.AuthCache;
 import com.artipie.cache.SettingsCaches;
 import com.artipie.http.auth.Authentication;
-import com.artipie.http.slice.KeyFromPath;
 import com.artipie.management.Users;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -99,20 +98,9 @@ public final class YamlSettings implements Settings {
         final YamlMapping cred = this.meta()
             .yamlMapping("credentials");
         final CompletionStage<Users> res;
-        final String path = "path";
-        if (YamlSettings.hasTypeFile(cred) && cred.string(path) != null) {
-            final Storage strg = this.storage();
-            final KeyFromPath key = new KeyFromPath(cred.string(path));
-            res = strg.exists(key).thenApply(
-                exists -> {
-                    final Users creds;
-                    if (exists) {
-                        creds = new UsersFromStorageYaml(strg, key);
-                    } else {
-                        creds = new UsersFromEnv();
-                    }
-                    return creds;
-                }
+        if (YamlSettings.hasTypeFile(cred) && cred.string("path") != null) {
+            res = CompletableFuture.completedFuture(
+                this.caches.credsConfig().credentials(this)
             );
         } else if (YamlSettings.hasTypeFile(cred)) {
             res = CompletableFuture.failedFuture(

--- a/src/main/java/com/artipie/YamlSettings.java
+++ b/src/main/java/com/artipie/YamlSettings.java
@@ -12,6 +12,7 @@ import com.artipie.auth.GithubAuth;
 import com.artipie.cache.AuthCache;
 import com.artipie.cache.SettingsCaches;
 import com.artipie.http.auth.Authentication;
+import com.artipie.http.slice.KeyFromPath;
 import com.artipie.management.Users;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -98,9 +99,20 @@ public final class YamlSettings implements Settings {
         final YamlMapping cred = this.meta()
             .yamlMapping("credentials");
         final CompletionStage<Users> res;
-        if (YamlSettings.hasTypeFile(cred) && cred.string("path") != null) {
-            res = CompletableFuture.completedFuture(
-                this.caches.credsConfig().credentials(this)
+        final String path = "path";
+        if (YamlSettings.hasTypeFile(cred) && cred.string(path) != null) {
+            final Storage strg = this.storage();
+            final KeyFromPath key = new KeyFromPath(cred.string(path));
+            res = strg.exists(key).thenApply(
+                exists -> {
+                    final Users creds;
+                    if (exists) {
+                        creds = new UsersFromStorageYaml(strg, key, this.caches.credsConfig());
+                    } else {
+                        creds = new UsersFromEnv();
+                    }
+                    return creds;
+                }
             );
         } else if (YamlSettings.hasTypeFile(cred)) {
             res = CompletableFuture.failedFuture(

--- a/src/main/java/com/artipie/cache/CachedCreds.java
+++ b/src/main/java/com/artipie/cache/CachedCreds.java
@@ -30,11 +30,16 @@ public final class CachedCreds implements CredsConfigCache {
     /**
      * Cache for storages settings.
      */
-    private static LoadingCache<Metadata, CompletionStage<YamlMapping>> creds;
+    private final LoadingCache<Metadata, CompletionStage<YamlMapping>> creds;
 
-    static {
-        CachedCreds.creds = CacheBuilder.newBuilder()
-            .expireAfterAccess(
+    /**
+     * Ctor.
+     * Here an instance of cache is created. It is important that cache
+     * is a local variable.
+     */
+    public CachedCreds() {
+        this.creds = CacheBuilder.newBuilder()
+            .expireAfterWrite(
                 //@checkstyle MagicNumberCheck (1 line)
                 new Property(ArtipieProperties.CREDS_TIMEOUT).asLongOrDefault(180_000L),
                 TimeUnit.MILLISECONDS
@@ -55,19 +60,19 @@ public final class CachedCreds implements CredsConfigCache {
 
     @Override
     public CompletionStage<YamlMapping> credentials(final Storage storage, final Key path) {
-        return CachedCreds.creds.getUnchecked(new Metadata(storage, path));
+        return this.creds.getUnchecked(new Metadata(storage, path));
     }
 
     @Override
     public void invalidateAll() {
-        CachedCreds.creds.invalidateAll();
+        this.creds.invalidateAll();
     }
 
     @Override
     public String toString() {
         return String.format(
             "%s(size=%d)",
-            this.getClass().getSimpleName(), CachedCreds.creds.size()
+            this.getClass().getSimpleName(), this.creds.size()
         );
     }
 

--- a/src/main/java/com/artipie/cache/CachedCreds.java
+++ b/src/main/java/com/artipie/cache/CachedCreds.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.cache;
+
+import com.artipie.ArtipieException;
+import com.artipie.Settings;
+import com.artipie.UsersFromStorageYaml;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.http.slice.KeyFromPath;
+import com.artipie.management.Users;
+import com.artipie.misc.ArtipieProperties;
+import com.artipie.misc.Property;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Implementation of cache for credentials with similar configurations
+ * in Artipie settings using {@link LoadingCache}.
+ * @since 0.23
+ */
+final class CachedCreds implements CredsConfigCache {
+    /**
+     * Cache for storages settings.
+     */
+    private static LoadingCache<Metadata, Users> creds;
+
+    static {
+        CachedCreds.creds = CacheBuilder.newBuilder()
+            .expireAfterAccess(
+                //@checkstyle MagicNumberCheck (1 line)
+                new Property(ArtipieProperties.CREDS_TIMEOUT).asLongOrDefault(180_000L),
+                TimeUnit.MILLISECONDS
+            ).softValues()
+            .build(
+                new CacheLoader<>() {
+                    @Override
+                    public Users load(final Metadata meta) {
+                        final Pair<Key, Storage> pair = meta.credsMeta();
+                        return new UsersFromStorageYaml(pair.getRight(), pair.getLeft());
+                    }
+                }
+            );
+    }
+
+    @Override
+    public Users credentials(final Settings settings) {
+        return CachedCreds.creds.getUnchecked(new Metadata(settings));
+    }
+
+    @Override
+    public void invalidateAll() {
+        CachedCreds.creds.invalidateAll();
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "%s(size=%d)",
+            this.getClass().getSimpleName(), CachedCreds.creds.size()
+        );
+    }
+
+    /**
+     * Extra class for using metadata information in static section.
+     * It is important that storages here are obtained from cache because
+     * it allows comparing by keys (e.g. path to file with credentials) and
+     * storages. It compares by storages because otherwise it would not be
+     * possible to cache different values for the same paths but different storages.
+     * @since 0.23
+     */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    private static final class Metadata {
+        /**
+         * Settings of Artipie server.
+         */
+        private final Settings csettings;
+
+        /**
+         * Ctor.
+         * @param settings Settings
+         */
+        Metadata(final Settings settings) {
+            this.csettings = settings;
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            final boolean res;
+            if (this == obj) {
+                res = true;
+            } else if (obj == null || this.getClass() != obj.getClass()) {
+                res = false;
+            } else {
+                final Pair<Key, Storage> meta = ((Metadata) obj).credsMeta();
+                final Pair<Key, Storage> curr = this.credsMeta();
+                final boolean keys = Key.CMP_STRING.compare(
+                    curr.getLeft(), meta.getLeft()
+                ) == 0;
+                res = keys && meta.getRight().equals(curr.getRight());
+            }
+            return res;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.credsMeta().getLeft().string());
+        }
+
+        /**
+         * Obtains meta information about credentials configuration.
+         * @return Information about credentials configuration.
+         */
+        Pair<Key, Storage> credsMeta() {
+            return Pair.of(
+                new KeyFromPath(
+                    Optional.ofNullable(
+                        this.csettings.meta().yamlMapping("credentials")
+                    ).flatMap(meta -> Optional.ofNullable(meta.string("path")))
+                    .orElseThrow(
+                        () -> new ArtipieException(
+                            String.format(
+                                "Failed to read credentials configuration in \n%s", this.csettings
+                            )
+                        )
+                    )
+                ),
+                this.csettings.storage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/artipie/cache/CredsConfigCache.java
+++ b/src/main/java/com/artipie/cache/CredsConfigCache.java
@@ -4,9 +4,12 @@
  */
 package com.artipie.cache;
 
-import com.artipie.Settings;
-import com.artipie.UsersFromEnv;
-import com.artipie.management.Users;
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Cache for credentials with similar configurations in Artipie settings.
@@ -16,10 +19,11 @@ public interface CredsConfigCache {
     /**
      * Finds credentials by specified in settings configuration cache or creates
      * a new item and caches it.
-     * @param settings Artipie settings
-     * @return Storage
+     * @param storage Storage
+     * @param path Path to the credentials file
+     * @return Yaml credentials
      */
-    Users credentials(Settings settings);
+    CompletionStage<YamlMapping> credentials(Storage storage, Key path);
 
     /**
      * Invalidate all items in cache.
@@ -27,25 +31,24 @@ public interface CredsConfigCache {
     void invalidateAll();
 
     /**
-     * Fake implementation of {@link CredsConfigCache} which
-     * always returns credentials from env.
+     * Fake implementation of {@link CredsConfigCache}.
      * @since 0.23
      */
-    class FromEnv implements CredsConfigCache {
+    class Fake implements CredsConfigCache {
         /**
          * Users credentials.
          */
-        private final Users creds;
+        private final CompletionStage<YamlMapping> creds;
 
         /**
          * Ctor.
          */
-        FromEnv() {
-            this.creds = new UsersFromEnv();
+        public Fake() {
+            this.creds = CompletableFuture.completedFuture(Yaml.createYamlMappingBuilder().build());
         }
 
         @Override
-        public Users credentials(final Settings settings) {
+        public CompletionStage<YamlMapping> credentials(final Storage storage, final Key path) {
             return this.creds;
         }
 

--- a/src/main/java/com/artipie/cache/CredsConfigCache.java
+++ b/src/main/java/com/artipie/cache/CredsConfigCache.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.cache;
+
+import com.artipie.Settings;
+import com.artipie.UsersFromEnv;
+import com.artipie.management.Users;
+
+/**
+ * Cache for credentials with similar configurations in Artipie settings.
+ * @since 0.23
+ */
+public interface CredsConfigCache {
+    /**
+     * Finds credentials by specified in settings configuration cache or creates
+     * a new item and caches it.
+     * @param settings Artipie settings
+     * @return Storage
+     */
+    Users credentials(Settings settings);
+
+    /**
+     * Invalidate all items in cache.
+     */
+    void invalidateAll();
+
+    /**
+     * Fake implementation of {@link CredsConfigCache} which
+     * always returns credentials from env.
+     * @since 0.23
+     */
+    class FromEnv implements CredsConfigCache {
+        /**
+         * Users credentials.
+         */
+        private final Users creds;
+
+        /**
+         * Ctor.
+         */
+        FromEnv() {
+            this.creds = new UsersFromEnv();
+        }
+
+        @Override
+        public Users credentials(final Settings settings) {
+            return this.creds;
+        }
+
+        @Override
+        public void invalidateAll() {
+            // do nothing
+        }
+    }
+}

--- a/src/main/java/com/artipie/cache/SettingsCaches.java
+++ b/src/main/java/com/artipie/cache/SettingsCaches.java
@@ -16,6 +16,12 @@ public interface SettingsCaches {
     StorageConfigCache storageConfig();
 
     /**
+     * Obtains cache for configurations of credentials.
+     * @return Cache for configurations of credentials.
+     */
+    CredsConfigCache credsConfig();
+
+    /**
      * Obtains cache for user logins.
      * @return Cache for user logins.
      */
@@ -37,16 +43,27 @@ public interface SettingsCaches {
         private final StorageConfigCache strgcache;
 
         /**
+         * Cache for configurations of credentials.
+         */
+        private final CredsConfigCache credscache;
+
+        /**
          * Ctor with all initialized caches.
          */
         public All() {
             this.authcache = new CachedUsers();
             this.strgcache = new CachedStorages();
+            this.credscache = new CachedCreds();
         }
 
         @Override
         public StorageConfigCache storageConfig() {
             return this.strgcache;
+        }
+
+        @Override
+        public CredsConfigCache credsConfig() {
+            return this.credscache;
         }
 
         @Override
@@ -71,16 +88,27 @@ public interface SettingsCaches {
         private final StorageConfigCache strgcache;
 
         /**
+         * Cache for configurations of credentials.
+         */
+        private final CredsConfigCache credscache;
+
+        /**
          * Ctor with all fake initialized caches.
          */
         public Fake() {
             this.authcache = new AuthCache.Fake();
             this.strgcache = new StorageConfigCache.Fake();
+            this.credscache = new CredsConfigCache.FromEnv();
         }
 
         @Override
         public StorageConfigCache storageConfig() {
             return this.strgcache;
+        }
+
+        @Override
+        public CredsConfigCache credsConfig() {
+            return this.credscache;
         }
 
         @Override

--- a/src/main/java/com/artipie/cache/SettingsCaches.java
+++ b/src/main/java/com/artipie/cache/SettingsCaches.java
@@ -98,7 +98,7 @@ public interface SettingsCaches {
         public Fake() {
             this.authcache = new AuthCache.Fake();
             this.strgcache = new StorageConfigCache.Fake();
-            this.credscache = new CredsConfigCache.FromEnv();
+            this.credscache = new CredsConfigCache.Fake();
         }
 
         @Override

--- a/src/main/java/com/artipie/misc/ArtipieProperties.java
+++ b/src/main/java/com/artipie/misc/ArtipieProperties.java
@@ -28,12 +28,17 @@ public final class ArtipieProperties {
     /**
      * Expiration time for cache of storage setting.
      */
-    public static final String STORAGE_TIMEOUT = "artipie.storage.cache.timeout";
+    public static final String STORAGE_TIMEOUT = "artipie.storage.file.cache.timeout";
 
     /**
      * Expiration time for cache of configuration files.
      */
     public static final String CONFIG_TIMEOUT = "artipie.config.cache.timeout";
+
+    /**
+     * Expiration time for cache of credential setting.
+     */
+    public static final String CREDS_TIMEOUT = "artipie.credentials.file.cache.timeout";
 
     /**
      * Name of file with properties.

--- a/src/main/resources/artipie.properties
+++ b/src/main/resources/artipie.properties
@@ -1,4 +1,5 @@
 artipie.version=${project.version}
 artipie.config.cache.timeout=120000
 artipie.cached.auth.timeout=300000
-artipie.storage.cache.timeout=180000
+artipie.storage.file.cache.timeout=180000
+artipie.credentials.file.cache.timeout=180000

--- a/src/test/java/com/artipie/UsersFromStorageYamlTest.java
+++ b/src/test/java/com/artipie/UsersFromStorageYamlTest.java
@@ -9,6 +9,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.cache.CachedCreds;
 import com.artipie.management.Users;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -59,7 +60,7 @@ class UsersFromStorageYamlTest {
         final String pass = "111";
         this.creds(sha, Pair.of(jane, pass), Pair.of(john, pass));
         MatcherAssert.assertThat(
-            new UsersFromStorageYaml(this.storage, this.key).list()
+            new UsersFromStorageYaml(this.storage, this.key, new CachedCreds()).list()
                 .toCompletableFuture().join(),
             Matchers.containsInAnyOrder(jane, john)
         );
@@ -74,7 +75,9 @@ class UsersFromStorageYamlTest {
             .saveTo(this.storage, this.key);
         MatcherAssert.assertThat(
             new UsersFromStorageYaml(
-                this.storage, new Key.From(String.format("_cred%s", extension))
+                this.storage,
+                new Key.From(String.format("_cred%s", extension)),
+                new CachedCreds()
             ).list()
             .toCompletableFuture().join(),
             Matchers.containsInAnyOrder(jane, john)
@@ -92,7 +95,7 @@ class UsersFromStorageYamlTest {
         final String pass = "abc";
         final Users.PasswordFormat sha = Users.PasswordFormat.SHA256;
         this.creds(sha, Pair.of(maria, pass));
-        new UsersFromStorageYaml(this.storage, this.key)
+        new UsersFromStorageYaml(this.storage, this.key, new CachedCreds())
             .add(olga, DigestUtils.sha256Hex(pass), sha).toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
@@ -117,7 +120,7 @@ class UsersFromStorageYamlTest {
         final String newpass = "000";
         final Users.PasswordFormat plain = Users.PasswordFormat.PLAIN;
         this.creds(plain, Pair.of(jack, old), Pair.of(silvia, old));
-        new UsersFromStorageYaml(this.storage, this.key)
+        new UsersFromStorageYaml(this.storage, this.key, new CachedCreds())
             .add(silvia, newpass, Users.PasswordFormat.PLAIN).toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
@@ -139,7 +142,8 @@ class UsersFromStorageYamlTest {
         final String pass = "123";
         final Users.PasswordFormat plain = Users.PasswordFormat.PLAIN;
         this.creds(plain, Pair.of(mark, pass), Pair.of(ann, pass));
-        new UsersFromStorageYaml(this.storage, this.key).remove(ann.name())
+        new UsersFromStorageYaml(this.storage, this.key, new CachedCreds())
+            .remove(ann.name())
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())
@@ -155,7 +159,8 @@ class UsersFromStorageYamlTest {
         final String pass = "098";
         final Users.PasswordFormat plain = Users.PasswordFormat.PLAIN;
         this.creds(plain, Pair.of(ted, pass), Pair.of(alex, pass));
-        new UsersFromStorageYaml(this.storage, this.key).remove("alice")
+        new UsersFromStorageYaml(this.storage, this.key, new CachedCreds())
+            .remove("alice")
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             new PublisherAs(this.storage.value(this.key).join())

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -8,13 +8,11 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.amihaiemil.eoyaml.YamlMappingBuilder;
 import com.artipie.asto.SubStorage;
-import com.artipie.asto.ValueNotFoundException;
 import com.artipie.cache.SettingsCaches;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
@@ -174,26 +172,6 @@ class YamlSettingsTest {
         MatcherAssert.assertThat(
             settings.credentials().toCompletableFuture().join(),
             new IsInstanceOf(UsersFromStorageYaml.class)
-        );
-    }
-
-    @Test
-    void failsToGetCredentialsWhenFileIsAbsent(@TempDir final Path tmp) throws IOException {
-        final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), "file", Optional.of("_cred.yml")),
-            new SettingsCaches.All()
-        );
-        Files.writeString(tmp.resolve("_cred_another.yml"), this.credentials());
-        final Exception exc = Assertions.assertThrows(
-            CompletionException.class,
-            () -> settings.credentials()
-                .toCompletableFuture().join()
-                .list()
-                .toCompletableFuture().join()
-        );
-        MatcherAssert.assertThat(
-            exc.getCause(),
-            new IsInstanceOf(ValueNotFoundException.class)
         );
     }
 

--- a/src/test/java/com/artipie/cache/CachedCredsTest.java
+++ b/src/test/java/com/artipie/cache/CachedCredsTest.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.cache;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.ArtipieException;
+import com.artipie.Settings;
+import com.artipie.YamlSettings;
+import com.artipie.management.Users;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link CachedCreds}.
+ * @since 0.23
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class CachedCredsTest {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/some/path/with/prefix", "only/some/path"
+    })
+    void getsValueFromCache(final String path) {
+        final String stpath = "any/storage/path";
+        final CredsConfigCache cache = new CachedCreds();
+        cache.invalidateAll();
+        final Users creds = cache.credentials(CachedCredsTest.config(path, stpath));
+        final Users same = cache.credentials(CachedCredsTest.config(path, stpath));
+        MatcherAssert.assertThat(
+            "Obtained configurations were different",
+            creds.equals(same),
+            new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+            "Storage configuration was not cached",
+            cache.toString(),
+            new StringContains("size=1")
+        );
+    }
+
+    @Test
+    void getsOriginForDifferentConfiguration() {
+        final String stpath = "any/storage/path/also";
+        final CredsConfigCache cache = new CachedCreds();
+        cache.invalidateAll();
+        final Users frst = cache.credentials(CachedCredsTest.config("first", stpath));
+        final Users scnd = cache.credentials(CachedCredsTest.config("second", stpath));
+        MatcherAssert.assertThat(
+            "Obtained configurations were the same",
+            frst.equals(scnd),
+            new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Storage configuration was not cached",
+            cache.toString(),
+            new StringContains("size=2")
+        );
+    }
+
+    @Test
+    void failsToGetCredentialsWhenSectionIsAbsent() {
+        final CredsConfigCache cache = new CachedCreds();
+        cache.invalidateAll();
+        Assertions.assertThrows(
+            ArtipieException.class,
+            () -> cache.credentials(
+                new YamlSettings(
+                    Yaml.createYamlMappingBuilder()
+                        .add("meta", Yaml.createYamlMappingBuilder().build())
+                        .build(),
+                    new SettingsCaches.Fake()
+                )
+            )
+        );
+    }
+
+    @Test
+    void getsOriginForSameConfigurationButDifferentStorages() {
+        final String crpath = "any/creds/path";
+        final CredsConfigCache cache = new CachedCreds();
+        cache.invalidateAll();
+        final Users frst = cache.credentials(CachedCredsTest.config(crpath, "first/strg"));
+        final Users scnd = cache.credentials(CachedCredsTest.config(crpath, "second/strg"));
+        MatcherAssert.assertThat(
+            "Obtained configurations were the same",
+            frst.equals(scnd),
+            new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Storage configuration was not cached",
+            cache.toString(),
+            new StringContains("size=2")
+        );
+    }
+
+    @Test
+    void failsToGetCredentialsWhenPathIsAbsent() {
+        final CredsConfigCache cache = new CachedCreds();
+        cache.invalidateAll();
+        Assertions.assertThrows(
+            ArtipieException.class,
+            () -> cache.credentials(
+                new YamlSettings(
+                    Yaml.createYamlMappingBuilder()
+                        .add(
+                            "meta", Yaml.createYamlMappingBuilder()
+                                .add("credentials", Yaml.createYamlMappingBuilder().build())
+                                .build()
+                        ).build(),
+                    new SettingsCaches.Fake()
+                )
+            )
+        );
+    }
+
+    private static Settings config(final String crpath, final String stpath) {
+        return new YamlSettings(
+            Yaml.createYamlMappingBuilder()
+                .add(
+                    "meta",
+                    Yaml.createYamlMappingBuilder().add(
+                        "credentials",
+                        Yaml.createYamlMappingBuilder()
+                            .add("type", "file")
+                            .add("path", crpath).build()
+                    ).add(
+                        "storage",
+                        Yaml.createYamlMappingBuilder()
+                            .add("type", "fs")
+                            .add("path", stpath)
+                            .build()
+                    ).build()
+                ).build(),
+            new SettingsCaches.All()
+        );
+    }
+}

--- a/src/test/java/com/artipie/cache/CachedCredsTest.java
+++ b/src/test/java/com/artipie/cache/CachedCredsTest.java
@@ -38,7 +38,6 @@ final class CachedCredsTest {
     void getsValueFromCache() {
         final Key path = new Key.From("creds.yaml");
         final CredsConfigCache cache = new CachedCreds();
-        cache.invalidateAll();
         this.storage.save(path, Content.EMPTY).join();
         final YamlMapping creds = cache.credentials(this.storage, path)
             .toCompletableFuture().join();
@@ -59,7 +58,6 @@ final class CachedCredsTest {
     @Test
     void getsOriginForDifferentConfigurations() {
         final CredsConfigCache cache = new CachedCreds();
-        cache.invalidateAll();
         final Key onekey = new Key.From("first.yml");
         final Key twokey = new Key.From("credentials.yml");
         final BlockingStorage blck = new BlockingStorage(this.storage);
@@ -86,7 +84,6 @@ final class CachedCredsTest {
         final String path = "_credentials.yaml";
         final Key key = new Key.From(path);
         final CredsConfigCache cache = new CachedCreds();
-        cache.invalidateAll();
         final Storage another = new InMemoryStorage();
         new TestResource(path).saveTo(this.storage);
         new BlockingStorage(another)


### PR DESCRIPTION
Part of #87 
Added cache for credentials configuration. At first, it reads credentials section from Artipie settings. If this content exists in cache and is not expired, credentials will be loaded from the cache. Otherwise a new instance will be created. Next I'm planning to add more tests