### PR TITLE
feat: added endpoint to get users list

### DIFF
--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -117,7 +117,8 @@ public final class VertxMain {
                 new BlockingStorage(settings.repoConfigsStorage()),
                 settings.layout().toString(),
                 // @checkstyle MagicNumberCheck (1 line)
-                8086
+                8086,
+                settings.credentialsKey()
             )
         );
         return main;

--- a/src/main/java/com/artipie/api/UsersRest.java
+++ b/src/main/java/com/artipie/api/UsersRest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.api;
+
+import com.artipie.settings.users.CrudUsers;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.openapi.RouterBuilder;
+import org.eclipse.jetty.http.HttpStatus;
+
+/**
+ * REST API methods to manage Artipie users.
+ * @since 0.27
+ */
+public final class UsersRest extends BaseRest {
+
+    /**
+     * Crud users object.
+     */
+    private final CrudUsers users;
+
+    /**
+     * Ctor.
+     * @param users Crud users object
+     */
+    public UsersRest(final CrudUsers users) {
+        this.users = users;
+    }
+
+    @Override
+    public void init(final RouterBuilder rbr) {
+        rbr.operation("listAllUsers")
+            .handler(this::listAllUsers)
+            .failureHandler(this.errorHandler(HttpStatus.INTERNAL_SERVER_ERROR_500));
+    }
+
+    /**
+     * List all users.
+     * @param context Request context
+     */
+    private void listAllUsers(final RoutingContext context) {
+        context.response().setStatusCode(HttpStatus.OK_200)
+            .end(this.users.list().toString());
+    }
+
+}

--- a/src/main/java/com/artipie/api/ValidRepositoryName.java
+++ b/src/main/java/com/artipie/api/ValidRepositoryName.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * Valid repository name.
  * @since 0.26
  */
