### PR TITLE
feat: get user info

### DIFF
--- a/src/main/java/com/artipie/api/ManageUsers.java
+++ b/src/main/java/com/artipie/api/ManageUsers.java
@@ -24,6 +24,7 @@ import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
 
 /**
  * Users from yaml file.
@@ -59,12 +60,15 @@ public final class ManageUsers implements CrudUsers {
         final JsonArrayBuilder builder = Json.createArrayBuilder();
         users.map(
             yaml -> yaml.keys().stream().map(node -> node.asScalar().value()).map(
-                name -> Json.createObjectBuilder().add("name", name).addAll(
-                    Json.createObjectBuilder(
+                name -> {
+                    final JsonObjectBuilder usr = Json.createObjectBuilder(
                         new Yaml2Json().apply(users.get().yamlMapping(name).toString())
                             .asJsonObject()
-                    )
-                ).build()
+                    );
+                    usr.remove("pass");
+                    usr.remove("type");
+                    return Json.createObjectBuilder().add("name", name).addAll(usr).build();
+                }
             ).collect(Collectors.toList())
         ).orElse(Collections.emptyList()).forEach(builder::add);
         return builder.build();

--- a/src/main/java/com/artipie/api/ManageUsers.java
+++ b/src/main/java/com/artipie/api/ManageUsers.java
@@ -60,18 +60,16 @@ public final class ManageUsers implements CrudUsers {
         final JsonArrayBuilder builder = Json.createArrayBuilder();
         users.map(
             yaml -> yaml.keys().stream().map(node -> node.asScalar().value()).map(
-                name -> {
-                    final JsonObjectBuilder usr = Json.createObjectBuilder(
-                        new Yaml2Json().apply(users.get().yamlMapping(name).toString())
-                            .asJsonObject()
-                    );
-                    usr.remove("pass");
-                    usr.remove("type");
-                    return Json.createObjectBuilder().add("name", name).addAll(usr).build();
-                }
+                name -> jsonFromYaml(name, users.get().yamlMapping(name))
             ).collect(Collectors.toList())
         ).orElse(Collections.emptyList()).forEach(builder::add);
         return builder.build();
+    }
+
+    @Override
+    public Optional<JsonObject> get(final String uname) {
+        return this.users().flatMap(yaml -> Optional.ofNullable(yaml.yamlMapping(uname)))
+            .map(yaml -> jsonFromYaml(uname, yaml));
     }
 
     @Override
@@ -133,5 +131,20 @@ public final class ManageUsers implements CrudUsers {
             }
         }
         return res;
+    }
+
+    /**
+     * Transform user info in yaml format to json.
+     * @param uname User name
+     * @param yaml Yaml info
+     * @return User info as json object
+     */
+    private static JsonObject jsonFromYaml(final String uname, final YamlMapping yaml) {
+        final JsonObjectBuilder usr = Json.createObjectBuilder(
+            new Yaml2Json().apply(yaml.toString()).asJsonObject()
+        );
+        usr.remove("pass");
+        usr.remove("type");
+        return Json.createObjectBuilder().add("name", uname).addAll(usr).build();
     }
 }

--- a/src/main/java/com/artipie/api/UsersRest.java
+++ b/src/main/java/com/artipie/api/UsersRest.java
@@ -7,6 +7,8 @@ package com.artipie.api;
 import com.artipie.settings.users.CrudUsers;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.openapi.RouterBuilder;
+import java.util.Optional;
+import javax.json.JsonValue;
 import org.eclipse.jetty.http.HttpStatus;
 
 /**
@@ -33,6 +35,25 @@ public final class UsersRest extends BaseRest {
         rbr.operation("listAllUsers")
             .handler(this::listAllUsers)
             .failureHandler(this.errorHandler(HttpStatus.INTERNAL_SERVER_ERROR_500));
+        rbr.operation("getUser")
+            .handler(this::getUser)
+            .failureHandler(this.errorHandler(HttpStatus.INTERNAL_SERVER_ERROR_500));
+    }
+
+    /**
+     * Get single user info.
+     * @param context Request context
+     */
+    private void getUser(final RoutingContext context) {
+        final Optional<JsonValue> usr = this.users.list().stream().filter(
+            item -> item.asJsonObject().getString("name")
+                .equals(context.pathParam(RepositoryName.UNAME))
+        ).findFirst();
+        if (usr.isPresent()) {
+            context.response().setStatusCode(HttpStatus.OK_200).end(usr.get().toString());
+        } else {
+            context.response().setStatusCode(HttpStatus.NOT_FOUND_404).end();
+        }
     }
 
     /**
@@ -40,8 +61,7 @@ public final class UsersRest extends BaseRest {
      * @param context Request context
      */
     private void listAllUsers(final RoutingContext context) {
-        context.response().setStatusCode(HttpStatus.OK_200)
-            .end(this.users.list().toString());
+        context.response().setStatusCode(HttpStatus.OK_200).end(this.users.list().toString());
     }
 
 }

