### PR TITLE
fix: Broken links on wiki pages #1137

### DIFF
--- a/.wiki/repositories/anaconda.md
+++ b/.wiki/repositories/anaconda.md
@@ -30,7 +30,7 @@ the repository `settings` section contains two optional parameters:
 - `clean_auth_token_at` - time to clean expired auth tokens as a cron expression.
   Default value is `0 0 1 * * ?` - at 01 AM every night.
 
-Find more information about permissions [here](./Configuration-Repository-Permissions.md).
+Find more information about permissions [here](./Configuration-Repository-Permissions).
 
 To use Artipie repository with `conda` command-line tool, add the repository to `conda` channels settings to `/root/.condarc` file
 (check [documentation](https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html) for more details):

--- a/.wiki/repositories/composer.md
+++ b/.wiki/repositories/composer.md
@@ -18,7 +18,7 @@ repo:
 The Composer repository configuration requires `url` field that contains repository full URL,
 `{host}` and `{port}` are Artipie service host and port, `{repository-name}`
 is the name of the repository (and repository name is the name of the repo config yaml file). Check
-[storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+[storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 To upload the file into repository, use `PUT` HTTP request:

--- a/.wiki/repositories/debian.md
+++ b/.wiki/repositories/debian.md
@@ -27,9 +27,9 @@ where
 - `Architectures` is a space separated [list of the architectures](https://wiki.debian.org/DebianRepository/Format#Architectures),
 supported by the repository, required;
 - Debian repository supports gpg signature, to enable it, provide gpg password in `gpg_password` field and 
-secret file location `gpg_secret_key` relatively to [Artipie configuration storage](./Configuration.md).
+secret file location `gpg_secret_key` relatively to [Artipie configuration storage](./Configuration).
 
-Check [storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+Check [storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 To use Artipie Debian repository, add local repository to the list of repos for `apt` by adding

--- a/.wiki/repositories/docker-proxy.md
+++ b/.wiki/repositories/docker-proxy.md
@@ -27,4 +27,4 @@ will try to request the image from each remote while the image is not found.
 When `storage` section under `meta` section in configured, it is also possible to push images
 using `docker push` command to proxy repository and store them locally.
 
-Find the example how to pull and push images into docker registry in [Docker repository section](./docker.md#usage-example).
+Find the example how to pull and push images into docker registry in [Docker repository section](./docker#usage-example).

--- a/.wiki/repositories/docker.md
+++ b/.wiki/repositories/docker.md
@@ -16,7 +16,7 @@ repo:
     "*":
       - download
 ```
-Note, that Docker repository also supports [granular permissions](./Configuration-Repository-Permissions.md#docker-repository-granular-permissions).
+Note, that Docker repository also supports [granular permissions](./Configuration-Repository-Permissions#docker-repository-granular-permissions).
 
 ### Usage example
 

--- a/.wiki/repositories/file.md
+++ b/.wiki/repositories/file.md
@@ -1,7 +1,7 @@
 ## File
 
 Files repository is a general purpose file storage which provides API for upload and download: `PUT` requests for upload and `GET` for download.
-To set up this repository, create config with `file` repository type and storage configuration. [Permissions configuration](./Configuration-Repository-Permissions.md)
+To set up this repository, create config with `file` repository type and storage configuration. [Permissions configuration](./Configuration-Repository-Permissions)
 can authorize users allowed to upload and download.
 
 *Example:*

--- a/.wiki/repositories/gem.md
+++ b/.wiki/repositories/gem.md
@@ -14,7 +14,7 @@ repo:
       - upload
 ```
 Check
-[storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+[storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 Before uploading gems, obtain a key for authorization and set it to `GEM_HOST_API_KEY` environment variable. 

--- a/.wiki/repositories/go.md
+++ b/.wiki/repositories/go.md
@@ -13,7 +13,7 @@ repo:
     "*":
       - download
 ```
-Check [storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+Check [storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 In order to use Artipie Go repository, declare the following environment variables:

--- a/.wiki/repositories/helm.md
+++ b/.wiki/repositories/helm.md
@@ -17,7 +17,7 @@ repo:
 The repository configuration requires `url` field that contains repository full URL,
 `{host}` and `{port}` are Artipie service host and port, `{repository-name}`
 is the name of the repository (and repository name is the name of the repo config yaml file). Check
-[storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+[storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 The chart can be published with simple HTTP `PUT` request:

--- a/.wiki/repositories/hexpm.md
+++ b/.wiki/repositories/hexpm.md
@@ -19,7 +19,7 @@ repo:
        - download
 ```
 Repository name is the name of the repo config yaml file(e.g. `my_hexpm`).
-Check [storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md) 
+Check [storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions) 
 documentations to learn more about these settings.
 
 To use your HexPM repository in Elixir project with `mix` build tool, add the following configuration

--- a/.wiki/repositories/npm-proxy.md
+++ b/.wiki/repositories/npm-proxy.md
@@ -15,7 +15,7 @@ repo:
       url: http://npmjs-repo/
 ```
 
-All the fields of YAML config are required, `path` is the repository relative path, [storage section](./Configuration-Storage.md)
+All the fields of YAML config are required, `path` is the repository relative path, [storage section](./Configuration-Storage)
 configures storage to cache the packages, `settings` section sets remote repository url.
 
 To use Artipie NPM proxy repository with `npm` client, specify the repository URL with `--registry` option:

--- a/.wiki/repositories/npm.md
+++ b/.wiki/repositories/npm.md
@@ -18,7 +18,7 @@ repo:
 The NPM repository configuration requires `url` field that contains repository full URL,
 `{host}` and `{port}` are Artipie service host and port, `{repository-name}`
 is the name of the repository (and repository name is the name of the repo config yaml file). Check
-[storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+[storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 To use NPM repository with `npm` client, you can specify Artipie NPM repository with `--registry` option:

--- a/.wiki/repositories/pypi-proxy.md
+++ b/.wiki/repositories/pypi-proxy.md
@@ -20,7 +20,7 @@ repo:
 In the settings `remotes` section should have one `url` item with cache storage (the cache storage is required),
 username and password are optional credentials for remote. Caching feature makes all previously accessed 
 indexes and packages available when remote repository is down.
-Check [storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+Check [storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about its properties.
 
 To install the package with `pip install` specify Artipie repository url with `--index-url` option:

--- a/.wiki/repositories/pypi.md
+++ b/.wiki/repositories/pypi.md
@@ -14,7 +14,7 @@ repo:
     john:
       - upload
 ```
-Check [storage](./Configuration-Storage.md) and [permission](./Configuration-Repository-Permissions.md)
+Check [storage](./Configuration-Storage) and [permission](./Configuration-Repository-Permissions)
 documentations to learn more about these settings.
 
 To publish the packages with [twine](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)

--- a/.wiki/repositories/rpm.md
+++ b/.wiki/repositories/rpm.md
@@ -35,7 +35,7 @@ Section `setting` allows to configure repository-specific parameters and is not 
 - `update` section allows to set update mode: either update the repository when the package is uploaded via HTTP
   or schedule the update via cron
 
-[Permissions configuration](./Configuration-Repository-Permissions.md) section specifies users who can upload and download from the repository.
+[Permissions configuration](./Configuration-Repository-Permissions) section specifies users who can upload and download from the repository.
 
 In order to use Artipie `rpm` repository with `yum` follow the steps:
 


### PR DESCRIPTION
close: #1138 
Remove .md extension in links