### PR TITLE
deps: bump `conda-adapter` from `v0.5.2` to `v0.5.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>conda-adapter</artifactId>
-      <version>v0.5.2</version>
+      <version>v0.5.3</version>
     </dependency>
     <dependency>
       <groupId>wtf.g4s8</groupId>


### PR DESCRIPTION
This version fixes conda smoke test.

Ref: #995