-public class ValidRepositoryName {
+public final class ValidRepositoryName {
     /**
      * Words that should not be present inside repository name.
      */

--- a/src/main/java/com/artipie/settings/Settings.java
+++ b/src/main/java/com/artipie/settings/Settings.java
@@ -6,11 +6,13 @@ package com.artipie.settings;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.auth.Authentication;
 import com.artipie.settings.users.Users;
 import com.artipie.settings.users.UsersFromEnv;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -59,6 +61,12 @@ public interface Settings {
      * @return Completion action with credentials
      */
     CompletionStage<Users> credentials();
+
+    /**
+     * Key for credentials yaml settings.
+     * @return Key for credentials
+     */
+    Optional<Key> credentialsKey();
 
     /**
      * Fake {@link Settings} using a file storage.
@@ -211,6 +219,11 @@ public interface Settings {
         @Override
         public CompletionStage<Users> credentials() {
             return CompletableFuture.completedFuture(this.cred);
+        }
+
+        @Override
+        public Optional<Key> credentialsKey() {
+            return Optional.empty();
         }
     }
 }

--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -1,7 +1,7 @@
 meta:
   storage:
     type: fs
-    path: /var/artipie/repo
+    path: /Users/alena/artipie/artipie/src/main/resources/example/repo
   credentials:
     -
       type: env

--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -1,7 +1,7 @@
 meta:
   storage:
     type: fs
-    path: /Users/alena/artipie/artipie/src/main/resources/example/repo
+    path: /var/artipie/repo
   credentials:
     -
       type: env

--- a/src/main/resources/swagger-ui/swagger-initializer-flat.js
+++ b/src/main/resources/swagger-ui/swagger-initializer-flat.js
@@ -4,7 +4,10 @@ window.onload = function() {
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle(
   {
-    url: "./yaml/flat.yaml",
+    urls: [
+          {url: "./yaml/flat.yaml", name: "Repositories"},
+          {url: "./yaml/users.yaml", name: "Users"},
+        ],
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/src/main/resources/swagger-ui/swagger-initializer-org.js
+++ b/src/main/resources/swagger-ui/swagger-initializer-org.js
@@ -4,7 +4,10 @@ window.onload = function() {
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle(
   {
-    url: "./yaml/org.yaml",
+    urls: [
+              {url: "./yaml/org.yaml", name: "Repositories"},
+              {url: "./yaml/users.yaml", name: "Users"},
+            ],
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/src/main/resources/swagger-ui/yaml/users.yaml
+++ b/src/main/resources/swagger-ui/yaml/users.yaml
@@ -1,0 +1,66 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Artipie - OpenAPI 3.0
+  description:
+    This is Atripie Server based on the OpenAPI 3.0 specification.
+  license:
+    name: MIT
+externalDocs:
+  description: Find out more about Artipie
+  url: https://github.com/artipie
+tags:
+  - name: users
+    description: Operations about users
+paths:
+  /api/v1/users:
+    get:
+      summary: List all users.
+      operationId: listAllUsers
+      tags:
+        - users
+      responses:
+        '200':
+          description: A list of the existing users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    User:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        pass:
+          type: string
+        type:
+          type: string
+        email:
+          type: string
+        groups:
+          type: array
+          items:
+            type: string

--- a/src/test/java/com/artipie/api/ManageUsersTest.java
+++ b/src/test/java/com/artipie/api/ManageUsersTest.java
@@ -48,7 +48,7 @@ class ManageUsersTest {
     /**
      * Test credentials key.
      */
-    private static final Key KEY = new Key.From("creds.yaml");
+    static final Key KEY = new Key.From("creds.yaml");
 
     /**
      * Test storage.

--- a/src/test/java/com/artipie/api/RestApiServerBase.java
+++ b/src/test/java/com/artipie/api/RestApiServerBase.java
@@ -125,7 +125,9 @@ public abstract class RestApiServerBase {
         this.asto = new BlockingStorage(new InMemoryStorage());
         this.caches = new SettingsCaches.Fake();
         vertx.deployVerticle(
-            new RestApi(this.caches, this.asto, this.layout(), this.prt),
+            new RestApi(
+                this.caches, this.asto, this.layout(), this.prt, Optional.of(ManageUsersTest.KEY)
+            ),
             context.succeedingThenComplete()
         );
         this.waitServer(vertx);

--- a/src/test/java/com/artipie/api/UsersRestTest.java
+++ b/src/test/java/com/artipie/api/UsersRestTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.api;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.misc.UncheckedConsumer;
+import com.artipie.settings.CredsConfigYaml;
+import com.artipie.settings.users.Users;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+/**
+ * Test for {@link UsersRest}.
+ * @since 0.27
+ */
+final class UsersRestTest extends RestApiServerBase {
+
+    @Test
+    void listsUsers(final Vertx vertx, final VertxTestContext ctx) throws Exception {
+        this.save(
+            new Key.From(ManageUsersTest.KEY),
+            new CredsConfigYaml().withUserAndGroups("Alice", List.of("readers")).withFullInfo(
+                "Bob", Users.PasswordFormat.PLAIN, "xyz", "bob@example.com", Set.of("admin")
+            ).toString().getBytes(StandardCharsets.UTF_8)
+        );
+        this.requestAndAssert(
+            vertx, ctx, new TestRequest("/api/v1/users"),
+            new UncheckedConsumer<>(
+                response -> JSONAssert.assertEquals(
+                    response.body().toString(),
+                    // @checkstyle LineLengthCheck (1 line)
+                    "[{\"name\":\"Alice\",\"pass\":123,\"type\":\"plain\",\"groups\":[\"readers\"]},{\"name\":\"Bob\",\"type\":\"plain\",\"pass\":\"xyz\",\"email\":\"bob@example.com\",\"groups\":[\"admin\"]}]",
+                    true
+                )
+            )
+        );
+    }
+
+    @Override
+    String layout() {
+        return "org";
+    }
+}

--- a/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
+++ b/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
@@ -6,6 +6,7 @@ package com.artipie.http;
 
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.asto.Content;
+import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.http.auth.Authentication;
 import com.artipie.http.headers.Authorization;
@@ -23,6 +24,7 @@ import com.artipie.settings.users.Users;
 import io.reactivex.Flowable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.hamcrest.MatcherAssert;
@@ -155,6 +157,11 @@ final class DockerRoutingSliceTest {
         @Override
         public CompletionStage<Users> credentials() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Key> credentialsKey() {
+            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
Part of #1099 
Added endpoint to get users list. 
As endpoint to manage users are the same for org and flat layouts, I've added new single open api yaml. In swagger, repositories and users APIs will be available by user's chose, check the screenshot:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/14931449/189680591-249de41c-9e7f-42ad-9911-35d66f3b186f.png">
