### PR TITLE
wiki: corrected repo table links

### DIFF
--- a/.wiki/Configuration-Repository.md
+++ b/.wiki/Configuration-Repository.md
@@ -28,25 +28,25 @@ For now Artipie supports the following repository types:
 
 | Type                                               | Description                                                                               |
 |----------------------------------------------------|-------------------------------------------------------------------------------------------|
-| [Files](./repositories/file.md)                    | General purpose files repository                                                          |
-| [Files Proxy](./repositories/file-proxy-mirror.md) | Files repository proxy                                                                    |
-| [Maven](./repositories/maven.md)                   | [Java artifacts and dependencies repository](https://maven.apache.org/what-is-maven.html) |
-| [Maven Proxy](./repositories/maven-proxy.md)       | Proxy for maven repository                                                                |
-| [Rpm](./repositories/rpm.md)                       | `.rpm` ([linux binaries](https://rpm-packaging-guide.github.io/)) packages repository     |
-| [Docker](./repositories/docker.md)                 | [Docker images registry](https://docs.docker.com/registry/)                               |
-| [Docker Proxy](./repositories/docker-proxy.md)     | Proxy for docker repository                                                               |
-| [Helm](./repositories/helm.md)                     | [Helm charts repository](https://helm.sh/docs/topics/chart_repository/)                   |
-| [Npm](./repositories/npm.md)                       | [JavaScript code sharing and packages store](https://www.npmjs.com/)                      |
-| [Npm Proxy](./repositories/npm-proxy.md)           | Proxy for NPM repository                                                                  |
-| [Composer](./repositories/composer.md)             | [Dependency manager for PHP packages](https://getcomposer.org/)                           |
-| [NuGet](./repositories/nuget.md)                   | [Hosting service for .NET packages](https://www.nuget.org/packages)                       |
-| [Gem](./repositories/gem.md)                       | [RubyGem hosting service](https://rubygems.org/)                                          |
-| [PyPI](./repositories/pypi.md)                     | [Python packages index](https://pypi.org/)                                                |
-| [PyPI Proxy](./repositories/pypi-proxy.md)         | Proxy for Python repository                                                               |
-| [Go](./repositories/go.md)                         | [Go packages storages](https://golang.org/cmd/go/#hdr-Module_proxy_protocol)              |
-| [Debian](./repositories/debian.md)                 | [Debian linux packages repository](https://wiki.debian.org/DebianRepository/Format)       |
-| [Anaconda](./repositories/anaconda.md)             | [Built packages for data science](https://www.anaconda.com/)                              |
-| [HexPM](./repositories/hexpm.md)                   | [Package manager for Elixir and Erlang](https://www.hex.pm/)                              |
+| [Files](./repositories/file)                       | General purpose files repository                                                          |
+| [Files Proxy](./repositories/file-proxy-mirror)    | Files repository proxy                                                                    |
+| [Maven](./repositories/maven)                      | [Java artifacts and dependencies repository](https://maven.apache.org/what-is-maven.html) |
+| [Maven Proxy](./repositories/maven-proxy)          | Proxy for maven repository                                                                |
+| [Rpm](./repositories/rpm)                          | `.rpm` ([linux binaries](https://rpm-packaging-guide.github.io/)) packages repository     |
+| [Docker](./repositories/docker)                    | [Docker images registry](https://docs.docker.com/registry/)                               |
+| [Docker Proxy](./repositories/docker-proxy)        | Proxy for docker repository                                                               |
+| [Helm](./repositories/helm)                        | [Helm charts repository](https://helm.sh/docs/topics/chart_repository/)                   |
+| [Npm](./repositories/npm)                          | [JavaScript code sharing and packages store](https://www.npmjs.com/)                      |
+| [Npm Proxy](./repositories/npm-proxy)              | Proxy for NPM repository                                                                  |
+| [Composer](./repositories/composer)                | [Dependency manager for PHP packages](https://getcomposer.org/)                           |
+| [NuGet](./repositories/nuget)                      | [Hosting service for .NET packages](https://www.nuget.org/packages)                       |
+| [Gem](./repositories/gem)                          | [RubyGem hosting service](https://rubygems.org/)                                          |
+| [PyPI](./repositories/pypi)                        | [Python packages index](https://pypi.org/)                                                |
+| [PyPI Proxy](./repositories/pypi-proxy)            | Proxy for Python repository                                                               |
+| [Go](./repositories/go)                            | [Go packages storages](https://golang.org/cmd/go/#hdr-Module_proxy_protocol)              |
+| [Debian](./repositories/debian)                    | [Debian linux packages repository](https://wiki.debian.org/DebianRepository/Format)       |
+| [Anaconda](./repositories/anaconda)                | [Built packages for data science](https://www.anaconda.com/)                              |
+| [HexPM](./repositories/hexpm)                      | [Package manager for Elixir and Erlang](https://www.hex.pm/)                              |
 
 Detailed configuration for each repository is provided in the corresponding subsection below.
 


### PR DESCRIPTION
Removed `.md` extensions from repository types table as with this extension links do not work correctly.