### PR TITLE
test: DockerProxyIT migrated to testcontainers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,8 +29,6 @@ jobs:
           restore-keys: |
             ubuntu-latest-jdk-17-maven-
       - run: mvn -B verify -Pitcase
-        # @todo #977:30min Fix integration tests and remove `@Disabled` annotation.
-        #  These tests were not migrated to testcontainers, fix them one by one:
-        #  src/test/java/com/artipie/docker/DockerProxyIT.java
+        # @todo #996:30min Fix integration test and remove `@Disabled` annotation.
+        #  This test is not migrated to testcontainers:
         #  src/test/java/com/artipie/docker/DockerOnPortIT.java
-        #  src/test/java/com/artipie/maven/MavenMultiProxyIT.java

--- a/src/test/resources/docker/docker-proxy.yml
+++ b/src/test/resources/docker/docker-proxy.yml
@@ -1,0 +1,5 @@
+repo:
+  type: docker-proxy
+  remotes:
+    - url: registry-1.docker.io
+    - url: mcr.microsoft.com


### PR DESCRIPTION
Closes #996 

- Migrated DockerProxyIT to test containers
- added a puzzle to refactor tests that require executing several steps like DockerProxyIT or DockerLocalITCase
- add a puzzle to fix DockerOnPortIT test