### PR TITLE
fix(pdd): exclude some doc files

### DIFF
--- a/.pdd
+++ b/.pdd
@@ -17,6 +17,9 @@
 --exclude .idea/**/*
 --exclude examples/**/*
 --exclude examples/helm/tomcat-0.4.1.tgz
+--exclude CHANGELOG.md
+--exclude CODE_OF_CONDUCT.md
+--exclude CONTRIBUTING.md
 --rule min-words:20
 --rule min-estimate:15
 --rule max-estimate:90


### PR DESCRIPTION
We noticed that sometimes we can use the keyword `@todo` in `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` without it being a puzzle. But `pdd` will fail on that saying that it doesn't match to puzzle format.
We decided to exclude them all from pdd checking.

Cc: [commit-b281fbd9](https://github.com/artipie/artipie/commit/b281fbd957752567387e707f090cfd5b52fc931a#commitcomment-65919004)