### PR TITLE
fix: report exceptions as error in ResponseMetricsSlice

### DIFF
--- a/src/main/java/com/artipie/ResponseMetricsSlice.java
+++ b/src/main/java/com/artipie/ResponseMetricsSlice.java
@@ -23,10 +23,6 @@ import org.reactivestreams.Publisher;
  * Returned response reported to metrics as success or error if it's status code is 4xx or 5xx.
  *
  * @since 0.9
- * @todo #231:30min Report exceptions as errors in `ResponseMetricsSlice`.
- *  In case of exceptions in origin slice handling or sending to `Connection` nothing is reported
- *  to `Metrics`. It needs to be fixed, so if origin slice fails or we failed to send response
- *  then error is sent to `Metrics`.
  */
 public final class ResponseMetricsSlice implements Slice {
 

--- a/src/main/java/com/artipie/ResponseMetricsSlice.java
+++ b/src/main/java/com/artipie/ResponseMetricsSlice.java
@@ -4,6 +4,7 @@
  */
 package com.artipie;
 
+import com.artipie.http.ArtipieHttpException;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.headers.Authorization;
@@ -51,16 +52,25 @@ public final class ResponseMetricsSlice implements Slice {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Response response(
         final String rqline,
         final Iterable<Map.Entry<String, String>> rqheaders,
         final Publisher<ByteBuffer> rqbody) {
-        return connection -> this.origin.response(rqline, rqheaders, rqbody).send(
-            (rsstatus, rsheaders, rsbody) -> {
-                this.report(rqline, rqheaders, rsstatus);
-                return connection.accept(rsstatus, rsheaders, rsbody);
+        return connection -> {
+            try {
+                return this.origin.response(rqline, rqheaders, rqbody).send(
+                    (rsstatus, rsheaders, rsbody) -> {
+                        this.report(rqline, rqheaders, rsstatus);
+                        return connection.accept(rsstatus, rsheaders, rsbody);
+                    }
+                );
+            // @checkstyle IllegalCatchCheck (1 line)
+            } catch (final Exception exc) {
+                this.report(rqline, rqheaders, RsStatus.INTERNAL_ERROR);
+                throw new ArtipieHttpException(RsStatus.INTERNAL_ERROR, exc);
             }
-        );
+        };
     }
 
     /**
@@ -76,9 +86,16 @@ public final class ResponseMetricsSlice implements Slice {
         final RsStatus rsstatus
     ) {
         if (rsstatus.error()) {
-            this.report(rqline, "error");
-            if (rsstatus.equals(RsStatus.UNAUTHORIZED)) {
-                this.reportUnauthorized(rqline, rqheaders);
+            switch (rsstatus) {
+                case UNAUTHORIZED:
+                    this.reportUnauthorized(rqline, rqheaders);
+                    break;
+                case INTERNAL_ERROR:
+                    this.report(rqline, "error.internal");
+                    break;
+                default:
+                    this.report(rqline, "error");
+                    break;
             }
         } else {
             this.report(rqline, "success");

--- a/src/test/java/com/artipie/ResponseMetricsSliceTest.java
+++ b/src/test/java/com/artipie/ResponseMetricsSliceTest.java
@@ -57,7 +57,7 @@ class ResponseMetricsSliceTest {
         this.send(RqMethod.POST, new RsWithStatus(RsStatus.INTERNAL_ERROR));
         this.send(RqMethod.POST, new RsWithStatus(RsStatus.INTERNAL_ERROR));
         MatcherAssert.assertThat(
-            this.metrics.counter("post.error").value(),
+            this.metrics.counter("post.error.internal").value(),
             new IsEqual<>(2L)
         );
     }


### PR DESCRIPTION
We catch exceptions and send them to metrics.

Fix: #273