### PR TITLE
fix: GithubAuth should return empty Optional when authentication is failed

### DIFF
--- a/src/main/java/com/artipie/auth/GithubAuth.java
+++ b/src/main/java/com/artipie/auth/GithubAuth.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.auth;
 
+import com.artipie.ArtipieException;
 import com.artipie.http.auth.Authentication;
 import com.jcabi.github.RtGithub;
 import java.io.IOException;
@@ -13,9 +14,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.cactoos.scalar.Not;
-import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.Contains;
 
 /**
  * GitHub authentication uses username prefixed by provider name {@code github.com}
@@ -75,14 +73,9 @@ public final class GithubAuth implements Authentication {
                     result = Optional.of(new Authentication.User(login));
                 }
             } catch (final AssertionError error) {
-                if (
-                    new Unchecked<>(
-                        new Not(
-                            new Contains(error.getMessage(), "401 Unauthorized")
-                        )
-                    ).value()
-                ) {
-                    throw error;
+                if (error.getMessage() == null
+                    || !error.getMessage().contains("401 Unauthorized")) {
+                    throw new ArtipieException(error);
                 }
             }
         }

--- a/src/test/java/com/artipie/auth/GithubAuthTest.java
+++ b/src/test/java/com/artipie/auth/GithubAuthTest.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.auth;
 
+import com.artipie.ArtipieException;
 import com.artipie.http.auth.Authentication;
 import java.util.Optional;
 import org.cactoos.text.Joined;
@@ -56,7 +57,7 @@ final class GithubAuthTest {
     @Test
     void shouldThrownExceptionWhenAssertionErrorIsHappened() {
         Assertions.assertThrows(
-            AssertionError.class,
+            ArtipieException.class,
             () -> new GithubAuth(
                 token -> {
                     throw new AssertionError("Any error");

--- a/src/test/java/com/artipie/auth/GithubAuthTest.java
+++ b/src/test/java/com/artipie/auth/GithubAuthTest.java
@@ -5,8 +5,11 @@
 package com.artipie.auth;
 
 import com.artipie.http.auth.Authentication;
+import java.util.Optional;
+import org.cactoos.text.Joined;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,6 +33,35 @@ final class GithubAuthTest {
                 }
             ).user("github.com/UsEr", secret).orElseThrow(),
             new IsEqual<>(new Authentication.User("user"))
+        );
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyWhenRequestIsUnauthorized() {
+        MatcherAssert.assertThat(
+            new GithubAuth(
+                token -> {
+                    throw new AssertionError(
+                        new Joined(
+                            "HTTP response status is not equal to 200:\n",
+                            "401 Unauthorized [https://api.github.com/user]"
+                        )
+                    );
+                }
+            ).user("github.com/bad_user", "bad_secret"),
+            new IsEqual<>(Optional.empty())
+        );
+    }
+
+    @Test
+    void shouldThrownExceptionWhenAssertionErrorIsHappened() {
+        Assertions.assertThrows(
+            AssertionError.class,
+            () -> new GithubAuth(
+                token -> {
+                    throw new AssertionError("Any error");
+                }
+            ).user("github.com/user", "pwd")
         );
     }
 }


### PR DESCRIPTION
Closes #406 

- added auth error handling to `GithubAuth`
- added tests for cases when auth is failed and any other error happens