### PR TITLE
feat: simplify `RepoConfig` class

### DIFF
--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -192,7 +192,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                             .stream().map(node -> node.asScalar().value())
                             .map(
                                 name -> new AsyncSlice(
-                                    new RepositoriesFromStorage(http, settings.storage()).config(name)
+                                    new RepositoriesFromStorage(settings.storage()).config(name)
                                         .thenApply(
                                             sub -> new SliceFromConfig(
                                                 http, settings, sub, aliases, standalone

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -169,7 +169,7 @@ public final class VertxMain {
             keys -> keys.stream().map(ConfigFile::new)
                 .filter(Predicate.not(ConfigFile::isSystem).and(ConfigFile::isYamlOrYml))
                 .map(ConfigFile::name)
-                .map(name -> new RepositoriesFromStorage(this.http, storage).config(name))
+                .map(name -> new RepositoriesFromStorage(storage).config(name))
                 .map(stage -> stage.toCompletableFuture().join())
                 .collect(Collectors.toList())
         ).toCompletableFuture().join();

--- a/src/main/java/com/artipie/adapters/docker/DockerProxy.java
+++ b/src/main/java/com/artipie/adapters/docker/DockerProxy.java
@@ -24,6 +24,7 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.auth.AuthClientSlice;
 import com.artipie.settings.repo.RepoConfig;
 import com.artipie.settings.repo.proxy.ProxyConfig;
+import com.artipie.settings.repo.proxy.YamlProxyConfig;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -101,9 +102,9 @@ public final class DockerProxy implements Slice {
      */
     private Slice delegate() {
         final Docker proxies = new MultiReadDocker(
-            this.cfg.proxy().remotes().stream().map(
-                remote -> proxy(this.client, remote)
-            ).collect(Collectors.toList())
+            new YamlProxyConfig(this.client, this.cfg)
+                .remotes().stream().map(remote -> proxy(this.client, remote))
+                .collect(Collectors.toList())
         );
         Docker docker = this.cfg.storageOpt()
             .<Docker>map(

--- a/src/main/java/com/artipie/adapters/file/FileProxy.java
+++ b/src/main/java/com/artipie/adapters/file/FileProxy.java
@@ -12,6 +12,7 @@ import com.artipie.http.Slice;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.settings.repo.RepoConfig;
 import com.artipie.settings.repo.proxy.ProxyConfig;
+import com.artipie.settings.repo.proxy.YamlProxyConfig;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -52,7 +53,8 @@ public final class FileProxy implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body
     ) {
-        final Collection<? extends ProxyConfig.Remote> remotes = this.cfg.proxy().remotes();
+        final Collection<? extends ProxyConfig.Remote> remotes =
+            new YamlProxyConfig(this.client, this.cfg).remotes();
         if (remotes.isEmpty()) {
             throw new IllegalArgumentException("No remotes specified");
         }

--- a/src/main/java/com/artipie/adapters/maven/MavenProxy.java
+++ b/src/main/java/com/artipie/adapters/maven/MavenProxy.java
@@ -12,6 +12,7 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.http.group.GroupSlice;
 import com.artipie.maven.http.MavenProxySlice;
 import com.artipie.settings.repo.RepoConfig;
+import com.artipie.settings.repo.proxy.YamlProxyConfig;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -53,7 +54,7 @@ public final class MavenProxy implements Slice {
         final Publisher<ByteBuffer> body
     ) {
         return new GroupSlice(
-            this.cfg.proxy().remotes().stream().map(
+            new YamlProxyConfig(this.client, this.cfg).remotes().stream().map(
                 remote -> new MavenProxySlice(
                     this.client,
                     URI.create(remote.url()),

--- a/src/main/java/com/artipie/adapters/php/ComposerProxy.java
+++ b/src/main/java/com/artipie/adapters/php/ComposerProxy.java
@@ -12,6 +12,7 @@ import com.artipie.http.Slice;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.settings.repo.RepoConfig;
 import com.artipie.settings.repo.proxy.ProxyConfig;
+import com.artipie.settings.repo.proxy.YamlProxyConfig;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -49,7 +50,8 @@ public final class ComposerProxy implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body
     ) {
-        final Collection<? extends ProxyConfig.Remote> remotes = this.cfg.proxy().remotes();
+        final Collection<? extends ProxyConfig.Remote> remotes =
+            new YamlProxyConfig(this.client, this.cfg).remotes();
         if (remotes.isEmpty()) {
             throw new IllegalArgumentException("No remotes were specified");
         }

--- a/src/main/java/com/artipie/adapters/pypi/PypiProxy.java
+++ b/src/main/java/com/artipie/adapters/pypi/PypiProxy.java
@@ -10,6 +10,7 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.pypi.http.PyProxySlice;
 import com.artipie.settings.repo.RepoConfig;
 import com.artipie.settings.repo.proxy.ProxyConfig;
+import com.artipie.settings.repo.proxy.YamlProxyConfig;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -46,7 +47,8 @@ public final class PypiProxy implements Slice {
     @Override
     public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
-        final Collection<? extends ProxyConfig.Remote> remotes = this.cfg.proxy().remotes();
+        final Collection<? extends ProxyConfig.Remote> remotes =
+            new YamlProxyConfig(this.client, this.cfg).remotes();
         if (remotes.isEmpty()) {
             throw new IllegalArgumentException("No remotes specified");
         }

--- a/src/main/java/com/artipie/http/ArtipieRepositories.java
+++ b/src/main/java/com/artipie/http/ArtipieRepositories.java
@@ -84,7 +84,7 @@ public final class ArtipieRepositories {
         final Key name,
         final int port
     ) {
-        return new RepositoriesFromStorage(this.http, storage).config(name.string()).thenCombine(
+        return new RepositoriesFromStorage(storage).config(name.string()).thenCombine(
             StorageAliases.find(storage, name),
             (config, aliases) -> {
                 final Slice res;

--- a/src/main/java/com/artipie/settings/repo/proxy/YamlProxyConfig.java
+++ b/src/main/java/com/artipie/settings/repo/proxy/YamlProxyConfig.java
@@ -12,6 +12,7 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.auth.Authenticator;
 import com.artipie.http.client.auth.GenericAuthenticator;
 import com.artipie.settings.StorageAliases;
+import com.artipie.settings.repo.RepoConfig;
 import com.artipie.settings.repo.StorageYamlConfig;
 import java.util.Collection;
 import java.util.Optional;
@@ -64,6 +65,16 @@ public final class YamlProxyConfig implements ProxyConfig {
         this.storages = storages;
         this.prefix = prefix;
         this.yaml = yaml;
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param http HTTP client
+     * @param repo Repo configuration.
+     */
+    public YamlProxyConfig(final ClientSlices http, final RepoConfig repo) {
+        this(http, repo.storageAliases(), new Key.From(repo.name()), repo.repoConfig());
     }
 
     @Override

--- a/src/test/java/com/artipie/docker/DockerProxyTest.java
+++ b/src/test/java/com/artipie/docker/DockerProxyTest.java
@@ -10,7 +10,6 @@ import com.artipie.asto.Key;
 import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Permissions;
-import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
@@ -77,12 +76,10 @@ class DockerProxyTest {
     }
 
     private static DockerProxy dockerProxy(final String yaml) throws IOException {
-        final ClientSlices http = new JettyClientSlices();
         return new DockerProxy(
-            http,
+            new JettyClientSlices(),
             false,
             new RepoConfig(
-                http,
                 alias -> {
                     throw new UnsupportedOperationException();
                 },

--- a/src/test/java/com/artipie/settings/RepositoriesFromStorageCacheTest.java
+++ b/src/test/java/com/artipie/settings/RepositoriesFromStorageCacheTest.java
@@ -10,8 +10,6 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
-import com.artipie.http.client.ClientSlices;
-import com.artipie.http.client.jetty.JettyClientSlices;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,12 +38,11 @@ final class RepositoriesFromStorageCacheTest {
         final byte[] old = "some: data".getBytes();
         final byte[] upd = "some: new data".getBytes();
         new BlockingStorage(this.storage).save(key, old);
-        final ClientSlices http = new JettyClientSlices();
-        new RepositoriesFromStorage(http, this.storage).config(key.string())
+        new RepositoriesFromStorage(this.storage).config(key.string())
             .toCompletableFuture().join();
         new BlockingStorage(this.storage).save(key, upd);
         MatcherAssert.assertThat(
-            new RepositoriesFromStorage(http, this.storage).config(key.string())
+            new RepositoriesFromStorage(this.storage).config(key.string())
                 .toCompletableFuture().join()
                 .toString(),
             new IsEqual<>(new String(old))
@@ -58,12 +55,11 @@ final class RepositoriesFromStorageCacheTest {
         final Key config = new Key.From("bin.yaml");
         new TestResource(alias.string()).saveTo(this.storage);
         new BlockingStorage(this.storage).save(config, "repo:\n  storage: default".getBytes());
-        final ClientSlices http = new JettyClientSlices();
-        new RepositoriesFromStorage(http, this.storage).config(config.string())
+        new RepositoriesFromStorage(this.storage).config(config.string())
             .toCompletableFuture().join();
         this.storage.save(alias, Content.EMPTY).join();
         MatcherAssert.assertThat(
-            new RepositoriesFromStorage(http, this.storage).config(config.string())
+            new RepositoriesFromStorage(this.storage).config(config.string())
                 .toCompletableFuture().join()
                 .storageOpt().isPresent(),
             new IsEqual<>(true)

--- a/src/test/java/com/artipie/settings/repo/RepoConfigTest.java
+++ b/src/test/java/com/artipie/settings/repo/RepoConfigTest.java
@@ -9,13 +9,10 @@ import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.asto.Key;
 import com.artipie.asto.test.TestResource;
 import com.artipie.auth.YamlPermissions;
-import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.settings.StorageAliases;
-import io.reactivex.Flowable;
-import java.nio.ByteBuffer;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.concurrent.ExecutionException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
@@ -160,7 +157,6 @@ public final class RepoConfigTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new RepoConfig(
-                new JettyClientSlices(),
                 StorageAliases.EMPTY,
                 new Key.From("key"),
                 Yaml.createYamlMappingBuilder().add(
@@ -188,7 +184,6 @@ public final class RepoConfigTest {
 
     private RepoConfig repoCustom(final String name, final String value) {
         return new RepoConfig(
-            new JettyClientSlices(),
             StorageAliases.EMPTY,
             new Key.From("repo-custom.yml"),
             Yaml.createYamlMappingBuilder().add(
@@ -201,14 +196,10 @@ public final class RepoConfigTest {
     }
 
     private RepoConfig readFromResource(final String name)
-        throws ExecutionException, InterruptedException {
-        return RepoConfig.fromPublisher(
-            new JettyClientSlices(),
-            StorageAliases.EMPTY,
-            new Key.From(name),
-            Flowable.just(
-                ByteBuffer.wrap(new TestResource(name).asBytes())
-            )
-        ).toCompletableFuture().get();
+        throws IOException {
+        return new RepoConfig(
+            StorageAliases.EMPTY, new Key.From(name),
+            Yaml.createYamlInput(new TestResource(name).asInputStream()).readYamlMapping()
+        );
     }
 }

--- a/src/test/java/com/artipie/settings/repo/RepositoriesFromStorageTest.java
+++ b/src/test/java/com/artipie/settings/repo/RepositoriesFromStorageTest.java
@@ -10,7 +10,6 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ValueNotFoundException;
 import com.artipie.asto.memory.InMemoryStorage;
-import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.settings.RepositoriesFromStorage;
 import com.artipie.settings.StorageAliases;
 import java.nio.file.Path;
@@ -160,7 +159,7 @@ final class RepositoriesFromStorageTest {
     }
 
     private RepoConfig repoConfig() {
-        return new RepositoriesFromStorage(new JettyClientSlices(), this.storage)
+        return new RepositoriesFromStorage(this.storage)
             .config(RepositoriesFromStorageTest.REPO)
             .toCompletableFuture().join();
     }


### PR DESCRIPTION
Part of #1099 
I've simplified `RepoConfig` class by:
- moving static method `fromPublisher()` to `RepositoriesFromStorage` class
- removing and inlining method `proxy()`
