### PR TITLE
test: `DockerOnPortIT` migrated to testcontainres; testcontainres config as string

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,3 @@ jobs:
           restore-keys: |
             ubuntu-latest-jdk-17-maven-
       - run: mvn -B verify -Pitcase
-        # @todo #996:30min Fix integration test and remove `@Disabled` annotation.
-        #  The test DockerOnPortIT is not migrated to testcontainers,
-        #  we should fix it.
-        #  src/test/java/com/artipie/docker/DockerOnPortIT.java

--- a/src/test/java/com/artipie/test/TestDeployment.java
+++ b/src/test/java/com/artipie/test/TestDeployment.java
@@ -283,7 +283,18 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
      * @throws IOException On error
      */
     public void setUpForDockerTests() throws IOException {
-        // @checkstyle MethodBodyCommentsCheck (10 lines)
+        // @checkstyle MagicNumberCheck (2 lines)
+        this.setUpForDockerTests(8080);
+    }
+
+    /**
+     * Sets up client environment for docker tests.
+     *
+     * @param port Artipie port
+     * @throws IOException On error
+     */
+    public void setUpForDockerTests(final int port) throws IOException {
+        // @checkstyle MethodBodyCommentsCheck (18 lines)
         // @checkstyle LineLengthCheck (10 lines)
         this.clientExec("apk", "add", "--update", "--no-cache", "openrc", "docker");
         // needs this command to initialize openrc directories on first call
@@ -291,7 +302,14 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
         // this flag file is needed to tell openrc working in non-boot mode
         this.clientExec("touch", "/run/openrc/softlevel");
         // allow artipie:8080 insecure connection before starting docker daemon
-        this.clientExec("sed", "-i", "s/DOCKER_OPTS=\"\"/DOCKER_OPTS=\"--insecure-registry=artipie:8080\"/g", "/etc/conf.d/docker");
+        this.clientExec(
+            "sed", "-i",
+            String.format(
+                "s/DOCKER_OPTS=\"\"/DOCKER_OPTS=\"--insecure-registry=artipie:%d\"/g",
+                port
+            ),
+            "/etc/conf.d/docker"
+        );
         this.clientExec("rc-service", "docker", "start");
         // docker daemon needs some time to start after previous command
         this.clientExec("sleep", "3");

--- a/src/test/java/com/artipie/test/TestDeployment.java
+++ b/src/test/java/com/artipie/test/TestDeployment.java
@@ -7,6 +7,9 @@ package com.artipie.test;
 
 import com.artipie.rpm.misc.UncheckedConsumer;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -321,6 +324,7 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
 
         /**
          * New artipie container with image name.
+         *
          * @param name Image name
          */
         public ArtipieContainer(final DockerImageName name) {
@@ -328,7 +332,18 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
         }
 
         /**
+         * New defaut definition.
+         *
+         * @return Default container definition
+         */
+        @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+        public static ArtipieContainer defaultDefinition() {
+            return new ArtipieContainer().withConfig("artipie.yaml");
+        }
+
+        /**
          * With artipie config file.
+         *
          * @param res Config resource name
          * @return Self
          */
@@ -339,7 +354,46 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
         }
 
         /**
+         * With artipie config.
+         *
+         * @param temp Temp directory
+         * @param cfg Config
+         * @return Self
+         */
+        public ArtipieContainer withConfig(
+            final Path temp,
+            final String cfg
+        ) {
+            return this.withFileSystemBind(
+                write(temp, cfg, "artipie"),
+                "/etc/artipie/artipie.yml",
+                BindMode.READ_ONLY
+            );
+        }
+
+        /**
          * With repository configuration.
+         *
+         * @param temp Temp directory
+         * @param config Repo config
+         * @param repo Repository name
+         * @return Self
+         */
+        public ArtipieContainer withRepoConfig(
+            final Path temp,
+            final String config,
+            final String repo
+        ) {
+            return this.withFileSystemBind(
+                write(temp, config, repo),
+                String.format("/var/artipie/repo/%s.yaml", repo),
+                BindMode.READ_ONLY
+            );
+        }
+
+        /**
+         * With repository configuration.
+         *
          * @param res Config resource path
          * @param repo Repository name
          * @return Self
@@ -351,8 +405,27 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
         }
 
         /**
-         * With repository configuration.
-         * @param res Config resource path
+         * With credentials.
+         *
+         * @param temp Temp directory
+         * @param cred Credentials
+         * @return Self
+         */
+        public ArtipieContainer withCredentials(
+            final Path temp,
+            final String cred
+        ) {
+            return this.withFileSystemBind(
+                write(temp, cred, "_credentials.yaml"),
+                "/var/artipie/repo/_credentials.yaml",
+                BindMode.READ_ONLY
+            );
+        }
+
+        /**
+         * With credentials.
+         *
+         * @param res Credentials resource path
          * @return Self
          */
         public ArtipieContainer withCredentials(final String res) {
@@ -363,6 +436,25 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
 
         /**
          * With repository permissions.
+         *
+         * @param temp Temp directory
+         * @param perms Permissions
+         * @return Self
+         */
+        public ArtipieContainer withPermissions(
+            final Path temp,
+            final String perms
+        ) {
+            return this.withFileSystemBind(
+                write(temp, perms, "_permissions.yaml"),
+                "/var/artipie/repo/_permissions.yaml",
+                BindMode.READ_ONLY
+            );
+        }
+
+        /**
+         * With repository permissions.
+         *
          * @param res Config resource path
          * @return Self
          */
@@ -373,12 +465,32 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
         }
 
         /**
-         * New defaut definition.
-         * @return Default container definition
+         * Write yaml to a file in the temp directory.
+         *
+         * @param temp Temp directory
+         * @param yaml Yaml content
+         * @param name File name prefix
+         * @return Path to the yaml resource
          */
-        @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-        public static ArtipieContainer defaultDefinition() {
-            return new ArtipieContainer().withConfig("artipie.yaml");
+        private static String write(
+            final Path temp,
+            final String yaml,
+            final String name
+        ) {
+            try {
+                final Path res = temp.resolve(
+                    String.format("%s%d.yaml", name, yaml.hashCode())
+                );
+                if (res.toFile().exists()) {
+                    Files.delete(res);
+                }
+                return Files.write(
+                    res,
+                    yaml.getBytes()
+                ).toString();
+            } catch (final IOException err) {
+                throw new UncheckedIOException(err);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1005 
Closes #1009 

- added overridden methods to `com.artipie.test.TestDeployment.ArtipieContainer` that let to specify a config as a string
- test `DockerOnPortIT` migrated to testcontainres