### PR TITLE
fix: corrected RpmITCase to use fedora instead of sentos 8

### DIFF
--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -11,7 +11,6 @@ import org.cactoos.list.ListOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -24,7 +23,6 @@ import org.testcontainers.containers.BindMode;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)
-@Disabled
 public final class RpmITCase {
 
     /**
@@ -35,7 +33,7 @@ public final class RpmITCase {
     final TestDeployment containers = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
             .withRepoConfig("rpm/my-rpm.yml", "my-rpm"),
-        () -> new TestDeployment.ClientContainer("centos:centos8")
+        () -> new TestDeployment.ClientContainer("fedora:35")
             .withClasspathResourceMapping(
                 "rpm/time-1.7-45.el7.x86_64.rpm", "/w/time-1.7-45.el7.x86_64.rpm",
                 BindMode.READ_ONLY
@@ -45,9 +43,7 @@ public final class RpmITCase {
     @BeforeEach
     void setUp() throws IOException {
         this.containers.assertExec(
-            "Yum install curl failed",
-            new ContainerResultMatcher(),
-            "yum", "-y", "install", "curl"
+            "Dnf install curl failed", new ContainerResultMatcher(), "dnf", "-y", "install", "curl"
         );
         this.containers.putBinaryToClient(
             String.join(
@@ -75,7 +71,7 @@ public final class RpmITCase {
                 new IsEqual<>(0),
                 new StringContainsInOrder(new ListOf<>("time-1.7-45.el7.x86_64", "Complete!"))
             ),
-            "yum", "-y", "repo-pkgs", "example", "install"
+            "dnf", "-y", "repository-packages", "example", "install"
         );
     }
 


### PR DESCRIPTION
Closes #993 
Sentos 8 went EOL in December 2021, so I've corrected the test to use fedora 35 and dnf.