### PR TITLE
fix: repository port usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
 VOLUME /var/artipie /etc/artipie
 WORKDIR /var/artipie
 EXPOSE 8080
-EXPOSE 8081
 CMD [ \
   "java", \
   "--add-opens", "java.base/java.util=ALL-UNNAMED", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
 VOLUME /var/artipie /etc/artipie
 WORKDIR /var/artipie
 EXPOSE 8080
+EXPOSE 8081
 CMD [ \
   "java", \
   "--add-opens", "java.base/java.util=ALL-UNNAMED", \

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -116,16 +116,12 @@ public final class SliceFromConfig extends Slice.Wrap {
         );
         switch (cfg.type()) {
             case "file":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new FilesSlice(cfg.storage(), permissions, auth)
+                slice = new TrimPathSlice(
+                    new FilesSlice(cfg.storage(), permissions, auth), settings.layout().pattern()
                 );
                 break;
             case "file-proxy":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new FileProxy(http, cfg)
-                );
+                slice = new TrimPathSlice(new FileProxy(http, cfg), settings.layout().pattern());
                 break;
             case "npm":
                 slice = trimIfNotStandalone(

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -124,85 +124,63 @@ public final class SliceFromConfig extends Slice.Wrap {
                 slice = new TrimPathSlice(new FileProxy(http, cfg), settings.layout().pattern());
                 break;
             case "npm":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new NpmSlice(
-                        cfg.url(),
-                        cfg.storage(),
-                        permissions,
-                        auth
-                    )
+                slice = new TrimPathSlice(
+                    new NpmSlice(cfg.url(), cfg.storage(), permissions, auth),
+                    settings.layout().pattern()
                 );
                 break;
             case "gem":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new GemSlice(
-                        cfg.storage()
-                    )
-                );
+                slice = new TrimPathSlice(new GemSlice(cfg.storage()), settings.layout().pattern());
                 break;
             case "helm":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new HelmSlice(
-                        cfg.storage(),
-                        cfg.path(),
-                        permissions,
-                        auth
-                    )
+                slice = new TrimPathSlice(
+                    new HelmSlice(cfg.storage(), cfg.path(), permissions, auth),
+                    settings.layout().pattern()
                 );
                 break;
             case "rpm":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
+                slice = new TrimPathSlice(
                     new RpmSlice(
                         cfg.storage(), permissions, auth,
                         new com.artipie.rpm.RepoConfig.FromYaml(cfg.settings())
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             case "php":
-                slice = trimIfNotStandalone(
-                    settings, standalone, new PhpComposer(
+                slice = new TrimPathSlice(
+                    new PhpComposer(
                         new AstoRepository(cfg.storage(), Optional.of(cfg.url().toString()))
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             case "php-proxy":
-                slice = trimIfNotStandalone(
-                    settings,
-                    standalone,
-                    new ComposerProxy(http, cfg)
+                slice = new TrimPathSlice(
+                    new ComposerProxy(http, cfg), settings.layout().pattern()
                 );
                 break;
             case "nuget":
-                slice = trimIfNotStandalone(
-                    settings,
-                    standalone,
+                slice = new TrimPathSlice(
                     new NuGet(
                         cfg.url(),
                         new com.artipie.nuget.AstoRepository(cfg.storage()),
                         permissions,
                         auth
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             case "maven":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new MavenSlice(cfg.storage(), permissions, auth)
+                slice = new TrimPathSlice(
+                    new MavenSlice(cfg.storage(), permissions, auth), settings.layout().pattern()
                 );
                 break;
             case "maven-proxy":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new MavenProxy(http, cfg)
-                );
+                slice = new TrimPathSlice(new MavenProxy(http, cfg), settings.layout().pattern());
                 break;
             case "maven-group":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
+                slice = new TrimPathSlice(
                     new GroupSlice(
                         cfg.settings().orElseThrow().yamlSequence("repositories").values()
                             .stream().map(node -> node.asScalar().value())
@@ -216,13 +194,13 @@ public final class SliceFromConfig extends Slice.Wrap {
                                         )
                                 )
                             ).collect(Collectors.toList())
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             case "go":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new GoSlice(cfg.storage(), permissions, auth)
+                slice = new TrimPathSlice(
+                    new GoSlice(cfg.storage(), permissions, auth), settings.layout().pattern()
                 );
                 break;
             case "npm-proxy":
@@ -238,16 +216,12 @@ public final class SliceFromConfig extends Slice.Wrap {
                 );
                 break;
             case "pypi":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new PySlice(cfg.storage(), permissions, auth)
+                slice = new TrimPathSlice(
+                    new PySlice(cfg.storage(), permissions, auth), settings.layout().pattern()
                 );
                 break;
             case "pypi-proxy":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
-                    new PypiProxy(http, cfg)
-                );
+                slice = new TrimPathSlice(new PypiProxy(http, cfg), settings.layout().pattern());
                 break;
             case "docker":
                 final Docker docker = new AstoDocker(
@@ -273,21 +247,21 @@ public final class SliceFromConfig extends Slice.Wrap {
                 slice = new DockerProxy(http, standalone, cfg, permissions, auth);
                 break;
             case "deb":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
+                slice = new TrimPathSlice(
                     new DebianSlice(
                         cfg.storage(), permissions, auth,
                         new Config.FromYaml(cfg.name(), cfg.settings(), settings.storage())
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             case "conda":
-                slice = trimIfNotStandalone(
-                    settings, standalone,
+                slice = new TrimPathSlice(
                     new CondaSlice(
                         cfg.storage(), permissions, auth, cfg.url().toString(),
                         new CondaConfig(cfg.settings()).authTokenTtl()
-                    )
+                    ),
+                    settings.layout().pattern()
                 );
                 break;
             default:
@@ -300,25 +274,5 @@ public final class SliceFromConfig extends Slice.Wrap {
                 .<Slice>map(limit -> new ContentLengthRestriction(slice, limit))
                 .orElse(slice)
         );
-    }
-
-    /**
-     * Wraps origin slice if into TrimPathSlice if it is not standalone.
-     *
-     * @param settings Artipie settings
-     * @param standalone Standalone flag
-     * @param origin Origin slice
-     * @return Origin slice wrapped if needed
-     */
-    private static Slice trimIfNotStandalone(
-        final Settings settings, final boolean standalone, final Slice origin
-    ) {
-        final Slice result;
-        if (standalone) {
-            result = origin;
-        } else {
-            result = new TrimPathSlice(origin, settings.layout().pattern());
-        }
-        return result;
     }
 }

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -176,23 +176,16 @@ public final class VertxMain {
                         final String name = new ConfigFile(repo.name()).name();
                         this.listenOn(
                             new ArtipieRepositories(this.http, settings).slice(
-                                new Key.From(name),
-                                true
-                            ),
-                            metrics, prt
+                                new Key.From(name), prt
+                            ), metrics, prt
                         );
                         Logger.info(
-                            VertxMain.class,
-                            "Artipie repo '%s' was started on port %d", name, prt
+                            VertxMain.class, "Artipie repo '%s' was started on port %d", name, prt
                         );
                     }
                 );
             } catch (final IllegalStateException err) {
-                Logger.error(
-                    this,
-                    "Invalid repo config file %s: %[exception]s", repo.name(),
-                    err
-                );
+                Logger.error(this, "Invalid repo config file %s: %[exception]s", repo.name(), err);
             }
         }
         new QuartzScheduler(configs).start();

--- a/src/main/java/com/artipie/http/ArtipieRepositories.java
+++ b/src/main/java/com/artipie/http/ArtipieRepositories.java
@@ -49,17 +49,17 @@ public final class ArtipieRepositories {
     /**
      * Find slice by name.
      * @param name Repository name
-     * @param standalone Standalone flag
+     * @param port Repository port
      * @return Repository slice
      */
-    public Slice slice(final Key name, final boolean standalone) {
+    public Slice slice(final Key name, final int port) {
         final Storage storage = this.settings.repoConfigsStorage();
         return new AsyncSlice(
             new ConfigFile(name).existsIn(storage).thenCompose(
                 exists -> {
                     final CompletionStage<Slice> res;
                     if (exists) {
-                        res = this.resolve(storage, name, standalone);
+                        res = this.resolve(storage, name, port);
                     } else {
                         res = CompletableFuture.completedFuture(
                             new SliceSimple(new RsRepoNotFound(name))
@@ -75,21 +75,27 @@ public final class ArtipieRepositories {
      * Resolve async {@link Slice} by provided configuration.
      * @param storage Artipie config storage
      * @param name Repository name
-     * @param standalone Standalone flag
+     * @param port Repository port
      * @return Async slice for repo
      * @checkstyle ParameterNumberCheck (2 lines)
      */
     private CompletionStage<Slice> resolve(
         final Storage storage,
         final Key name,
-        final boolean standalone
+        final int port
     ) {
         return new RepositoriesFromStorage(this.http, storage).config(name.string()).thenCombine(
             StorageAliases.find(storage, name),
-            (config, aliases) -> new SliceFromConfig(
-                this.http, this.settings,
-                config, aliases, standalone
-            )
+            (config, aliases) -> {
+                Slice res = new SliceSimple(new RsRepoNotFound(name));
+                if (config.port().isEmpty() || config.port().getAsInt() == port) {
+                    res = new SliceFromConfig(
+                        this.http, this.settings,
+                        config, aliases, config.port().isPresent()
+                    );
+                }
+                return res;
+            }
         );
     }
 

--- a/src/main/java/com/artipie/http/ArtipieRepositories.java
+++ b/src/main/java/com/artipie/http/ArtipieRepositories.java
@@ -87,12 +87,14 @@ public final class ArtipieRepositories {
         return new RepositoriesFromStorage(this.http, storage).config(name.string()).thenCombine(
             StorageAliases.find(storage, name),
             (config, aliases) -> {
-                Slice res = new SliceSimple(new RsRepoNotFound(name));
+                final Slice res;
                 if (config.port().isEmpty() || config.port().getAsInt() == port) {
                     res = new SliceFromConfig(
                         this.http, this.settings,
                         config, aliases, config.port().isPresent()
                     );
+                } else {
+                    res = new SliceSimple(new RsRepoNotFound(name));
                 }
                 return res;
             }

--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -59,7 +59,8 @@ final class SliceByPath implements Slice {
                 StandardCharsets.UTF_8
             );
         }
-        return new ArtipieRepositories(this.http, this.settings).slice(key.get(), false)
+        return new ArtipieRepositories(this.http, this.settings)
+            .slice(key.get(), new RequestLineFrom(line).uri().getPort())
             .response(line, headers, body);
     }
 }

--- a/src/test/java/com/artipie/composer/PhpComposerITCase.java
+++ b/src/test/java/com/artipie/composer/PhpComposerITCase.java
@@ -14,6 +14,10 @@ import org.testcontainers.containers.BindMode;
 /**
  * Integration test for Composer repo.
  * @since 0.18
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class PhpComposerITCase {

--- a/src/test/java/com/artipie/composer/PhpComposerITCase.java
+++ b/src/test/java/com/artipie/composer/PhpComposerITCase.java
@@ -14,10 +14,10 @@ import org.testcontainers.containers.BindMode;
 /**
  * Integration test for Composer repo.
  * @since 0.18
- * @todo #1041:30min Add test cases with repository on individual port: create one more
- *  repository with `port` settings and start it in Artipie container exposing the port with
- *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
- *  ports. Check `FileITCase` as an example.
+ * @todo #1041:30min PhpComposerITCase: Add test cases with repository on individual port: create
+ *  one more repository with `port` settings and start it in Artipie container exposing the port
+ *  with `withExposedPorts` method. Then, parameterize test cases to check repositories with
+ *  different ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class PhpComposerITCase {

--- a/src/test/java/com/artipie/conda/CondaITCase.java
+++ b/src/test/java/com/artipie/conda/CondaITCase.java
@@ -24,6 +24,10 @@ import org.testcontainers.containers.BindMode;
  * Conda IT case.
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @EnabledOnOs({OS.LINUX, OS.MAC})
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/com/artipie/conda/CondaITCase.java
+++ b/src/test/java/com/artipie/conda/CondaITCase.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.BindMode;
  * Conda IT case.
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min CondaITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/debian/DebianITCase.java
+++ b/src/test/java/com/artipie/debian/DebianITCase.java
@@ -21,7 +21,7 @@ import org.testcontainers.containers.BindMode;
  * Debian integration test.
  * @since 0.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min DebianIT: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/debian/DebianITCase.java
+++ b/src/test/java/com/artipie/debian/DebianITCase.java
@@ -21,6 +21,10 @@ import org.testcontainers.containers.BindMode;
  * Debian integration test.
  * @since 0.15
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @EnabledOnOs({OS.LINUX, OS.MAC})
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/com/artipie/file/FileITCase.java
+++ b/src/test/java/com/artipie/file/FileITCase.java
@@ -27,12 +27,14 @@ final class FileITCase {
     /**
      * Deployment for tests.
      * @checkstyle VisibilityModifierCheck (5 lines)
+     * @checkstyle MagicNumberCheck (10 lines)
      */
     @RegisterExtension
     final TestDeployment deployment = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
             .withRepoConfig("binary/bin.yml", "bin")
-            .withRepoConfig("binary/bin-port.yml", "bin-port"),
+            .withRepoConfig("binary/bin-port.yml", "bin-port")
+            .withExposedPorts(8081),
         () -> new TestDeployment.ClientContainer("alpine:3.11")
             .withWorkingDirectory("/w")
     );

--- a/src/test/java/com/artipie/file/FileITCase.java
+++ b/src/test/java/com/artipie/file/FileITCase.java
@@ -7,10 +7,15 @@ package com.artipie.file;
 
 import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Integration test for binary repo.
@@ -26,7 +31,8 @@ final class FileITCase {
     @RegisterExtension
     final TestDeployment deployment = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
-            .withRepoConfig("binary/bin.yml", "bin"),
+            .withRepoConfig("binary/bin.yml", "bin")
+            .withRepoConfig("binary/bin-port.yml", "bin-port"),
         () -> new TestDeployment.ClientContainer("alpine:3.11")
             .withWorkingDirectory("/w")
     );
@@ -40,28 +46,60 @@ final class FileITCase {
         );
     }
 
-    @Test
-    void canDownload() throws Exception {
+    @ParameterizedTest
+    @CsvSource({
+        "8080,bin",
+        "8081,bin-port"
+    })
+    void canDownload(final String port, final String repo) throws Exception {
         final byte[] target = new byte[]{0, 1, 2, 3};
-        this.deployment.putBinaryToArtipie(target, "/var/artipie/data/bin/target");
+        this.deployment.putBinaryToArtipie(
+            target, String.format("/var/artipie/data/%s/target", repo)
+        );
         this.deployment.assertExec(
             "Failed to download artifact",
             new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
-            "curl", "-X", "GET", "http://artipie:8080/bin/target"
+            "curl", "-X", "GET", String.format("http://artipie:%s/%s/target", port, repo)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "8080,bin",
+        "8081,bin-port"
+    })
+    void canUpload(final String port, final String repo) throws Exception {
+        this.deployment.assertExec(
+            "Failed to upload",
+            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
+            "curl", "-X", "PUT", "--data-binary", "123",
+            String.format("http://artipie:%s/%s/target", port, repo)
+        );
+        this.deployment.assertArtipieContent(
+            "Bad content after upload",
+            String.format("/var/artipie/data/%s/target", repo),
+            Matchers.equalTo("123".getBytes())
         );
     }
 
     @Test
-    void canUpload() throws Exception {
+    void repoWithPortIsNotAvailableByDefaultPort() throws IOException {
         this.deployment.assertExec(
             "Failed to upload",
-            new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
-            "curl", "-X", "PUT", "--data-binary", "123", "http://artipie:8080/bin/test"
+            new ContainerResultMatcher(
+                ContainerResultMatcher.SUCCESS, new StringContains("HTTP/1.1 404 Not Found")
+            ),
+            "curl", "-i", "-X", "PUT", "--data-binary", "123", "http://artipie:8080/bin-port/target"
         );
-        this.deployment.assertArtipieContent(
-            "Bad content after upload",
-            "/var/artipie/data/bin/test",
-            Matchers.equalTo("123".getBytes())
+        this.deployment.putBinaryToArtipie(
+            "target".getBytes(StandardCharsets.UTF_8), "/var/artipie/data/bin-port/target"
+        );
+        this.deployment.assertExec(
+            "Failed to download artifact",
+            new ContainerResultMatcher(
+                ContainerResultMatcher.SUCCESS, new StringContains("not found")
+            ),
+            "curl", "-X", "GET", "http://artipie:8080/bin-port/target"
         );
     }
 }

--- a/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -29,6 +29,7 @@ final class FileProxyAuthIT {
     /**
      * Test deployments.
      * @checkstyle VisibilityModifierCheck (10 lines)
+     * @checkstyle MagicNumberCheck (20 lines)
      */
     @RegisterExtension
     final TestDeployment containers = new TestDeployment(
@@ -44,6 +45,7 @@ final class FileProxyAuthIT {
                 () -> TestDeployment.ArtipieContainer.defaultDefinition()
                     .withRepoConfig("binary/bin-proxy.yml", "my-bin-proxy")
                     .withRepoConfig("binary/bin-proxy-port.yml", "my-bin-proxy-port")
+                    .withExposedPorts(8081)
             )
         ),
         () -> new TestDeployment.ClientContainer("alpine:3.11")

--- a/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -11,10 +11,11 @@ import org.cactoos.map.MapOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Integration test for files proxy.
@@ -42,6 +43,7 @@ final class FileProxyAuthIT {
                 "artipie-proxy",
                 () -> TestDeployment.ArtipieContainer.defaultDefinition()
                     .withRepoConfig("binary/bin-proxy.yml", "my-bin-proxy")
+                    .withRepoConfig("binary/bin-proxy-port.yml", "my-bin-proxy-port")
             )
         ),
         () -> new TestDeployment.ClientContainer("alpine:3.11")
@@ -57,8 +59,9 @@ final class FileProxyAuthIT {
         );
     }
 
-    @Test
-    void shouldGetAndCacheFile() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"8080/my-bin-proxy", "8081/my-bin-proxy-port"})
+    void shouldGetFileFromOrigin(final String repo) throws Exception {
         final byte[] data = "Hello world!".getBytes();
         this.containers.putBinaryToArtipie(
             "artipie", data,
@@ -69,7 +72,7 @@ final class FileProxyAuthIT {
             new ContainerResultMatcher(
                 new IsEqual<>(0), new StringContains("HTTP/1.1 200 OK")
             ),
-            "curl", "-i", "-X", "GET", "http://artipie-proxy:8080/my-bin-proxy/foo/bar.txt"
+            "curl", "-i", "-X", "GET", String.format("http://artipie-proxy:%s/foo/bar.txt", repo)
         );
     }
 }

--- a/src/test/java/com/artipie/gem/GemITCase.java
+++ b/src/test/java/com/artipie/gem/GemITCase.java
@@ -22,6 +22,10 @@ import org.testcontainers.containers.BindMode;
  * Integration tests for Gem repository.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.13
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/gem/GemITCase.java
+++ b/src/test/java/com/artipie/gem/GemITCase.java
@@ -22,7 +22,7 @@ import org.testcontainers.containers.BindMode;
  * Integration tests for Gem repository.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.13
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min GemITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/src/test/java/com/artipie/helm/HelmITCase.java
@@ -23,6 +23,10 @@ import org.testcontainers.containers.BindMode;
  *  be better to verify install within `helm install`. For this,
  *  it's necessary to create a kubernetes cluster in Docker.
  * @since 0.13
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/src/test/java/com/artipie/helm/HelmITCase.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.BindMode;
  *  be better to verify install within `helm install`. For this,
  *  it's necessary to create a kubernetes cluster in Docker.
  * @since 0.13
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min HelmITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/src/test/java/com/artipie/maven/MavenITCase.java
@@ -26,63 +26,81 @@ import org.testcontainers.containers.BindMode;
  * Integration tests for Maven repository.
  * @since 0.11
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle ParameterNumberCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.UseObjectForClearerAPI"})
 @DisabledOnOs(OS.WINDOWS)
 public final class MavenITCase {
 
     /**
      * Test deployments.
      * @checkstyle VisibilityModifierCheck (10 lines)
+     * @checkstyle MagicNumberCheck (10 lines)
      */
     @RegisterExtension
     final TestDeployment containers = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
-            .withRepoConfig("maven/maven.yml", "my-maven"),
+            .withRepoConfig("maven/maven.yml", "my-maven")
+            .withRepoConfig("maven/maven-port.yml", "my-maven-port")
+            .withExposedPorts(8081),
         () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
             .withWorkingDirectory("/w")
             .withClasspathResourceMapping(
                 "maven/maven-settings.xml", "/w/settings.xml", BindMode.READ_ONLY
             )
+            .withClasspathResourceMapping(
+                "maven/maven-settings-port.xml", "/w/settings-port.xml", BindMode.READ_ONLY
+            )
     );
 
     @ParameterizedTest
-    @CsvSource({"helloworld,0.1", "snapshot,1.0-SNAPSHOT"})
-    void downloadsArtifact(final String type, final String vers) throws Exception {
+    @CsvSource({
+        "helloworld,0.1,settings.xml,my-maven",
+        "snapshot,1.0-SNAPSHOT,settings.xml,my-maven",
+        "helloworld,0.1,settings-port.xml,my-maven-port",
+        "snapshot,1.0-SNAPSHOT,settings-port.xml,my-maven-port"
+    })
+    void downloadsArtifact(final String type, final String vers, final String stn,
+        final String repo) throws Exception {
         final String meta = String.format("com/artipie/%s/maven-metadata.xml", type);
         this.containers.putResourceToArtipie(
-            meta, String.join("/", "/var/artipie/data/my-maven", meta)
+            meta, String.format("/var/artipie/data/%s/%s", repo, meta)
         );
         final String base = String.format("com/artipie/%s/%s", type, vers);
         MavenITCase.getResourceFiles(base).stream().map(r -> String.join("/", base, r)).forEach(
             item -> this.containers.putResourceToArtipie(
-                item, String.join("/", "/var/artipie/data/my-maven", item)
+                item, String.format("/var/artipie/data/%s/%s", repo, item)
             )
         );
         this.containers.assertExec(
             "Failed to get dependency",
             new ContainerResultMatcher(),
-            "mvn", "-B", "-q", "-s", "settings.xml", "-e", "dependency:get",
+            "mvn", "-B", "-q", "-s", stn, "-e", "dependency:get",
             String.format("-Dartifact=com.artipie:%s:%s", type, vers)
         );
     }
 
     @ParameterizedTest
-    @CsvSource({"helloworld,0.1,0.1", "snapshot,1.0-SNAPSHOT"})
-    void deploysArtifact(final String type, final String vers) throws Exception {
+    @CsvSource({
+        "helloworld,0.1,settings.xml,pom.xml",
+        "snapshot,1.0-SNAPSHOT,settings.xml,pom.xml",
+        "helloworld,0.1,settings-port.xml,pom-port.xml",
+        "snapshot,1.0-SNAPSHOT,settings-port.xml,pom-port.xml"
+    })
+    void deploysArtifact(final String type, final String vers, final String stn, final String pom)
+        throws Exception {
         this.containers.putBinaryToClient(
-            new TestResource(String.format("%s-src/pom.xml", type)).asBytes(), "/w/pom.xml"
+            new TestResource(String.format("%s-src/%s", type, pom)).asBytes(), "/w/pom.xml"
         );
         this.containers.assertExec(
             "Deploy failed",
             new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
-            "mvn", "-B", "-q", "-s", "settings.xml",
-            "deploy", "-Dmaven.install.skip=true"
+            "mvn", "-B", "-q", "-s", stn, "deploy", "-Dmaven.install.skip=true"
         );
         this.containers.assertExec(
             "Download failed",
             new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),
-            "mvn", "-B", "-q", "-s", "settings.xml", "-U", "dependency:get",
+            "mvn", "-B", "-q", "-s", stn, "-U", "dependency:get",
             String.format("-Dartifact=com.artipie:%s:%s", type, vers)
         );
     }

--- a/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
@@ -20,6 +20,10 @@ import org.testcontainers.containers.BindMode;
  * Integration test for maven proxy with multiple remotes.
  *
  * @since 0.12
+ * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)

--- a/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
@@ -20,10 +20,10 @@ import org.testcontainers.containers.BindMode;
  * Integration test for maven proxy with multiple remotes.
  *
  * @since 0.12
- * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
- *  repository with `port` settings and start it in Artipie container exposing the port with
- *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
- *  ports. Check `FileProxyAuthIT` as an example.
+ * @todo #1041:30min MavenMultiProxyIT: Add test cases with proxy repository on individual port:
+ *  create one more repository with `port` settings and start it in Artipie container
+ *  exposing the port with `withExposedPorts` method. Then, parameterize test cases to check
+ *  repositories with different ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)

--- a/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -20,6 +20,10 @@ import org.testcontainers.containers.BindMode;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.11
+ * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)

--- a/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -20,10 +20,10 @@ import org.testcontainers.containers.BindMode;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.11
- * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
- *  repository with `port` settings and start it in Artipie container exposing the port with
- *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
- *  ports. Check `FileProxyAuthIT` as an example.
+ * @todo #1041:30min MavenProxyIT: Add test cases with proxy repository on individual port: create
+ *  one more repository with `port` settings and start it in Artipie container exposing the port
+ *  with `withExposedPorts` method. Then, parameterize test cases to check repositories with
+ *  different ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)

--- a/src/test/java/com/artipie/npm/NpmITCase.java
+++ b/src/test/java/com/artipie/npm/NpmITCase.java
@@ -24,6 +24,10 @@ import org.llorllale.cactoos.matchers.MatcherOf;
  * Integration tests for Npm repository.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.12
+ * @todo #1041:30min NpmITCase: Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/npm/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/NpmProxyITCase.java
@@ -21,6 +21,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Integration test for {@link com.artipie.npm.proxy.http.NpmProxySlice}.
  * @since 0.13
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/npm/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/NpmProxyITCase.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Integration test for {@link com.artipie.npm.proxy.http.NpmProxySlice}.
  * @since 0.13
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #1041:30min Add test cases with proxy repository on individual port: create one more
- *  repository with `port` settings and start it in Artipie container exposing the port with
- *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
- *  ports. Check `FileProxyAuthIT` as an example.
+ * @todo #1041:30min NpmProxyITCase: Add test cases with proxy repository on individual port: create
+ *  one more repository with `port` settings and start it in Artipie container exposing the port
+ *  with `withExposedPorts` method. Then, parameterize test cases to check repositories with
+ *  different ports. Check `FileProxyAuthIT` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/nuget/NugetITCase.java
+++ b/src/test/java/com/artipie/nuget/NugetITCase.java
@@ -21,6 +21,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /**
  * Integration tests for Nuget repository.
  * @since 0.12
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/nuget/NugetITCase.java
+++ b/src/test/java/com/artipie/nuget/NugetITCase.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /**
  * Integration tests for Nuget repository.
  * @since 0.12
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min NugetITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -22,6 +22,10 @@ import org.testcontainers.containers.BindMode;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.12
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledOnOs({OS.LINUX, OS.MAC})

--- a/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -22,7 +22,7 @@ import org.testcontainers.containers.BindMode;
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.12
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min PypiITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -20,7 +20,7 @@ import org.testcontainers.containers.BindMode;
 /**
  * IT case for RPM repository.
  * @since 0.12
- * @todo #1041:30min Add test cases with repository on individual port: create one more
+ * @todo #1041:30min RpmITCase: Add test cases with repository on individual port: create one more
  *  repository with `port` settings and start it in Artipie container exposing the port with
  *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
  *  ports. Check `FileITCase` as an example.

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -20,6 +20,10 @@ import org.testcontainers.containers.BindMode;
 /**
  * IT case for RPM repository.
  * @since 0.12
+ * @todo #1041:30min Add test cases with repository on individual port: create one more
+ *  repository with `port` settings and start it in Artipie container exposing the port with
+ *  `withExposedPorts` method. Then, parameterize test cases to check repositories with different
+ *  ports. Check `FileITCase` as an example.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)

--- a/src/test/resources/binary/bin-port.yml
+++ b/src/test/resources/binary/bin-port.yml
@@ -1,0 +1,6 @@
+repo:
+  type: file
+  port: 8081
+  storage:
+    type: fs
+    path: /var/artipie/data/

--- a/src/test/resources/binary/bin-proxy-port.yml
+++ b/src/test/resources/binary/bin-proxy-port.yml
@@ -1,0 +1,8 @@
+repo:
+  type: file-proxy
+  port: 8081
+  remotes:
+    - url: http://artipie:8080/my-bin
+      username: alice
+      password: 123
+

--- a/src/test/resources/helloworld-src/pom-port.xml
+++ b/src/test/resources/helloworld-src/pom-port.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.artipie</groupId>
+    <artifactId>helloworld</artifactId>
+    <version>0.1</version>
+    <packaging>jar</packaging>
+    <name>Hello World</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+    <distributionManagement>
+        <repository>
+            <id>my-maven</id>
+            <name>Maven</name>
+            <url>http://artipie:8081/my-maven-port/</url>
+        </repository>
+    </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/maven/maven-port.yml
+++ b/src/test/resources/maven/maven-port.yml
@@ -1,0 +1,7 @@
+---
+repo:
+  type: maven
+  port: 8081
+  storage:
+    type: fs
+    path: /var/artipie/data/

--- a/src/test/resources/maven/maven-settings-port.xml
+++ b/src/test/resources/maven/maven-settings-port.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>artipie</id>
+            <repositories>
+                <repository>
+                    <id>my-maven-port</id>
+                    <url>http://artipie:8081/my-maven-port/</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artipie</activeProfile>
+    </activeProfiles>
+  </settings>

--- a/src/test/resources/snapshot-src/pom-port.xml
+++ b/src/test/resources/snapshot-src/pom-port.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.artipie</groupId>
+    <artifactId>snapshot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Hello World</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+    <distributionManagement>
+        <repository>
+            <id>my-maven-port</id>
+            <name>Maven</name>
+            <url>http://artipie:8081/my-maven-port/</url>
+        </repository>
+    </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Part of #1041 

Fixed cases with repository port:

1) path trimming is necessary when repo port is set (for now, I've only fixed it for files repository and added corresponding tests)
2) repository with port should not be accessible by default port

