### PR TITLE
fix: casesensitive username in auth from github

### DIFF
--- a/src/main/java/com/artipie/auth/GithubAuth.java
+++ b/src/main/java/com/artipie/auth/GithubAuth.java
@@ -70,7 +70,7 @@ public final class GithubAuth implements Authentication {
                 if (
                     Objects.equals(login, matcher.group(1).toLowerCase(Locale.US))
                 ) {
-                    result = Optional.of(new Authentication.User(login));
+                    result = Optional.of(new Authentication.User(matcher.group(1)));
                 }
             } catch (final AssertionError error) {
                 if (error.getMessage() == null

--- a/src/test/java/com/artipie/auth/GithubAuthTest.java
+++ b/src/test/java/com/artipie/auth/GithubAuthTest.java
@@ -33,7 +33,7 @@ final class GithubAuthTest {
                     return "";
                 }
             ).user("github.com/UsEr", secret).orElseThrow(),
-            new IsEqual<>(new Authentication.User("user"))
+            new IsEqual<>(new Authentication.User("UsEr"))
         );
     }
 


### PR DESCRIPTION
Closes #1032

Corrected `GithubAuth` to use case-sensitive username as it was passed by user in auth header. 
Usernames in Artipie (in `_credeentials.yaml` and use from env) are generally case-sensitive, so here we should follow the same idea. 
Github usernames are not case-sensitive, thus we compare usernames ignoring capitals and inside Artipie use case-sensitive usernames as they were passed by users. In permissions (repositories and API) usernames should case-sensitively correspond usernames, passed in auth header.