### PR TITLE
feat: alternative authentication

### DIFF
--- a/src/main/java/com/artipie/UsersFromGithub.java
+++ b/src/main/java/com/artipie/UsersFromGithub.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletionStage;
  * Credentials from GitHub.
  * @since 0.12.2
  */
-public class UsersFromGithub implements Users {
+public final class UsersFromGithub implements Users {
     @Override
     public CompletionStage<List<User>> list() {
         return CompletableFuture.failedFuture(

--- a/src/main/java/com/artipie/UsersFromGithub.java
+++ b/src/main/java/com/artipie/UsersFromGithub.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie;
+
+import com.artipie.auth.GithubAuth;
+import com.artipie.http.auth.Authentication;
+import com.artipie.management.Users;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Credentials from GitHub.
+ * @since 0.12.2
+ */
+public class UsersFromGithub implements Users {
+    @Override
+    public CompletionStage<List<User>> list() {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("Listing users is not supported")
+        );
+    }
+
+    @Override
+    public CompletionStage<Void> add(
+        final User user,
+        final String pswd,
+        final PasswordFormat format
+    ) {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("Adding users is not supported")
+        );
+    }
+
+    @Override
+    public CompletionStage<Void> remove(final String username) {
+        return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("Removing users is not supported")
+        );
+    }
+
+    @Override
+    public CompletionStage<Authentication> auth() {
+        return CompletableFuture.completedFuture(new GithubAuth());
+    }
+}

--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -5,8 +5,6 @@ meta:
   credentials:
     type: file
     path: _credentials.yaml
-    alternative_auth:
-      type: github
   layout: org
   base_url: http://central.artipie.com/
   metrics:

--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -5,6 +5,8 @@ meta:
   credentials:
     type: file
     path: _credentials.yaml
+    alternative_auth:
+      type: github
   layout: org
   base_url: http://central.artipie.com/
   metrics:

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -75,7 +75,7 @@ class YamlSettingsTest {
     @Test
     void shouldBuildFileStorageFromSettings() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", credentials("env")),
+            this.config("some/path", this.credentials("env")),
             new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
@@ -113,7 +113,7 @@ class YamlSettingsTest {
     @Test
     void shouldCreateAuthFromEnv() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", credentials("env")),
+            this.config("some/path", this.credentials("env")),
             new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
@@ -125,7 +125,7 @@ class YamlSettingsTest {
     @Test
     void shouldCreateGithub() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", credentials("github")),
+            this.config("some/path", this.credentials("github")),
             new SettingsCaches.All()
         );
         MatcherAssert.assertThat(
@@ -141,7 +141,7 @@ class YamlSettingsTest {
         final YamlSettings settings = new YamlSettings(
             this.config(
                 tmp.toString(),
-                credentials("env")
+                this.credentials("env")
                     .add(
                         "alternative_auth",
                         Yaml.createYamlMappingBuilder()
@@ -197,7 +197,7 @@ class YamlSettingsTest {
         throws Exception {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), credentials("file", Optional.of(fname))),
+            this.config(tmp.toString(), this.credentials("file", Optional.of(fname))),
             new SettingsCaches.All()
         );
         final Path yaml = tmp.resolve(fname);
@@ -212,7 +212,7 @@ class YamlSettingsTest {
     void returnsCredentials(@TempDir final Path tmp) throws IOException {
         final String fname = "_cred.yml";
         final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), credentials("file", Optional.of(fname))),
+            this.config(tmp.toString(), this.credentials("file", Optional.of(fname))),
             new SettingsCaches.All()
         );
         final Path yaml = tmp.resolve(fname);
@@ -228,7 +228,7 @@ class YamlSettingsTest {
         final String fname = "_cred.yml";
         final SettingsCaches cache = new SettingsCaches.All();
         final YamlSettings settings = new YamlSettings(
-            this.config(tmp.toString(), credentials("file", Optional.of(fname))),
+            this.config(tmp.toString(), this.credentials("file", Optional.of(fname))),
             cache
         );
         Files.writeString(tmp.resolve(fname), this.credentials());
@@ -255,7 +255,7 @@ class YamlSettingsTest {
     void returnsRepoConfigs(@TempDir final Path tmp) {
         MatcherAssert.assertThat(
             new YamlSettings(
-                this.config(tmp.toString(), credentials("file")),
+                this.config(tmp.toString(), this.credentials("file")),
                 new SettingsCaches.Fake()
             ).repoConfigsStorage(),
             new IsInstanceOf(SubStorage.class)
@@ -265,7 +265,7 @@ class YamlSettingsTest {
     @Test
     void shouldThrowExceptionWhenPathIsNotSet() {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path", credentials("file", Optional.empty())),
+            this.config("some/path", this.credentials("file", Optional.empty())),
             new SettingsCaches.Fake()
         );
         MatcherAssert.assertThat(
@@ -322,7 +322,7 @@ class YamlSettingsTest {
     }
 
     private YamlMappingBuilder credentials(final String type) {
-        return credentials(type, Optional.empty());
+        return this.credentials(type, Optional.empty());
     }
 
     private YamlMappingBuilder credentials(
@@ -343,7 +343,8 @@ class YamlSettingsTest {
         return Yaml.createYamlMappingBuilder()
             .add(
                 "meta",
-                Yaml.createYamlMappingBuilder().add(
+                Yaml.createYamlMappingBuilder()
+                    .add(
                         "storage",
                         Yaml.createYamlMappingBuilder()
                             .add("type", "fs")

--- a/src/test/java/com/artipie/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/YamlSettingsTest.java
@@ -6,7 +6,7 @@ package com.artipie;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
-import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import com.amihaiemil.eoyaml.YamlNode;
 import com.artipie.asto.SubStorage;
 import com.artipie.cache.SettingsCaches;
 import java.io.IOException;
@@ -141,20 +141,23 @@ class YamlSettingsTest {
         final YamlSettings settings = new YamlSettings(
             this.config(
                 tmp.toString(),
-                this.credentials("env")
+                Yaml.createYamlSequenceBuilder()
                     .add(
-                        "alternative_auth",
                         Yaml.createYamlMappingBuilder()
-                            .add("type", "github")
-                            .add(
-                                "alternative_auth",
-                                Yaml.createYamlMappingBuilder()
-                                    .add("type", "file")
-                                    .add("path", fname)
-                                    .build()
-                            )
+                            .add("type", "file")
+                            .add("path", fname)
                             .build()
                     )
+                    .add(
+                        Yaml.createYamlMappingBuilder()
+                            .add("type", "env")
+                            .build()
+                    )
+                    .add(
+                        Yaml.createYamlMappingBuilder()
+                            .add("type", "github")
+                            .build()
+                    ).build()
             ),
             new SettingsCaches.All()
         );
@@ -321,11 +324,11 @@ class YamlSettingsTest {
         );
     }
 
-    private YamlMappingBuilder credentials(final String type) {
+    private YamlNode credentials(final String type) {
         return this.credentials(type, Optional.empty());
     }
 
-    private YamlMappingBuilder credentials(
+    private YamlNode credentials(
         final String type,
         final Optional<String> path
     ) {
@@ -333,12 +336,12 @@ class YamlSettingsTest {
             val -> Yaml.createYamlMappingBuilder()
                 .add("type", type)
                 .add("path", val)
-        ).orElse(Yaml.createYamlMappingBuilder().add("type", type));
+        ).orElse(Yaml.createYamlMappingBuilder().add("type", type)).build();
     }
 
     private YamlMapping config(
         final String stpath,
-        final YamlMappingBuilder creds
+        final YamlNode creds
     ) {
         return Yaml.createYamlMappingBuilder()
             .add(
@@ -350,7 +353,7 @@ class YamlSettingsTest {
                             .add("type", "fs")
                             .add("path", stpath).build()
                     )
-                    .add("credentials", creds.build())
+                    .add("credentials", creds)
                     .add("repo_configs", "repos")
                     .build()
             ).build();


### PR DESCRIPTION
Closes #337 

- added an opportunity to set Github auth in YAML settings
- added an opportunity to set a few authentications in YAML settings
```
 credentials:
    -
      type: file
      path: _credentials.yaml
    -
      type: env
```
If there is only one type of credentials, then it can be set up as before
```
 credentials:
      type: file
      path: _credentials.yaml
```
- added tests to check Github auth and alternative authentication
