### PR TITLE
feat: add docker-compose.yaml and correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ docker-compose up
 ```
 
 It'll start a new Docker container with latest Artipie and Artipie dashboard service image. 
+Containers should share same config directory, default local mount location is `/usr/local/artipie`,
+you may need to correct it if docker client is running not on linux operating system.
 A new image generate default configuration if not found at `/etc/artipie/artipie.yml`, prints initial
 credentials to console and prints a link to the dashboard. If started on localhost with command
 above, the dashboard URI is `http://localhost:8080/dashboard/artipie` and default username and password 
-are `artipie/artipie`. Artipie server side (repositories) are served on `8081` port and are 
+are `artipie/artipie`. Artipie server side (repositories) is served on `8081` port and is 
 available on URI `http://localhost:8081/artipie/{reponame}`, where `{reponame}` is the name of the
 repository.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ docker-compose up
 It'll start a new Docker container with latest Artipie and Artipie dashboard service image. 
 A new image generate default configuration if not found at `/etc/artipie/artipie.yml`, prints initial
 credentials to console and prints a link to the dashboard. If started on localhost with command
-above, the dashboard URI is http://localhost:8080/dashboard/artipie and default username and password 
-are `artipie/artipie`.
+above, the dashboard URI is `http://localhost:8080/dashboard/artipie` and default username and password 
+are `artipie/artipie`. Artipie server side (repositories) are served on `8081` port and are 
+available on URI `http://localhost:8081/artipie/{reponame}`, where `{reponame}` is the name of the
+repository.
 
 
 To create a new artifact repository:

--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ The following set of features makes Artipie unique among all others:
     [Rpm](./examples/rpm),
     and [others](./examples)
   * It is database-free
-  * It can host the data in the file system,
-    [Amazon S3](https://aws.amazon.com/s3/),
-    [Google Cloud](https://cloud.google.com/products/storage/),
-    [HuaweiCloud OBS](https://www.huaweicloud.com/en-us/product/obs.html) etc.
+  * It can host the data in the file system or [Amazon S3](https://aws.amazon.com/s3/)
   * Its quality of Java code is extraordinary high :)
 
 # Quickstart

--- a/README.md
+++ b/README.md
@@ -44,31 +44,35 @@ The following set of features makes Artipie unique among all others:
 # Quickstart
 
 The fastest way to start using Artipie is via
-[Docker](https://docs.docker.com/get-docker/):
+[Docker-compose](https://docs.docker.com/compose/), use 
+[`docker-compose.yaml`](https://github.com/artipie/artipie/blob/master/docker-compose.yaml) to run 
+the service:
 
 ```bash
-docker run --rm --name artipie -p 8080:8080 --user=artipie:artipie artipie/artipie:latest
+docker-compose up
 ```
 
-It'll start a new Docker container with latest Artipie image. A new image generates
-default server config if not found at `/etc/artipie/artipie.yml`, prints initial
+It'll start a new Docker container with latest Artipie and Artipie dashboard service image. 
+A new image generate default configuration if not found at `/etc/artipie/artipie.yml`, prints initial
 credentials to console and prints a link to the dashboard. If started on localhost with command
-above, the dashboard URI is http://localhost:8080/dashboard/artipie.
+above, the dashboard URI is http://localhost:8080/dashboard/artipie and default username and password 
+are `artipie/artipie`.
 
 
 To create a new artifact repository:
  1. Go to the dashboard
  2. Enter the name of a new repository, choose a type, and click button "Add"
- 3. Artipie generates standard configuration for this kind of repository, and
+ 3. Artipie generates standard configuration for selected kind of repository, and
   asks for review or edit. You can ignore this step for now.
  4. Below the repository configuration, the page will have a simple configuration
   for your client, and usage examples, e.g. the code for `pom.xml` for Maven repository.
 
 Default server configuration refers to `/var/artipie/repos` to look up for repository configurations.
-You may want to mount local configurations here to edit it manually by adding `docker run` mount option:
-`-v <your-local-config-dir>:/var/artipie/repo`, where `<your-local-config-dir>` is you local config directory.<br/>
-**Important:** check that `<your-local-config-dir>` has correct permissions, it should be `2020:2021`, to change it correctly use
-`chown -R 2020:2021 <your-local-config-dir>`.
+You may want to mount local configurations to `/var/artipie/repos` to edit it manually by changing
+`volumes` values inside `docker-compose` script.
+
+**Important:** check that `<your-local-config-dir>` has correct permissions, it should be `2020:2021`, 
+to change it correctly use `chown -R 2020:2021 <your-local-config-dir>`.
 
 
 More examples are [here](./examples).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
       - ARTIPIE_USER_PASS=artipie
     networks:
       - artipie-net
+    ports:
+      - "8081:8080"
   front:
     image: artipie/front:latest
     container_name: front
@@ -21,6 +23,8 @@ services:
       - TKN_KEY=abc123
     volumes:
       - configs:/var/artipie/repo
+    ports:
+      - "8080:8080"
 
 volumes:
   configs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     ports:
       - "8081:8080"
     volumes:
-      - configs:/var/artipie/repo
+      - /usr/local/artipie:/var/artipie/repo
   front:
     image: artipie/front:latest
     container_name: front
@@ -24,12 +24,9 @@ services:
       - ARTIPIE_USER_PASS=artipie
       - TKN_KEY=abc123
     volumes:
-      - configs:/var/artipie/repo
+      - /usr/local/artipie:/var/artipie/repo
     ports:
       - "8080:8080"
-
-volumes:
-  configs:
 
 networks:
   artipie-net:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: "3.3"
+services:
+  artipie:
+    image: artipie/artipie:latest
+    container_name: artipie
+    restart: unless-stopped
+    environment:
+      - ARTIPIE_USER_NAME=artipie
+      - ARTIPIE_USER_PASS=artipie
+    networks:
+      - artipie-net
+  front:
+    image: artipie/front:latest
+    container_name: front
+    restart: unless-stopped
+    networks:
+      - artipie-net
+    environment:
+      - ARTIPIE_USER_NAME=artipie
+      - ARTIPIE_USER_PASS=artipie
+      - TKN_KEY=abc123
+    volumes:
+      - configs:/var/artipie/repo
+
+volumes:
+  configs:
+
+networks:
+  artipie-net:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       - artipie-net
     ports:
       - "8081:8080"
+    volumes:
+      - configs:/var/artipie/repo
   front:
     image: artipie/front:latest
     container_name: front

--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -3,8 +3,13 @@ meta:
     type: fs
     path: /var/artipie/repo
   credentials:
-    type: file
-    path: _credentials.yaml
+    -
+      type: env
+    -
+      type: github
+    -
+      type: file
+      path: _credentials.yml
   layout: org
   base_url: http://central.artipie.com/
   metrics:

--- a/src/main/resources/example/repo/_storages.yaml
+++ b/src/main/resources/example/repo/_storages.yaml
@@ -1,4 +1,4 @@
 storages:
   default:
     type: fs
-    path: ./.storage/data
+    path: /var/artipie/repo/data


### PR DESCRIPTION
Closes #1028 
Added docker-compose script to run both Artipie and Artipie front, corrected readme. 

Note, that I'm not a devops and have no idea about best practicies for such type of configurations.