### PR TITLE
Avoiding log4j vulnerability CVE-2021-44228

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -4,5 +4,7 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %d %t %c - %m%n
 
+log4j2.formatMsgNoLookups=True
+
 #log4j.logger.com.artipie.MeasuredSlice=DEBUG
 #log4j.logger.com.artipie.MeasuredStorage=DEBUG

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -5,3 +5,6 @@ log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%color{%p}] %t %c: %m%n
 
 log4j.logger.com.artipie=DEBUG
+
+log4j2.formatMsgNoLookups=True
+


### PR DESCRIPTION
Log4j got zero-day vulnerability, which could be mitigated by configuration changes in the commit. More details could be found below:
https://securityonline.info/apache-log4j2-remote-code-execution-vulnerability-alert/
