### PR TITLE
test: cover PromuSlice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,12 +384,12 @@ SOFTWARE.
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.12.0</version>
+      <version>0.14.1</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_common</artifactId>
-      <version>0.12.0</version>
+      <version>0.14.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/artipie/http/PromuSlice.java
+++ b/src/main/java/com/artipie/http/PromuSlice.java
@@ -4,18 +4,22 @@
  */
 package com.artipie.http;
 
+import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.http.headers.Accept;
 import com.artipie.http.headers.ContentType;
+import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsFull;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.metrics.Metrics;
 import com.artipie.metrics.publish.MetricsOutput;
 import com.artipie.metrics.publish.PrometheusOutput;
 import com.google.common.base.Splitter;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,13 +29,10 @@ import org.reactivestreams.Publisher;
 
 /**
  * Slice that allows Prometheus to collect metrics (pull strategy).
+ *
  * @see <a href="https://prometheus.io/docs/practices/instrumentation/#offline-processing"/>
  * @since 0.23
- * @todo #889:30min Test that {@link PromuSlice}'s response is correct.
- *  We implemented {@link PromuSlice} in a way that Prometheus can pull
- *  model via that. Now, we should check that its response is correct.
- *  We should also add an integration test to be sure that configuration
- *  is taken into account.
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class PromuSlice implements Slice {
 
@@ -52,40 +53,50 @@ public final class PromuSlice implements Slice {
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
         final String ctype = new Accept(headers).values().get(0);
-        final StringWriter writer = new StringWriter();
-        final Set<String> filters = PromuSlice.params(line, "name");
-        final MetricsOutput output = new PrometheusOutput(writer, ctype, filters);
-        this.metrics.publish(output);
-        return new RsFull(
-            RsStatus.OK,
-            new Headers.From(new ContentType(ctype)),
-            new Content.From(
-                String.valueOf(writer.getBuffer()).getBytes(StandardCharsets.UTF_8)
-            )
-        );
+        try (StringWriter writer = new StringWriter()) {
+            final Set<String> filters = PromuSlice.params(line, "name");
+            final MetricsOutput output = new PrometheusOutput(writer, ctype, filters);
+            this.metrics.publish(output);
+            return new RsFull(
+                RsStatus.OK,
+                new Headers.From(new ContentType(ctype)),
+                new Content.From(
+                    writer.toString().getBytes(StandardCharsets.UTF_8)
+                )
+            );
+        } catch (final IOException ioe) {
+            throw new ArtipieIOException(ioe);
+        }
     }
 
     /**
      * Get all params with name in query.
-     * @param query Query
+     * @param line Line
      * @param name Name
      * @return All params with this name
      */
