### PR TITLE
refactor: use instance field for cache

### DIFF
--- a/src/main/java/com/artipie/cache/CachedUsers.java
+++ b/src/main/java/com/artipie/cache/CachedUsers.java
@@ -4,12 +4,12 @@
  */
 package com.artipie.cache;
 
+import com.artipie.asto.misc.UncheckedScalar;
 import com.artipie.http.auth.Authentication;
 import com.artipie.misc.ArtipieProperties;
 import com.artipie.misc.Property;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -26,23 +26,31 @@ final class CachedUsers implements AuthCache {
     /**
      * Cache for users.
      */
-    private static LoadingCache<Data, Optional<Authentication.User>> users;
+    private final Cache<Data, Optional<Authentication.User>> users;
 
-    static {
-        CachedUsers.users = CacheBuilder.newBuilder()
-            .expireAfterAccess(
-                //@checkstyle MagicNumberCheck (1 line)
-                new Property(ArtipieProperties.AUTH_TIMEOUT).asLongOrDefault(300_000L),
-                TimeUnit.MILLISECONDS
-            ).softValues()
-            .build(
-                new CacheLoader<>() {
-                    @Override
-                    public Optional<Authentication.User> load(final Data data) {
-                        return data.user();
-                    }
-                }
-            );
+    /**
+     * Ctor.
+     * Here an instance of cache is created. It is important that cache
+     * is a local variable.
+     */
+    CachedUsers() {
+        this(
+            CacheBuilder.newBuilder()
+                .expireAfterAccess(
+                    //@checkstyle MagicNumberCheck (1 line)
+                    new Property(ArtipieProperties.AUTH_TIMEOUT).asLongOrDefault(300_000L),
+                    TimeUnit.MILLISECONDS
+                ).softValues()
+                .build()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param cache Cache for users
+     */
+    CachedUsers(final Cache<Data, Optional<Authentication.User>> cache) {
+        this.users = cache;
     }
 
     @Override
@@ -51,21 +59,22 @@ final class CachedUsers implements AuthCache {
         final String password,
         final Authentication origin
     ) {
-        return CachedUsers.users.getUnchecked(
-            new Data(username, password, origin)
-        );
+        final Data data = new Data(username, password, origin);
+        return new UncheckedScalar<>(
+            () -> this.users.get(data, data::user)
+        ).value();
     }
 
     @Override
     public void invalidateAll() {
-        CachedUsers.users.invalidateAll();
+        this.users.invalidateAll();
     }
 
     @Override
     public String toString() {
         return String.format(
             "%s(size=%d)",
-            this.getClass().getSimpleName(), CachedUsers.users.size()
+            this.getClass().getSimpleName(), this.users.size()
         );
     }
 
@@ -73,7 +82,7 @@ final class CachedUsers implements AuthCache {
      * Extra class for using instance field in static section.
      * @since 0.22
      */
-    private static class Data {
+    static class Data {
         /**
          * Username.
          */

--- a/src/test/java/com/artipie/cache/CachedCredsTest.java
+++ b/src/test/java/com/artipie/cache/CachedCredsTest.java
@@ -49,7 +49,6 @@ final class CachedCredsTest {
     void getsValueFromCache() {
         final Key path = new Key.From("creds.yaml");
         final CredsConfigCache configs = new CachedCreds(this.cache);
-        configs.invalidateAll();
         this.storage.save(path, Content.EMPTY).join();
         final YamlMapping creds = configs.credentials(this.storage, path)
             .toCompletableFuture().join();
@@ -70,7 +69,6 @@ final class CachedCredsTest {
     @Test
     void getsOriginForDifferentConfigurations() {
         final CredsConfigCache configs = new CachedCreds(this.cache);
-        configs.invalidateAll();
         final Key onekey = new Key.From("first.yml");
         final Key twokey = new Key.From("credentials.yml");
         final BlockingStorage blck = new BlockingStorage(this.storage);
@@ -97,7 +95,6 @@ final class CachedCredsTest {
         final String path = "_credentials.yaml";
         final Key key = new Key.From(path);
         final CredsConfigCache configs = new CachedCreds(this.cache);
-        configs.invalidateAll();
         final Storage another = new InMemoryStorage();
         new TestResource(path).saveTo(this.storage);
         new BlockingStorage(another)

--- a/src/test/java/com/artipie/cache/CachedUsersTest.java
+++ b/src/test/java/com/artipie/cache/CachedUsersTest.java
@@ -5,10 +5,14 @@
 package com.artipie.cache;
 
 import com.artipie.http.auth.Authentication;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -18,13 +22,23 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class CachedUsersTest {
+    /**
+     * Cache for users.
+     */
+    private Cache<CachedUsers.Data, Optional<Authentication.User>> cache;
+
+    @BeforeEach
+    void setUp() {
+        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.MINUTES)
+            .softValues().build();
+    }
+
     @Test
     void callsOriginOnlyOnce() {
         final String username = "usr";
         final AtomicInteger counter = new AtomicInteger();
         final String expected = "usr-1";
-        final CachedUsers target = new CachedUsers();
-        target.invalidateAll();
+        final CachedUsers target = new CachedUsers(this.cache);
         MatcherAssert.assertThat(
             "Wrong user on first cache call",
             target.user(
@@ -47,14 +61,18 @@ final class CachedUsersTest {
             ).orElseThrow().name(),
             new IsEqual<>(expected)
         );
+        MatcherAssert.assertThat(
+            "More than one time was cached",
+            this.cache.size(),
+            new IsEqual<>(1L)
+        );
     }
 
     @Test
     void failsToGetUserWhenCacheContainsAnotherUser() {
         final String absent = "absent_user";
         final String cached = "cached_user";
-        final CachedUsers target = new CachedUsers();
-        target.invalidateAll();
+        final CachedUsers target = new CachedUsers(this.cache);
         target.user(
             cached, "", (usr, pass) -> Optional.of(new Authentication.User(cached))
         );
@@ -67,14 +85,18 @@ final class CachedUsersTest {
     @Test
     void getsUserFromCache() {
         final String user = "super_user";
-        final CachedUsers target = new CachedUsers();
-        target.invalidateAll();
+        final CachedUsers target = new CachedUsers(this.cache);
         target.user(
             user, "", (usr, pass) -> Optional.of(new Authentication.User(user))
         );
         MatcherAssert.assertThat(
             target.user(user, "", (usr, pass) -> Optional.empty()).isPresent(),
             new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
+            "Size of cache differed from 1",
+            this.cache.size(),
+            new IsEqual<>(1L)
         );
     }
 }


### PR DESCRIPTION
Closes #87
Used instance field instead of static because this instance is created only once. I didn't refactor static field in `RepositoriesFromStorage` because instances of this class are created many times