### PR TITLE
refactor: replace params method in PromuSlice

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -55,4 +55,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: g4s8/pdd-action@v1.0.0
+      - uses: g4s8/pdd-action@master

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v0.26.1</version>
+      <version>v1.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/http/PromuSlice.java
+++ b/src/main/java/com/artipie/http/PromuSlice.java
@@ -20,7 +20,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import org.reactivestreams.Publisher;
 

--- a/src/main/java/com/artipie/http/PromuSlice.java
+++ b/src/main/java/com/artipie/http/PromuSlice.java
@@ -9,22 +9,19 @@ import com.artipie.asto.Content;
 import com.artipie.http.headers.Accept;
 import com.artipie.http.headers.ContentType;
 import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rq.RqParams;
 import com.artipie.http.rs.RsFull;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.metrics.Metrics;
 import com.artipie.metrics.publish.MetricsOutput;
 import com.artipie.metrics.publish.PrometheusOutput;
-import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.reactivestreams.Publisher;
 
 /**
@@ -54,8 +51,14 @@ public final class PromuSlice implements Slice {
         final Publisher<ByteBuffer> body) {
         final String ctype = new Accept(headers).values().get(0);
         try (StringWriter writer = new StringWriter()) {
-            final Set<String> filters = PromuSlice.params(line, "name");
-            final MetricsOutput output = new PrometheusOutput(writer, ctype, filters);
+            final MetricsOutput output = new PrometheusOutput(
+                writer, ctype,
+                new HashSet<>(
+                    new RqParams(
+                        new RequestLineFrom(line).uri()
+                    ).values("name")
+                )
+            );
             this.metrics.publish(output);
             return new RsFull(
                 RsStatus.OK,
@@ -67,36 +70,5 @@ public final class PromuSlice implements Slice {
         } catch (final IOException ioe) {
             throw new ArtipieIOException(ioe);
         }
-    }
-
-    /**
-     * Get all params with name in query.
-     * @param line Line
-     * @param name Name
-     * @return All params with this name
-     */
-    private static Set<String> params(final String line, final String name) {
-        final Set<String> values;
-        final String query = new RequestLineFrom(line).uri().getQuery();
-        if (query == null) {
-            values = new HashSet<>();
-        } else {
-            values = StreamSupport.stream(
-                Splitter.on("&").omitEmptyStrings().split(query).spliterator(),
-                false
-            ).flatMap(
-                param -> {
-                    final String prefix = String.format("%s=", name);
-                    final Stream<String> value;
-                    if (param.startsWith(prefix)) {
-                        value = Stream.of(param.substring(prefix.length()));
-                    } else {
-                        value = Stream.empty();
-                    }
-                    return value;
-                }
-            ).collect(Collectors.toSet());
-        }
-        return values;
     }
 }


### PR DESCRIPTION
A new method has been introduced in `RqParams` (artipie/http) that allow us to obtain all values of a
query parameter. We refactored `PromuSlice` with this new method.

Ref: #978