--- a/src/main/java/com/artipie/api/UsersRest.java
+++ b/src/main/java/com/artipie/api/UsersRest.java
@@ -8,7 +8,7 @@ import com.artipie.settings.users.CrudUsers;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import java.util.Optional;
-import javax.json.JsonValue;
+import javax.json.JsonObject;
 import org.eclipse.jetty.http.HttpStatus;
 
 /**
@@ -45,10 +45,7 @@ public final class UsersRest extends BaseRest {
      * @param context Request context
      */
     private void getUser(final RoutingContext context) {
-        final Optional<JsonValue> usr = this.users.list().stream().filter(
-            item -> item.asJsonObject().getString("name")
-                .equals(context.pathParam(RepositoryName.UNAME))
-        ).findFirst();
+        final Optional<JsonObject> usr = this.users.get(context.pathParam(RepositoryName.UNAME));
         if (usr.isPresent()) {
             context.response().setStatusCode(HttpStatus.OK_200).end(usr.get().toString());
         } else {

--- a/src/main/java/com/artipie/settings/users/CrudUsers.java
+++ b/src/main/java/com/artipie/settings/users/CrudUsers.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.settings.users;
 
+import java.util.Optional;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
@@ -17,6 +18,13 @@ public interface CrudUsers {
      * @return Artipie users
      */
     JsonArray list();
+
+    /**
+     * Get user info.
+     * @param uname Username
+     * @return User info if user is found
+     */
+    Optional<JsonObject> get(String uname);
 
     /**
      * Add user.

--- a/src/main/resources/swagger-ui/yaml/users.yaml
+++ b/src/main/resources/swagger-ui/yaml/users.yaml
@@ -34,6 +34,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/v1/users/{uname}:
+    get:
+      summary: Get user info.
+      operationId: getUser
+      tags:
+        - users
+      parameters:
+        - name: uname
+          in: path
+          required: true
+          description: User name
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        '404':
+          description: User does not exist
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Error:
@@ -53,10 +81,6 @@ components:
         - name
       properties:
         name:
-          type: string
-        pass:
-          type: string
-        type:
           type: string
         email:
           type: string

--- a/src/test/java/com/artipie/api/UsersRestTest.java
+++ b/src/test/java/com/artipie/api/UsersRestTest.java
@@ -41,7 +41,7 @@ final class UsersRestTest extends RestApiServerBase {
                     response.body().toString(),
                     // @checkstyle LineLengthCheck (1 line)
                     "[{\"name\":\"Alice\",\"groups\":[\"readers\"]},{\"name\":\"Bob\",\"email\":\"bob@example.com\",\"groups\":[\"admin\"]}]",
-                    true
+                    false
                 )
             )
         );
@@ -64,7 +64,7 @@ final class UsersRestTest extends RestApiServerBase {
                     response.body().toString(),
                     // @checkstyle LineLengthCheck (1 line)
                     "{\"name\":\"John\",\"email\":\"john@example.com\",\"groups\":[\"readers\",\"tags\"]}",
-                    true
+                    false
                 )
             )
         );

--- a/src/test/java/com/artipie/api/UsersRestTest.java
+++ b/src/test/java/com/artipie/api/UsersRestTest.java
@@ -13,6 +13,9 @@ import io.vertx.junit5.VertxTestContext;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -20,6 +23,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
  * Test for {@link UsersRest}.
  * @since 0.27
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class UsersRestTest extends RestApiServerBase {
 
     @Test
@@ -36,9 +40,44 @@ final class UsersRestTest extends RestApiServerBase {
                 response -> JSONAssert.assertEquals(
                     response.body().toString(),
                     // @checkstyle LineLengthCheck (1 line)
-                    "[{\"name\":\"Alice\",\"pass\":123,\"type\":\"plain\",\"groups\":[\"readers\"]},{\"name\":\"Bob\",\"type\":\"plain\",\"pass\":\"xyz\",\"email\":\"bob@example.com\",\"groups\":[\"admin\"]}]",
+                    "[{\"name\":\"Alice\",\"groups\":[\"readers\"]},{\"name\":\"Bob\",\"email\":\"bob@example.com\",\"groups\":[\"admin\"]}]",
                     true
                 )
+            )
+        );
+    }
+
+    @Test
+    void getsUser(final Vertx vertx, final VertxTestContext ctx) throws Exception {
+        this.save(
+            new Key.From(ManageUsersTest.KEY),
+            new CredsConfigYaml().withUsers("Mark")
+                .withFullInfo(
+                    "John", Users.PasswordFormat.PLAIN, "231", "john@example.com",
+                    Set.of("readers", "tags")
+                ).toString().getBytes(StandardCharsets.UTF_8)
+        );
+        this.requestAndAssert(
+            vertx, ctx, new TestRequest("/api/v1/users/John"),
+            new UncheckedConsumer<>(
+                response -> JSONAssert.assertEquals(
+                    response.body().toString(),
+                    // @checkstyle LineLengthCheck (1 line)
+                    "{\"name\":\"John\",\"email\":\"john@example.com\",\"groups\":[\"readers\",\"tags\"]}",
+                    true
+                )
+            )
+        );
+    }
+
+    @Test
+    void returnsNotFoundIfUserDoesNotExist(final Vertx vertx, final VertxTestContext ctx)
+        throws Exception {
+        this.requestAndAssert(
+            vertx, ctx, new TestRequest("/api/v1/users/Jane"),
+            response -> MatcherAssert.assertThat(
+                response.statusCode(),
+                new IsEqual<>(HttpStatus.NOT_FOUND_404)
             )
         );
     }


### PR DESCRIPTION
Part of #1099 
Fixed `ManageUsers#list()` to remove user's password from user info, we should not return the password in rest api responses and added get method to obtain single user info.