### PR TITLE
feat: simplify tests

### DIFF
--- a/src/test/java/com/artipie/api/RepositoryRestFlatTest.java
+++ b/src/test/java/com/artipie/api/RepositoryRestFlatTest.java
@@ -32,7 +32,7 @@ final class RepositoryRestFlatTest extends RestApiServerBase {
         this.save(new Key.From("rpm-local.yml"), new byte[0]);
         this.save(new Key.From("conda-remote.yml"), new byte[0]);
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/repository/list"),
+            vertx, ctx, new TestRequest("/api/v1/repository/list"),
             resp -> MatcherAssert.assertThat(
                 resp.body().toJsonArray().stream().collect(Collectors.toList()),
                 Matchers.containsInAnyOrder(
@@ -51,7 +51,7 @@ final class RepositoryRestFlatTest extends RestApiServerBase {
                     .put("storage", new JsonObject())
             );
         this.requestAndAssert(
-            vertx, ctx, new Request(HttpMethod.PUT, "/api/v1/repository/newrepo", json),
+            vertx, ctx, new TestRequest(HttpMethod.PUT, "/api/v1/repository/newrepo", json),
             res -> {
                 MatcherAssert.assertThat(
                     res.statusCode(),
@@ -75,7 +75,7 @@ final class RepositoryRestFlatTest extends RestApiServerBase {
                     .put("storage", new JsonObject())
             );
         this.requestAndAssert(
-            vertx, ctx, new Request(HttpMethod.PUT, "/api/v1/repository/newrepo", json),
+            vertx, ctx, new TestRequest(HttpMethod.PUT, "/api/v1/repository/newrepo", json),
             res ->
                 MatcherAssert.assertThat(
                     res.statusCode(),

--- a/src/test/java/com/artipie/api/RepositoryRestOrgTest.java
+++ b/src/test/java/com/artipie/api/RepositoryRestOrgTest.java
@@ -32,7 +32,7 @@ final class RepositoryRestOrgTest extends RestApiServerBase {
         this.save(new Key.From("alice/rpm-local.yml"), new byte[0]);
         this.save(new Key.From("alice/conda.yml"), new byte[0]);
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/repository/list"),
+            vertx, ctx, new TestRequest("/api/v1/repository/list"),
             resp ->
                 MatcherAssert.assertThat(
                     resp.body().toJsonArray().stream().collect(Collectors.toList()),
@@ -49,7 +49,7 @@ final class RepositoryRestOrgTest extends RestApiServerBase {
         this.save(new Key.From("alice/rpm-local.yml"), new byte[0]);
         this.save(new Key.From("alice/conda.yml"), new byte[0]);
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/repository/list/alice"),
+            vertx, ctx, new TestRequest("/api/v1/repository/list/alice"),
             resp ->
                 MatcherAssert.assertThat(
                     resp.body().toJsonArray().stream().collect(Collectors.toList()),
@@ -67,7 +67,7 @@ final class RepositoryRestOrgTest extends RestApiServerBase {
                     .put("storage", new JsonObject())
             );
         this.requestAndAssert(
-            vertx, ctx, new Request(HttpMethod.PUT, "/api/v1/repository/alice/newrepo", json),
+            vertx, ctx, new TestRequest(HttpMethod.PUT, "/api/v1/repository/alice/newrepo", json),
             resp -> {
                 MatcherAssert.assertThat(
                     resp.statusCode(),
@@ -91,7 +91,7 @@ final class RepositoryRestOrgTest extends RestApiServerBase {
                     .put("storage", new JsonObject())
             );
         this.requestAndAssert(
-            vertx, ctx, new Request(HttpMethod.PUT, "/api/v1/repository/alice/newrepo", json),
+            vertx, ctx, new TestRequest(HttpMethod.PUT, "/api/v1/repository/alice/newrepo", json),
             resp ->
                 MatcherAssert.assertThat(
                     resp.statusCode(),

--- a/src/test/java/com/artipie/api/RestApiServerBase.java
+++ b/src/test/java/com/artipie/api/RestApiServerBase.java
@@ -126,10 +126,10 @@ public abstract class RestApiServerBase {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     final void requestAndAssert(final Vertx vertx, final VertxTestContext ctx,
-        final Request rqs, final Consumer<HttpResponse<Buffer>> assertion) throws Exception {
+        final TestRequest rqs, final Consumer<HttpResponse<Buffer>> assertion) throws Exception {
         final HttpRequest<Buffer> request = WebClient.create(vertx)
             .request(rqs.method, this.port(), RestApiServerBase.HOST, rqs.path);
-        rqs.body.map(item -> request.sendJsonObject(rqs.body.get()))
+        rqs.body.map(request::sendJsonObject)
             .orElse(request.send())
             .onSuccess(
                 res -> {
@@ -182,7 +182,7 @@ public abstract class RestApiServerBase {
      * Test request.
      * @since 0.27
      */
-    static final class Request {
+    static final class TestRequest {
 
         /**
          * Http method.
@@ -205,7 +205,7 @@ public abstract class RestApiServerBase {
          * @param path Request path
          * @param body Request body
          */
-        Request(final HttpMethod method, final String path, final Optional<JsonObject> body) {
+        TestRequest(final HttpMethod method, final String path, final Optional<JsonObject> body) {
             this.method = method;
             this.path = path;
             this.body = body;
@@ -217,7 +217,7 @@ public abstract class RestApiServerBase {
          * @param path Request path
          * @param body Request body
          */
-        Request(final HttpMethod method, final String path, final JsonObject body) {
+        TestRequest(final HttpMethod method, final String path, final JsonObject body) {
             this(method, path, Optional.of(body));
         }
 
@@ -226,7 +226,7 @@ public abstract class RestApiServerBase {
          * @param method Http method
          * @param path Request path
          */
-        Request(final HttpMethod method, final String path) {
+        TestRequest(final HttpMethod method, final String path) {
             this(method, path, Optional.empty());
         }
 
@@ -234,7 +234,7 @@ public abstract class RestApiServerBase {
          * Ctor with default GET method.
          * @param path Request path
          */
-        Request(final String path) {
+        TestRequest(final String path) {
             this(HttpMethod.GET, path);
         }
     }

--- a/src/test/java/com/artipie/api/StorageAliasesRestFlatTest.java
+++ b/src/test/java/com/artipie/api/StorageAliasesRestFlatTest.java
@@ -29,7 +29,7 @@ public final class StorageAliasesRestFlatTest extends RestApiServerBase {
             this.yamlAliases().getBytes(StandardCharsets.UTF_8)
         );
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/storages"),
+            vertx, ctx, new TestRequest("/api/v1/storages"),
             new UncheckedConsumer<>(
                 response -> JSONAssert.assertEquals(
                     response.body().toJsonArray().encode(),
@@ -48,7 +48,7 @@ public final class StorageAliasesRestFlatTest extends RestApiServerBase {
             this.yamlAliases().getBytes(StandardCharsets.UTF_8)
         );
         this.requestAndAssert(
-            vertx, ctx, new Request(String.format("/api/v1/repository/%s/storages", rname)),
+            vertx, ctx, new TestRequest(String.format("/api/v1/repository/%s/storages", rname)),
             new UncheckedConsumer<>(
                 response -> JSONAssert.assertEquals(
                     response.body().toJsonArray().encode(),
@@ -63,7 +63,7 @@ public final class StorageAliasesRestFlatTest extends RestApiServerBase {
     void returnsEmptyArrayIfAliasesDoNotExists(final Vertx vertx, final VertxTestContext ctx)
         throws Exception {
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/storages"),
+            vertx, ctx, new TestRequest("/api/v1/storages"),
             resp ->
                 MatcherAssert.assertThat(
                     resp.body().toJsonArray().isEmpty(), new IsEqual<>(true)

--- a/src/test/java/com/artipie/api/StorageAliasesRestOrgTest.java
+++ b/src/test/java/com/artipie/api/StorageAliasesRestOrgTest.java
@@ -27,7 +27,7 @@ public final class StorageAliasesRestOrgTest extends RestApiServerBase {
             this.yamlAliases().getBytes(StandardCharsets.UTF_8)
         );
         this.requestAndAssert(
-            vertx, ctx, new Request("/api/v1/storages"),
+            vertx, ctx, new TestRequest("/api/v1/storages"),
             new UncheckedConsumer<>(
                 response -> JSONAssert.assertEquals(
                     response.body().toJsonArray().encode(),
@@ -46,7 +46,7 @@ public final class StorageAliasesRestOrgTest extends RestApiServerBase {
             this.yamlAliases().getBytes(StandardCharsets.UTF_8)
         );
         this.requestAndAssert(
-            vertx, ctx, new Request(String.format("/api/v1/storages/%s", name)),
+            vertx, ctx, new TestRequest(String.format("/api/v1/storages/%s", name)),
             new UncheckedConsumer<>(
                 response -> JSONAssert.assertEquals(
                     response.body().toJsonArray().encode(),
@@ -65,7 +65,7 @@ public final class StorageAliasesRestOrgTest extends RestApiServerBase {
             this.yamlAliases().getBytes(StandardCharsets.UTF_8)
         );
         this.requestAndAssert(
-            vertx, ctx, new Request(String.format("/api/v1/repository/%s/storages", name)),
+            vertx, ctx, new TestRequest(String.format("/api/v1/repository/%s/storages", name)),
             new UncheckedConsumer<>(
                 response -> JSONAssert.assertEquals(
                     response.body().toJsonArray().encode(),


### PR DESCRIPTION
part of #1099 
I've simplified tests by extending `RestApiServerBase#requestAndAssert` method functionality and using it to avoid duplications.