-    private static Set<String> params(final String query, final String name) {
-        return StreamSupport.stream(
-            Splitter.on("&").omitEmptyStrings().split(query).spliterator(),
-            false
-        ).flatMap(
-            param -> {
-                final String prefix = String.format("%s=", name);
-                final Stream<String> value;
-                if (param.startsWith(prefix)) {
-                    value = Stream.of(param.substring(prefix.length()));
-                } else {
-                    value = Stream.empty();
+    private static Set<String> params(final String line, final String name) {
+        final Set<String> values;
+        final String query = new RequestLineFrom(line).uri().getQuery();
+        if (query == null) {
+            values = new HashSet<>();
+        } else {
+            values = StreamSupport.stream(
+                Splitter.on("&").omitEmptyStrings().split(query).spliterator(),
+                false
+            ).flatMap(
+                param -> {
+                    final String prefix = String.format("%s=", name);
+                    final Stream<String> value;
+                    if (param.startsWith(prefix)) {
+                        value = Stream.of(param.substring(prefix.length()));
+                    } else {
+                        value = Stream.empty();
+                    }
+                    return value;
                 }
-                return value;
-            }
-        ).collect(Collectors.toSet());
+            ).collect(Collectors.toSet());
+        }
+        return values;
     }
 }

--- a/src/main/java/com/artipie/metrics/memory/InMemoryMetrics.java
+++ b/src/main/java/com/artipie/metrics/memory/InMemoryMetrics.java
@@ -47,7 +47,7 @@ public final class InMemoryMetrics implements Metrics {
         out.counters(counters);
         final Map<String, Long> gauges = new HashMap<>(this.ggs.size());
         for (final Map.Entry<String, InMemoryGauge> entry : this.ggs.entrySet()) {
-            counters.put(entry.getKey(), entry.getValue().value());
+            gauges.put(entry.getKey(), entry.getValue().value());
         }
         out.gauges(gauges);
     }

--- a/src/test/java/com/artipie/http/PromuSliceTest.java
+++ b/src/test/java/com/artipie/http/PromuSliceTest.java
@@ -1,0 +1,329 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.http;
+
+import com.artipie.asto.Content;
+import com.artipie.http.headers.Accept;
+import com.artipie.http.headers.ContentType;
+import com.artipie.http.headers.Header;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.metrics.Metrics;
+import com.artipie.metrics.memory.InMemoryMetrics;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.AnyOf;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.text.MatchesPattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link PromuSlice}.
+ *
+ * @see <a href="https://sysdig.com/blog/prometheus-metrics/"/>
+ * @since 0.23
+ * @todo #978:30min Add an IT test for PromuSlice.
+ *  We should add an integration test to be sure that meta configuration
+ *  of Prometheus is taken into account.
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle ParameterNumberCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle MethodNameCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class PromuSliceTest {
+
+    /**
+     * Openmetrics text mime type.
+     */
+    private static final String OPENMETRICS_TEXT = "application/openmetrics-text";
+
+    /**
+     * Plain text mime type.
+     */
+    private static final String PLAIN_TEXT = "text/plain";
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "http.response.length,500,counter,text/plain",
+            "http.response.length,500,counter,application/openmetrics-text",
+            "app.used.memory,200,gauge,text/plain",
+            "app.used.memory,200,gauge,application/openmetrics-text"
+        }
+    )
+    void producesMetrics(
+        final String name, final long value,
+        final String type, final String mimetype
+    ) {
+        final Metrics metrics = new InMemoryMetrics();
+        collect(metrics, name, value, type);
+        MatcherAssert.assertThat(
+            new PromuSlice(metrics),
+            new SliceHasResponse(
+                new AllOf<>(
+                    Arrays.asList(
+                        new RsHasStatus(RsStatus.OK),
+                        new RsHasHeaders(
+                            new IsEqual<>(new Header(ContentType.NAME, mimetype)),
+                            new IsAnything<>()
+                        ),
+                        new RsHasBody(
+                            new MatchesPattern(
+                                Pattern.compile(
+                                    metricFormatted(name, value, type, mimetype)
+                                )
+                            ),
+                            StandardCharsets.UTF_8
+                        )
+                    )
+                ),
+                new RequestLine(RqMethod.GET, "/prometheus/metrics"),
+                new Headers.From(Accept.NAME, mimetype),
+                Content.EMPTY
+            )
+        );
+    }
+
+    @Test
+    void returnsMetricsThatMatchNames() {
+        final Metrics metrics = new InMemoryMetrics();
+        metrics.counter("http.response.count").inc();
+        metrics.gauge("http.response.content").set(5000L);
+        metrics.gauge("app.workload").set(300L);
+        MatcherAssert.assertThat(
+            new PromuSlice(metrics),
+            new SliceHasResponse(
+                new RsHasBody(
+                    new AnyOf<>(
+                        new IsEqual<>(
+                            String.join(
+                                "\n",
+                                "# HELP http_response_content Http response content",
+                                "# TYPE http_response_content gauge",
+                                "http_response_content 5000.0",
+                                "# HELP app_workload App workload",
+                                "# TYPE app_workload gauge",
+                                "app_workload 300.0",
+                                ""
+                            )
+                        ),
+                        new IsEqual<>(
+                            String.join(
+                                "\n",
+                                "# HELP app_workload App workload",
+                                "# TYPE app_workload gauge",
+                                "app_workload 300.0",
+                                "# HELP http_response_content Http response content",
+                                "# TYPE http_response_content gauge",
+                                "http_response_content 5000.0",
+                                ""
+                            )
+                        )
+                    ),
+                    StandardCharsets.UTF_8
+                ),
+                new RequestLine(
+                    RqMethod.GET,
+                    "/prometheus/metrics?name=http_response_content&name=app_workload"
+                ),
+                new Headers.From(
+                    new Header(Accept.NAME, PromuSliceTest.PLAIN_TEXT)
+                ),
+                Content.EMPTY
+            )
+        );
+    }
+
+    /**
+     * Collect locally a metric.
+     * @param metrics All metrics
+     * @param name Metric name
+     * @param value Metric value
+     * @param type Metric type
+     */
+    private static void collect(
+        final Metrics metrics,
+        final String name,
+        final long value,
+        final String type
+    ) {
+        switch (type) {
+            case "counter":
+                metrics.counter(name).add(value);
+                break;
+            case "gauge":
+                metrics.gauge(name).set(value);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown metric type");
+        }
+    }
+
+    /**
+     * Formats metric in Prometheus text/plain.
+     * @param name Metric name
+     * @param value Metric value
+     * @param type Metric type
+     * @return Text formatted
+     */
+    private static String metricInPlainText(
+        final String name,
+        final long value,
+        final String type
+    ) {
+        final double dvalue = value;
+        final String nname = normalize(name);
+        final String help = help(name);
+        final String text;
+        switch (type) {
+            case "counter":
+                text = String.format(
+                    Locale.ENGLISH,
+                    String.join(
+                        "\n",
+                        "# HELP %s_total %s",
+                        "# TYPE %s_total counter",
+                        "%s_total %.1f",
+                        "# HELP %s_created %s",
+                        "# TYPE %s_created gauge",
+                        "%s_created [0-9]*\\.?[0-9]+(E[0-9]+)?",
+                        ""
+                    ),
+                    nname, help, nname, nname, dvalue, nname, help, nname, nname
+                );
+                break;
+            case "gauge":
+                text = String.format(
+                    Locale.ENGLISH,
+                    String.join(
+                        "\n",
+                        "# HELP %s %s",
+                        "# TYPE %s gauge",
+                        "%s %.1f",
+                        ""
+                    ),
+                    nname, help, nname, nname, dvalue
+                );
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown metric type");
+        }
+        return text;
+    }
+
+    /**
+     * Formats metric in Prometheus application/openmetrics-text.
+     * @param name Metric name
+     * @param value Metric value
+     * @param type Metric type
+     * @return Text formatted
+     */
+    private static String metricInOpenmetricsText(
+        final String name,
+        final long value,
+        final String type
+    ) {
+        final double dvalue = value;
+        final String nname = normalize(name);
+        final String help = help(name);
+        final String text;
+        switch (type) {
+            case "counter":
+                text = String.format(
+                    Locale.ENGLISH,
+                    String.join(
+                        "\n",
+                        "# TYPE %s counter",
+                        "# HELP %s %s",
+                        "%s_total %.1f",
+                        "%s_created [0-9]*\\.?[0-9]+(E[0-9]+)?",
+                        "# EOF",
+                        ""
+                    ),
+                    nname, nname, help, nname, dvalue, nname
+                );
+                break;
+            case "gauge":
+                text = String.format(
+                    Locale.ENGLISH,
+                    String.join(
+                        "\n",
+                        "# TYPE %s gauge",
+                        "# HELP %s %s",
+                        "%s %.1f",
+                        "# EOF",
+                        ""
+                    ),
+                    nname, nname, help, nname, dvalue
+                );
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown metric type");
+        }
+        return text;
+    }
+
+    /**
+     * Metric formatted according to mime type.
+     * @param name Name
+     * @param value Value
+     * @param type Metric type
+     * @param mimetype Mime type
+     * @return Metric formatted
+     */
+    private static String metricFormatted(
+        final String name,
+        final long value,
+        final String type,
+        final String mimetype
+    ) {
+        final String body;
+        switch (mimetype) {
+            case PromuSliceTest.PLAIN_TEXT:
+                body = metricInPlainText(name, value, type);
+                break;
+            case PromuSliceTest.OPENMETRICS_TEXT:
+                body = metricInOpenmetricsText(name, value, type);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown mime type");
+        }
+        return body;
+    }
+
+    /**
+     * Normalizes metrics name.
+     * @param name Name
+     * @return Normalized name
+     */
+    private static String normalize(final String name) {
+        return name.replaceAll("\\.", "_");
+    }
+
+    /**
+     * Builds help from name.
+     * @param name Name
+     * @return Help
+     */
+    private static String help(final String name) {
+        return StringUtils.capitalize(
+            name.replaceAll("\\.", " ")
+        );
+    }
+}


### PR DESCRIPTION
- Introduce tests that check that `PromuSlice` not only produces metrics in the right format according to accepted mime type but also returns only metrics that match to specified names as filters.
- Add a todo for integration testing about availability of `PromuSlice` when we set up `Prometheus` in `meta` configuration.

Close: #978