### PR TITLE
doc: move all the configs details to wiki

### DIFF
--- a/.wiki/Configuration-Credentials.md
+++ b/.wiki/Configuration-Credentials.md
@@ -1,0 +1,86 @@
+## Credentials
+
+```yaml
+meta:
+  credentials:
+    type: file
+    path: _credentials.yml
+```
+
+If the `type` is set to `file`, another YAML file is required in the storage, with
+a list of users who will be allowed to create repos
+(`type` is password format, `plain` and `sha256` types are supported):
+
+```yaml
+credentials:
+  jane:
+    type: plain
+    pass: qwerty
+    email: jane@example.com # Optional
+  john:
+    type: sha256
+    pass: xxxxxxxxxxxxxxxxxxxxxxx
+    groups: # Optional
+      - readers
+      - dev-leads
+```
+Users can be assigned to some groups, all repository permissions granted to the group are applied
+to the users participating in this group.
+
+If the `type` is set to `env`, the following environment variables are expected:
+`ARTIPIE_USER_NAME` and `ARTIPIE_USER_PASS`. For example, you start
+Docker container with the `-e` option:
+
+```bash
+docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
+  -e ARTIPIE_USER_NAME=artipie -e ARTIPIE_USER_PASS=qwerty \
+  artipie/artipie:latest
+```
+
+The type of credentials config could be `file` (support other types such
+as database or LDAP will be added later). For file credentials, it has a `path`
+parameter - it's a relative key for repository storage configuration.
+It contains passwords validators for username keys in this format:
+```yaml
+credentials:
+  user1:
+    pass: "sha256:abc...123"
+  user2:
+    pass: "plain:secret-password"
+    groups:
+      - readers
+```
+Credentials file has a `credentials` root element with map of users, each user has a `pass` text element which specify a password validator in this format:
+`<type>:<data>`, where type is either `sha256` or `plain`
+(notice: it's not recommended to use plain password validation,
+it's added for debugging purpose), `sha256` validator data includes
+a SHA256 hash-sum of user's password, `plain` validator has a plain
+password string data.
+Also, users can be assigned to groups, all permissions granted to the group
+in repository are applied to the users participating in this group.
+
+If the `type` is set to `env`, the following environment variables are expected:
+`ARTIPIE_USER_NAME` and `ARTIPIE_USER_PASS`. For example, you start
+Docker container with the `-e` option:
+```bash
+docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
+  -e ARTIPIE_USER_NAME=artipie -e ARTIPIE_USER_PASS=qwerty \
+  artipie/artipie:latest
+```
+There is an ability to use GitHub credentials to authenticate users.
+You should specify `type` as `github` to do this.
+You can specify several types of credentials; in that case, authentication will
+process until one of them is successful.
+For example, the config may look like following:
+```yaml
+meta:
+  layout: org
+  storage:
+    type: fs
+    path: /tmp/artipie/data/my-docker
+  credentials:
+    - type: env
+    - type: github
+```
+If `env` is not successful, `github` will be applied to authenticate a user.
+If `github` is not successful, user authentication will fail.

--- a/.wiki/Configuration-Metrics.md
+++ b/.wiki/Configuration-Metrics.md
@@ -1,0 +1,19 @@
+## Metrics
+
+You may enable some basic metrics collecting and periodic publishing to application log
+by adding `metrics` to `meta` section of global configuration file `/etc/artipie/artipie.yml`:
+
+```yaml
+meta:
+  metrics:
+    type: log # Metrics type, for now only `log` type is supported
+    interval: 5 # Publishing interval in seconds, default value is 5
+```
+
+To collect metrics via `Prometheus`, simply configure `metrics` like this :
+
+```yaml
+meta :
+  metrics :
+    type : prometheus
+```

--- a/.wiki/Configuration-Repository Permissions.md
+++ b/.wiki/Configuration-Repository Permissions.md
@@ -1,0 +1,26 @@
+## Repository permissions
+
+Permissions for repository operations can be granted in the repo configuration file:
+```yaml
+repo:
+  ...
+  permissions:
+    jane:
+      - read
+      - write
+    admin:
+      - "*"
+    /readers:
+      - read
+```
+
+All repositories support `read` and `write` operations, other specific permissions may be supported
+in certain repository types.
+
+Group names should start with `/`, is the example above `read` operation is granted for `readers` group
+and every user within the group can read from the repository, user named `jane` is allowed to `read` and `write`.
+We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example
+can perform any operation in the repository.
+
+If `permissions` section is absent in repo config, then any supported operation is allowed for everyone,
+empty `permissions` section restricts any operations for anyone.

--- a/.wiki/Configuration-Repository.md
+++ b/.wiki/Configuration-Repository.md
@@ -1,3 +1,21 @@
+## Single repository on port
+
+Artipie repositories may run on separate ports if configured.
+This feature may be especially useful for Docker repository,
+as it's API is not well suited to serve multiple repositories on single port.
+
+To run repository on its own port
+`port` parameter should be specified in repository configuration YAML as follows:
+
+```yaml
+repo:
+  type: <repository type>
+  port: 54321
+  ...
+```
+
+*NOTE: Artipie scans repositories for port configuration only on start,
+so server requires restart in order to apply changes made in runtime.*
 
 ## File
 

--- a/.wiki/Configuration-Storage.md
+++ b/.wiki/Configuration-Storage.md
@@ -6,8 +6,10 @@ Artipie "Storage" is an abstraction on top of multiple key-value storage provide
  - etcd storage (see limitations)
  - in-memory
 
-The Storage is used for storing repository data, proxy/mirrors repository caching and for Artipie configuration. In configuration each storage
-is defined by `storage` yaml key, mandatory `type` parameter and provider dependent configuration parameters.
+The Storage is used for storing repository data, proxy/mirrors repository caching and for Artipie 
+configuration. Such storage can be configured in various config files and in various sections of 
+config files, but storage configuration structure is always the same: each storage is defined by 
+`storage` yaml key, mandatory `type` parameter and provider dependent configuration parameters.
 
 ## File System storage
 
@@ -46,17 +48,6 @@ storage:
     secretAccessKey: 9889sg8nas8ng
 ```
 
-## In memory storage
-
-In-memory storage is not persistent, it exists only while Artipie process is alive.
-It's not recommended to use it in production, it may be helpful for debugging and testing.
-
-*Example:*
-```yaml
-storage:
-  type: in-memory
-```
-
 ## Etcd storage
 
 Etcd storage uses etcd cluster as a back-end. It may be useful for configuration storage of Artipie server.
@@ -74,23 +65,43 @@ storage:
   timeout: 5000
 ```
 
-## Aliases
+## In memory storage
+
+In-memory storage is not persistent, it exists only while Artipie process is alive and is used in 
+Artipie tests, check the [implementation](https://github.com/artipie/asto/blob/master/asto-core/src/main/java/com/artipie/asto/memory/InMemoryStorage.java) 
+for more details. There is no possibility to use in memory storage from configuration, 
+it's for unit and integration tests only.
+
+# Storage Aliases
 
 Artipie has special configuration item for storage aliases: `_storages.yaml` located in configuration root.
-This file can define storages with names, then repository users can use alias instead of storage configuration.
+This file can define storages with names, then repository users can use alias instead of full storage configuration.
 Also, it allows to hide real storage configuration or credentials from repository or organization maintainers:
 Artipie server administrator can configure storage and provide alias to users, and users will set this alias
 for repositories instead of configuration.
 ```yaml
 # _storages.yaml
 storages:
-  default:
+  default: # storage alias name to use in repository configs
     type: fs
     path: /var/artipie/data
+  remote_s3: # storage alias name to use in repository configs
+     type: s3
+     bucket: artipie
+     region: east
+     endpoint: https://minio.selfhosted/s3
+     credentials:
+        type: basic
+        accessKeyId: asagn8as8f81
+        secretAccessKey: 9889sg8nas8ng
 ```
-```
+```yaml
 # repository configuration
 repo:
   type: file
   storage: default
+# or
+repo:
+   type: maven
+   storage: remote_s3
 ```

--- a/.wiki/Configuration.md
+++ b/.wiki/Configuration.md
@@ -1,8 +1,11 @@
 The main Artipie configuration file is `/etc/artipie/artipie.yml`.
 It contains server meta configuration, such as:
- - `layout` - `flat` or `org` string
- - `storage` - repositories definition storage config
- - `credentials` - user credentials config
+ - `layout` - `flat` or `org` string, not required, default value is `flat`;
+ - `storage` - repositories definition storage config, required;
+ - `credentials` - user [credentials config](./Configuration-Credentials.md);
+ - `configs` - repository config files location, not required, the storage key relatively to the 
+main storage, or, in file system storage terms, subdirectory where repo configs are located relatively to the storage;
+ - `metrics` - enable and set [metrics collection](./Configuration-Metrics.md), not required
 
 Example: 
 ```yaml
@@ -11,18 +14,19 @@ meta:
   layout: org
   storage:
     type: fs
-    path: /tmp/artipie/data/my-docker
+    path: /tmp/artipie/configs
+  congigs: repo
   credentials:
     type: file
     path: _credentials.yml
+  metrics:
+    type: log
 ```
 
 Layout specifies the URI path layout for Artipie. In case of `flat`,
 Artipie provides repositories at first path level, e.g. `artipie.host/repo1`,
-`artipie.host/repo2`. Only Artipie administrator can manage repositories in flat layout, users can't create new repositories or delete by self.
-`org` layout provides hierarchy support for repositories:
-URI path has two parts for `org` layouts: `<org>/<repo>`,
-where `<org>` is oganisation name, and `<repo>` the name of repository,
+`artipie.host/repo2`. For `org` layouts URI path has two parts: `<org>/<repo>`,
+where `<org>` is organisation name, and `<repo>` the name of repository,
 e.g. `artipie.host/artipie/maven` - `maven` repository of `artipie` organisation.
 In `org` layout, organisation may have a maintainer who can manage
 repositories and permissions within organisation; the maintainer can add,
@@ -33,52 +37,6 @@ for [repository definitions](https://github.com/artipie/artipie/wiki/Configurati
 It locates a storage where all config files for each repository are located. Keep in mind,
 Artipie user should have read and write permissions for this storage.
 
-Credentials - provider for user credentials,
-it can be managed only by Artipie server administrator.
-The type of credentials config could be `file` (support other types such
-as database or LDAP will be added later). For file credentials, it has a `path`
-parameter - it's a relative key for repository storage configuration.
-It contains passwords validators for username keys in this format:
-```yaml
-credentials:
-  user1:
-    pass: "sha256:abc...123"
-  user2:
-    pass: "plain:secret-password"
-    groups:
-      - readers
-```
-Credentials file has a `credentials` root element with map of users, each user has a `pass` text element which specify a password validator in this format:
-`<type>:<data>`, where type is either `sha256` or `plain`
-(notice: it's not recommended to use plain password validation,
-it's added for debugging purpose), `sha256` validator data includes
-a SHA256 hash-sum of user's password, `plain` validator has a plain
-password string data.
-Also, users can be assigned to groups, all permissions granted to the group
-in repository are applied to the users participating in this group.
+You may want configure it via environment variables:
 
-If the `type` is set to `env`, the following environment variables are expected:
-`ARTIPIE_USER_NAME` and `ARTIPIE_USER_PASS`. For example, you start
-Docker container with the `-e` option:
-```bash
-docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
-  -e ARTIPIE_USER_NAME=artipie -e ARTIPIE_USER_PASS=qwerty \
-  artipie/artipie:latest
-```
-There is an ability to use GitHub credentials to authenticate users. 
-You should specify `type` as `github` to do this.
-You can specify several types of credentials; in that case, authentication will 
-process until one of them is successful. 
-For example, the config may look like following:
-```yaml
-meta:
-  layout: org
-  storage:
-    type: fs
-    path: /tmp/artipie/data/my-docker
-  credentials:
-    - type: env
-    - type: github
-```
-If `env` is not successful, `github` will be applied to authenticate a user. 
-If `github` is not successful, user authentication will fail.
+- `SSL_TRUSTALL` - trust all unknown certificates

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-<img src="https://www.artipie.com/logo.svg" width="64px" height="64px"/>
+<a href="http://artipie.com"><img src="https://www.artipie.com/logo.svg" width="64px" height="64px"/></a>
+
+[![Join our Telegramm group](https://img.shields.io/badge/Join%20us-Telegram-blue?&logo=telegram&?link=http://right&link=http://t.me/artipie)](http://t.me/artipie)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
-[![DevOps By Rultor.com](http://www.rultor.com/b/artipie/artipie)](http://www.rultor.com/p/artipie/artipie)
+[![DevOps By Rultor.com](http://www.rultor.com/b/artipie/http-client)](http://www.rultor.com/p/artipie/http)
 [![We recommend IntelliJ IDEA](https://www.elegantobjects.org/intellij-idea.svg)](https://www.jetbrains.com/idea/)
 
-[![Build Status](https://img.shields.io/travis/artipie/artipie/master.svg)](https://travis-ci.org/artipie/artipie)
-![Docker Pulls](https://img.shields.io/docker/pulls/artipie/artipie)
+[![Javadoc](http://www.javadoc.io/badge/com.artipie/http-client.svg)](http://www.javadoc.io/doc/com.artipie/http-client)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/artipie/artipie/blob/master/LICENSE.txt)
+[![codecov](https://codecov.io/gh/artipie/http-client/branch/master/graph/badge.svg)](https://codecov.io/gh/artipie/http-client)
 [![Hits-of-Code](https://hitsofcode.com/github/artipie/artipie)](https://hitsofcode.com/view/github/artipie/artipie)
+![Docker Pulls](https://img.shields.io/docker/pulls/artipie/artipie)
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/artipie/artipie?label=DockerHub&sort=date)
 [![PDD status](http://www.0pdd.com/svg?name=artipie/artipie)](http://www.0pdd.com/p?name=artipie/artipie)
 
@@ -33,6 +36,8 @@ The following set of features makes Artipie unique among all others:
     [Composer](./examples/php),
     [Pip](./examples/pypi),
     [Rpm](./examples/rpm),
+    [Debian](./examples/debian),
+    [Anaconda](./examples/conda)
     and [others](./examples)
   * It is database-free
   * It can host the data in the file system or [Amazon S3](https://aws.amazon.com/s3/)
@@ -75,193 +80,28 @@ You may want to mount local configurations to `/var/artipie/repos` to edit it ma
 **Important:** check that `<your-local-config-dir>` has correct permissions, it should be `2020:2021`, 
 to change it correctly use `chown -R 2020:2021 <your-local-config-dir>`.
 
+More configuration details and examples are available in our [Wiki](https://github.com/artipie/artipie/wiki).
 
-More examples are [here](./examples).
+We recommend you read the "Architecture" section in our [White Paper](https://github.com/artipie/white-paper) 
+to fully understand how Artipie is designed.
 
-We recommend you read the "Architecture" section in our
-[White Paper](https://github.com/artipie/white-paper) to fully
-understand how Artipie is designed.
+If you have any question or suggestions, do not hesitate to [create an issue](https://github.com/artipie/artipie/issues/new) or contact us in
+[Telegram](https://t.me/artipie).  
+Artipie [roadmap](https://github.com/orgs/artipie/projects/3).
 
-## Contents
+## How to contribute
 
-- [Storage configuration](#storage-configuration)
-- [Repository permissions](#repository-permissions)
-- [Multitenancy](#multitenancy)
-- [Metrics](#metrics)
-- [Artipie REST API](#artipie-rest-api)
+Fork repository, make changes, send us a pull request. We will review
+your changes and apply them to the `master` branch shortly, provided
+they don't violate our quality standards. To avoid frustration, before
+sending us your pull request please run full Maven build:
 
-## Storage configuration
-
-For now, we support two storage types: file system and [S3](https://aws.amazon.com/s3/?nc1=h_ls) storages. 
-To configure file system storage it is enough to set the path where Artipie will store all the items:
-
-```yaml
-storage:
-  type: fs
-  path: /urs/local/aripie/data
+```
+$ mvn clean install -Pqulice
 ```
 
-S3 storage configuration requires specifying `bucket` and `credentials`:
-```yaml
-storage:
-  type: s3
-  bucket: my-bucket
-  region: my-region # optional
-  endpoint: https://my-s3-provider.com # optional
-  credentials:
-    type: basic
-    accessKeyId: xxx
-    secretAccessKey: xxx
-```
-
-Storages can be configured for each repository individually in repo configuration yaml or in 
-the `_storages.yaml` file along with aliases:
-
-```yaml
-storages:
-  default:
-    type: fs
-    path: ./.storage/data 
-```
-
-Then `default` storage alias can be used to configure a repository:
-
-```yaml
-repo:
-  type: maven
-  storage: default
-```
-
-## Repository permissions
-
-Permissions for repository operations can be granted in the repo configuration file:
-```yaml
-repo:
-  ...
-  permissions:
-    jane:
-      - read
-      - write
-    admin:
-      - "*"
-    /readers:
-      - read
-```
-
-All repositories support `read` and `write` operations, other specific permissions may be supported 
-in certain repository types.
-
-Group names should start with `/`, is the example above `read` operation is granted for `readers` group 
-and every user within the group can read from the repository, user named `jane` is allowed to `read` and `write`.
-We also support asterisk wildcard for "any operation" or "any user", user `admin` in the example 
-can perform any operation in the repository.
-
-If `permissions` section is absent in repo config, then any supported operation is allowed for everyone,
-empty `permissions` section restricts any operations for anyone.
-
-## Multitenancy
-
-You may want to run Artipie for your company, which has a few teams.
-Each team may want to have its own repository. To do this, you create
-a global configuration file `/etc/artipie/artipie.yml`:
-
-```yaml
-meta:
-  layout: org
-  storage:
-    type: fs
-    path: /tmp/artipie/data/my-docker
-  credentials:
-    type: file
-    path: _credentials.yml
-```
-
-If the `type` is set to `file`, another YAML file is required in the storage, with
-a list of users who will be allowed to create repos
-(`type` is password format, `plain` and `sha256` types are supported):
-
-```yaml
-credentials:
-  jane:
-    type: plain
-    pass: qwerty
-    email: jane@example.com # Optional
-  john:
-    type: sha256
-    pass: xxxxxxxxxxxxxxxxxxxxxxx
-    groups: # Optional
-      - readers
-      - dev-leads
-```
-Users can be assigned to some groups, all repository permissions granted to the group are applied 
-to the users participating in this group.
-
-If the `type` is set to `env`, the following environment variables are expected:
-`ARTIPIE_USER_NAME` and `ARTIPIE_USER_PASS`. For example, you start
-Docker container with the `-e` option:
-
-```bash
-docker run -d -v /var/artipie:/var/artipie` -p 80:80 \
-  -e ARTIPIE_USER_NAME=artipie -e ARTIPIE_USER_PASS=qwerty \
-  artipie/artipie:latest
-```
-
-## Single repository on port
-
-Artipie repositories may run on separate ports if configured.
-This feature may be especially useful for Docker repository,
-as it's API is not well suited to serve multiple repositories on single port.
-
-To run repository on its own port 
-`port` parameter should be specified in repository configuration YAML as follows:
-
-```yaml
-repo:
-  type: <repository type>
-  port: 54321
-  ...
-```
-
-*NOTE: Artipie scans repositories for port configuration only on start, 
-so server requires restart in order to apply changes made in runtime.* 
-
-## Metrics
-
-You may enable some basic metrics collecting and periodic publishing to application log
-by adding `metrics` to `meta` section of global configuration file `/etc/artipie/artipie.yml`:
-
-```yaml
-meta:
-  metrics:
-    type: log # Metrics type, for now only `log` type is supported
-    interval: 5 # Publishing interval in seconds, default value is 5
-```
-
-To collect metrics via `Prometheus`, simply configure `metrics` like this :
-
-```yaml
-meta :
-  metrics :
-    type : prometheus
-```
-
-## Artipie REST API
-
-Artipie provides a set of APIs to manage repositories and users.  The current APIs are fully documented [here](./REST_API.md).
-
-## Additional configuration
-
-You may want configure it via environment variables:
-
-  - `SSL_TRUSTALL` - trust all unknown certificates
-  
-To configure repository config files location, add to the global configuration file `/etc/artipie/artipie.yml`:
-```yaml
-meta:
-  repo_configs: configs
-```
-Location is the storage key relatively to the main storage, or, in file system storage terms, 
-subdirectory where repo configs are located relatively to the storage.
+To avoid build errors use Maven 3.2+ and please read 
+[contributing rules](https://github.com/artipie/artipie/blob/master/CONTRIBUTING.md).
 
 Thanks to [FreePik](https://www.freepik.com/free-photos-vectors/party) for the logo.
 


### PR DESCRIPTION
Part of #1031 

Created wiki sections structure and moved all the information from readme there. In readme I've left only general description, quickstart section and contributing details. 

Then I will extend and reformat each wiki page one by one.