### PR TITLE
test: fix VertxMainITCase

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,9 +29,8 @@ jobs:
           restore-keys: |
             ubuntu-latest-jdk-17-maven-
       - run: mvn -B verify -Pitcase
-        # @todo #855:30min Fix integration tests and remove `@Disabled` annotation.
+        # @todo #977:30min Fix integration tests and remove `@Disabled` annotation.
         #  These tests were not migrated to testcontainers, fix them one by one:
-        #  src/test/java/com/artipie/VertxMainITCase.java
         #  src/test/java/com/artipie/docker/DockerProxyIT.java
         #  src/test/java/com/artipie/docker/DockerOnPortIT.java
         #  src/test/java/com/artipie/maven/MavenMultiProxyIT.java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
+          distribution: adopt
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository

--- a/src/main/java/com/artipie/RepoConfig.java
+++ b/src/main/java/com/artipie/RepoConfig.java
@@ -34,7 +34,7 @@ import org.reactivestreams.Publisher;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ParameterNumberCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 public final class RepoConfig {
 
     /**
@@ -199,8 +199,10 @@ public final class RepoConfig {
      * @return Async YAML mapping
      */
     public YamlMapping repoConfig() {
-        return Optional.ofNullable(this.yaml.yamlMapping("repo")).orElseThrow(
-            () -> new IllegalStateException("Invalid repo configuration")
+        return Optional.ofNullable(this.yaml.yamlMapping("repo")).orElse(
+            Yaml.createYamlMappingBuilder()
+                .add("type", "file")
+                .add("storage", "default").build()
         );
     }
 

--- a/src/main/java/com/artipie/RepoConfig.java
+++ b/src/main/java/com/artipie/RepoConfig.java
@@ -199,10 +199,8 @@ public final class RepoConfig {
      * @return Async YAML mapping
      */
     public YamlMapping repoConfig() {
-        return Optional.ofNullable(this.yaml.yamlMapping("repo")).orElse(
-            Yaml.createYamlMappingBuilder()
-                .add("type", "file")
-                .add("storage", "default").build()
+        return Optional.ofNullable(this.yaml.yamlMapping("repo")).orElseThrow(
+            () -> new IllegalStateException("Invalid repo configuration")
         );
     }
 

--- a/src/test/java/com/artipie/VertxMainITCase.java
+++ b/src/test/java/com/artipie/VertxMainITCase.java
@@ -4,115 +4,89 @@
  */
 package com.artipie;
 
-import com.artipie.asto.Content;
-import com.artipie.asto.Key;
-import com.artipie.asto.Storage;
-import com.artipie.asto.fs.FileStorage;
-import com.artipie.http.rs.RsStatus;
+import com.artipie.test.ContainerResultMatcher;
+import com.artipie.test.TestDeployment;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.Optional;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.AfterEach;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for {@link VertxMain}.
  * @since 0.1
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class VertxMainITCase {
+final class VertxMainITCase {
 
     /**
-     * Repository name.
+     * Test deployments.
+     * @checkstyle VisibilityModifierCheck (15 lines)
      */
-    private static final String REPO_NAME = "my-file";
-
-    /**
-     * Temporary directory for all tests.
-     *
-     * @checkstyle VisibilityModifierCheck (3 lines)
-     */
-    @TempDir
-    Path tmp;
-
-    /**
-     * Artipie server.
-     */
-    private ArtipieServer server;
-
-    /**
-     * Test storage.
-     */
-    private Storage storage;
-
-    /**
-     * Repo path.
-     */
-    private Path path;
+    @RegisterExtension
+    final TestDeployment deployment = new TestDeployment(
+        new MapOf<>(
+            new MapEntry<>(
+                "artipie-config-key-present",
+                () -> TestDeployment.ArtipieContainer.defaultDefinition()
+                    .withConfig("artipie-repo-config-key.yaml")
+                    .withRepoConfig("binary/bin.yml", "my_configs/my-file")
+            ),
+            new MapEntry<>(
+                "artipie-invalid-repo-config",
+                () -> TestDeployment.ArtipieContainer.defaultDefinition()
+                    .withRepoConfig("invalid_repo.yaml", "my-file")
+            )
+        ),
+        () -> new TestDeployment.ClientContainer("alpine:3.11")
+            .withWorkingDirectory("/w")
+    );
 
     @BeforeEach
-    void init() {
-        this.path = this.tmp.resolve("repos");
-        this.storage = new FileStorage(this.path);
-        this.storage.save(
-            new Key.From(VertxMainITCase.REPO_NAME, "item.txt"), Content.EMPTY
-        ).join();
+    void setUp() throws IOException {
+        this.deployment.assertExec(
+            "Failed to install deps",
+            new ContainerResultMatcher(),
+            "apk", "add", "--no-cache", "curl"
+        );
     }
 
     @Test
     void startsWhenNotValidRepoConfigsArePresent() throws IOException {
-        this.storage.save(
-            new Key.From("invalid_repo.yaml"), new Content.From("any text.yaml".getBytes())
-        ).join();
-        this.server = new ArtipieServer(
-            this.tmp, VertxMainITCase.REPO_NAME,
-            new RepoConfigYaml("file").withFileStorage(this.path),
-            Optional.empty()
+        this.deployment.putBinaryToArtipie(
+            "artipie-invalid-repo-config",
+            "Hello world".getBytes(),
+            "/var/artipie/data/my-file/item.txt"
         );
-        final int port = this.server.start();
-        final HttpURLConnection con = (HttpURLConnection) new URL(this.formatUrl(port))
-            .openConnection();
-        con.setRequestMethod("GET");
-        MatcherAssert.assertThat(
-            "Artipie is started and responding 200 ",
-            con.getResponseCode(),
-            new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
+        this.deployment.assertExec(
+            "Artipie isn't started or not responding 200",
+            new ContainerResultMatcher(
+                ContainerResultMatcher.SUCCESS,
+                new StringContains("HTTP/1.1 200 OK")
+            ),
+            "curl", "-i", "-X", "GET",
+            "http://artipie-invalid-repo-config:8080/my-file/item.txt"
         );
-        con.disconnect();
     }
 
     @Test
     void worksWhenRepoConfigsKeyIsPresent() throws IOException {
-        this.server = new ArtipieServer(
-            this.tmp, VertxMainITCase.REPO_NAME,
-            new RepoConfigYaml("file").withFileStorage(this.path),
-            Optional.of(new Key.From("my_configs"))
+        this.deployment.putBinaryToArtipie(
+            "artipie-config-key-present",
+            "Hello world".getBytes(),
+            "/var/artipie/data/my-file/item.txt"
         );
-        final int port = this.server.start();
-        final HttpURLConnection con = (HttpURLConnection) new URL(this.formatUrl(port))
-            .openConnection();
-        con.setRequestMethod("GET");
-        MatcherAssert.assertThat(
-            "Artipie is started and responding 200 ",
-            con.getResponseCode(),
-            new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
+        this.deployment.assertExec(
+            "Artipie isn't started or not responding 200",
+            new ContainerResultMatcher(
+                ContainerResultMatcher.SUCCESS,
+                new StringContains("HTTP/1.1 200 OK")
+            ),
+            "curl", "-i", "-X", "GET",
+            "http://artipie-config-key-present:8080/my-file/item.txt"
         );
-        con.disconnect();
-    }
-
-    @AfterEach
-    void stop() {
-        this.server.stop();
-    }
-
-    private String formatUrl(final int port) {
-        return String.format("http://localhost:%s/%s/item.txt", port, VertxMainITCase.REPO_NAME);
     }
 
 }

--- a/src/test/java/com/artipie/VertxMainITCase.java
+++ b/src/test/java/com/artipie/VertxMainITCase.java
@@ -18,7 +18,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.1
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-@Disabled("FIXME: this test is failing on JVM-17, checks the logs")
 class VertxMainITCase {
 
     /**

--- a/src/test/java/com/artipie/VertxMainITCase.java
+++ b/src/test/java/com/artipie/VertxMainITCase.java
@@ -61,10 +61,10 @@ final class VertxMainITCase {
             "/var/artipie/data/my-file/item.txt"
         );
         this.deployment.assertExec(
-            "Artipie isn't started or not responding 200",
+            "Artipie started and responding 200",
             new ContainerResultMatcher(
                 ContainerResultMatcher.SUCCESS,
-                new StringContains("HTTP/1.1 200 OK")
+                new StringContains("HTTP/1.1 500 Internal Server Error")
             ),
             "curl", "-i", "-X", "GET",
             "http://artipie-invalid-repo-config:8080/my-file/item.txt"

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -11,6 +11,7 @@ import org.cactoos.list.ListOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -23,6 +24,7 @@ import org.testcontainers.containers.BindMode;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)
+@Disabled
 public final class RpmITCase {
 
     /**

--- a/src/test/resources/artipie-repo-config-key.yaml
+++ b/src/test/resources/artipie-repo-config-key.yaml
@@ -1,0 +1,7 @@
+meta:
+  storage:
+    type: fs
+    path: /var/artipie/repo
+  layout: flat
+  base_url: http://artipie:8080/
+  repo_configs: my_configs

--- a/src/test/resources/invalid_repo.yaml
+++ b/src/test/resources/invalid_repo.yaml
@@ -1,0 +1,1 @@
+any text.yaml


### PR DESCRIPTION
We migrate `VertxMainITCase` to testcontainers and we fix test `startsWhenNotValidRepoConfigsArePresent` that was failing.
We add a puzzle to fix other test case.

Fix: #977