### PR TITLE
wiki: fix links

### DIFF
--- a/.wiki/Configuration-Credentials.md
+++ b/.wiki/Configuration-Credentials.md
@@ -51,7 +51,7 @@ in the `pass` field.
 
 Users can be assigned to some groups, all repository permissions granted to the group are applied
 to the users participating in this group. More information about repository permissions can be found
-[here](./Configuration-Repository-Permissions.md).
+[here](./Configuration-Repository-Permissions).
 
 ### Credentials type `github`
 

--- a/.wiki/Configuration-Metrics.md
+++ b/.wiki/Configuration-Metrics.md
@@ -21,7 +21,7 @@ meta:
 
 ### Storage metrics
 
-Storage metrics will periodically publish statistics to [storage](./Configuration-Storage.md) as text files, 
+Storage metrics will periodically publish statistics to [storage](./Configuration-Storage) as text files, 
 here is the way to configure such metrics:
 ```yaml
 meta:

--- a/.wiki/Configuration-Repository-Permissions.md
+++ b/.wiki/Configuration-Repository-Permissions.md
@@ -1,6 +1,6 @@
 # Repository permissions
 
-Permissions for repository operations can be granted in the [repository configuration file](Configuration-Repository.md):
+Permissions for repository operations can be granted in the [repository configuration file](Configuration-Repository):
 ```yaml
 repo:
   ...
@@ -37,7 +37,7 @@ repo:
 ```
 Operations and their synonyms for users and groups are the same, users and groups can be mixed in 
 `permissions` section, the only rule here - groups names should start with `/` sign. Permissions granted 
-to the group are applied to the users participating in this group. Check [Credentials](./Configuration-Credentials.md) 
+to the group are applied to the users participating in this group. Check [Credentials](./Configuration-Credentials) 
 section to find out how to add users group.
 
 If `permissions` section is absent in repo config, then any supported operation is allowed for everyone,

--- a/.wiki/Configuration-Repository.md
+++ b/.wiki/Configuration-Repository.md
@@ -16,7 +16,7 @@ repo:
       - download
 ```
 `type` specifies the type of the repository (all supported types are listed below) and `storage` 
-[configures](./Configuration-Storage.md) a storage to store repository data. [Permissions section](./Configuration-Repository-Permissions.md)
+[configures](./Configuration-Storage) a storage to store repository data. [Permissions section](./Configuration-Repository-Permissions)
 allows to provide upload or download access for users and groups. 
 
 > **Warning**  
@@ -26,27 +26,27 @@ allows to provide upload or download access for users and groups.
 
 For now Artipie supports the following repository types:
 
-| Type                                               | Description                                                                               |
-|----------------------------------------------------|-------------------------------------------------------------------------------------------|
-| [Files](./repositories/file)                       | General purpose files repository                                                          |
-| [Files Proxy](./repositories/file-proxy-mirror)    | Files repository proxy                                                                    |
-| [Maven](./repositories/maven)                      | [Java artifacts and dependencies repository](https://maven.apache.org/what-is-maven.html) |
-| [Maven Proxy](./repositories/maven-proxy)          | Proxy for maven repository                                                                |
-| [Rpm](./repositories/rpm)                          | `.rpm` ([linux binaries](https://rpm-packaging-guide.github.io/)) packages repository     |
-| [Docker](./repositories/docker)                    | [Docker images registry](https://docs.docker.com/registry/)                               |
-| [Docker Proxy](./repositories/docker-proxy)        | Proxy for docker repository                                                               |
-| [Helm](./repositories/helm)                        | [Helm charts repository](https://helm.sh/docs/topics/chart_repository/)                   |
-| [Npm](./repositories/npm)                          | [JavaScript code sharing and packages store](https://www.npmjs.com/)                      |
-| [Npm Proxy](./repositories/npm-proxy)              | Proxy for NPM repository                                                                  |
-| [Composer](./repositories/composer)                | [Dependency manager for PHP packages](https://getcomposer.org/)                           |
-| [NuGet](./repositories/nuget)                      | [Hosting service for .NET packages](https://www.nuget.org/packages)                       |
-| [Gem](./repositories/gem)                          | [RubyGem hosting service](https://rubygems.org/)                                          |
-| [PyPI](./repositories/pypi)                        | [Python packages index](https://pypi.org/)                                                |
-| [PyPI Proxy](./repositories/pypi-proxy)            | Proxy for Python repository                                                               |
-| [Go](./repositories/go)                            | [Go packages storages](https://golang.org/cmd/go/#hdr-Module_proxy_protocol)              |
-| [Debian](./repositories/debian)                    | [Debian linux packages repository](https://wiki.debian.org/DebianRepository/Format)       |
-| [Anaconda](./repositories/anaconda)                | [Built packages for data science](https://www.anaconda.com/)                              |
-| [HexPM](./repositories/hexpm)                      | [Package manager for Elixir and Erlang](https://www.hex.pm/)                              |
+| Type                                        | Description                                                                               |
+|---------------------------------------------|-------------------------------------------------------------------------------------------|
+| [Files](./file)                             | General purpose files repository                                                          |
+| [Files Proxy](file-proxy-mirror)            | Files repository proxy                                                                    |
+| [Maven](./repositories/maven)               | [Java artifacts and dependencies repository](https://maven.apache.org/what-is-maven.html) |
+| [Maven Proxy](./repositories/maven-proxy)   | Proxy for maven repository                                                                |
+| [Rpm](./repositories/rpm)                   | `.rpm` ([linux binaries](https://rpm-packaging-guide.github.io/)) packages repository     |
+| [Docker](./repositories/docker)             | [Docker images registry](https://docs.docker.com/registry/)                               |
+| [Docker Proxy](./repositories/docker-proxy) | Proxy for docker repository                                                               |
+| [Helm](./repositories/helm)                 | [Helm charts repository](https://helm.sh/docs/topics/chart_repository/)                   |
+| [Npm](./repositories/npm)                   | [JavaScript code sharing and packages store](https://www.npmjs.com/)                      |
+| [Npm Proxy](./repositories/npm-proxy)       | Proxy for NPM repository                                                                  |
+| [Composer](./repositories/composer)         | [Dependency manager for PHP packages](https://getcomposer.org/)                           |
+| [NuGet](./repositories/nuget)               | [Hosting service for .NET packages](https://www.nuget.org/packages)                       |
+| [Gem](./repositories/gem)                   | [RubyGem hosting service](https://rubygems.org/)                                          |
+| [PyPI](./repositories/pypi)                 | [Python packages index](https://pypi.org/)                                                |
+| [PyPI Proxy](./repositories/pypi-proxy)     | Proxy for Python repository                                                               |
+| [Go](./repositories/go)                     | [Go packages storages](https://golang.org/cmd/go/#hdr-Module_proxy_protocol)              |
+| [Debian](./repositories/debian)             | [Debian linux packages repository](https://wiki.debian.org/DebianRepository/Format)       |
+| [Anaconda](./repositories/anaconda)         | [Built packages for data science](https://www.anaconda.com/)                              |
+| [HexPM](./repositories/hexpm)               | [Package manager for Elixir and Erlang](https://www.hex.pm/)                              |
 
 Detailed configuration for each repository is provided in the corresponding subsection below.
 

--- a/.wiki/Configuration.md
+++ b/.wiki/Configuration.md
@@ -8,10 +8,10 @@ of this file is `/etc/artipie/artipie.yml`.
 Yaml configuration file contains server meta configuration, such as:
  - `layout` - `flat` or `org` string, not required, default value is `flat`;
  - `storage` - repositories definition storage config, required;
- - `credentials` - user [credentials config](./Configuration-Credentials.md);
+ - `credentials` - user [credentials config](./Configuration-Credentials);
  - `configs` - repository config files location, not required, the storage key relative to the 
 main storage, or, in file system storage terms, subdirectory where repo configs are located relatively to the storage;
- - `metrics` - enable and set [metrics collection](./Configuration-Metrics.md), not required.
+ - `metrics` - enable and set [metrics collection](./Configuration-Metrics), not required.
 
 Example: 
 ```yaml
@@ -38,8 +38,8 @@ In `org` layout, repositories have a maintainer (owner) who can manage
 repositories and permissions; the maintainer can add,
 delete and edit repositories, add granular permissions for other users for each repository.
 
-Storage - is a [storage configuration](./Configuration-Storage.md)
-for [repository definitions](./Configuration-Repository.md).
+Storage - is a [storage configuration](./Configuration-Storage)
+for [repository definitions](./Configuration-Repository).
 It sets a storage where all config files for each repository are located. Keep in mind,
 Artipie user should have read and write permissions for this storage.
 
@@ -72,9 +72,9 @@ If the layout is `org`, then repository configurations will be located in users'
 │   │   │   nuget-repo.yaml
 ```
 
-In the examples above `_storages.yaml` is a file for [storages aliases](./Configuration-Storage.md#storage-aliases)
+In the examples above `_storages.yaml` is a file for [storages aliases](./Configuration-Storage#storage-aliases)
 (note, that is the case of `org` layout it can be added for users individually) and
-`_credentials.yaml` describes Artipie [users](./Configuration-Credentials.md). `repo` subdirectory
+`_credentials.yaml` describes Artipie [users](./Configuration-Credentials). `repo` subdirectory
 (as configured with `configs` field in `/etc/artipie/artipie.yml`) contains configs for repositories. If `configs` 
 setting is omitted in `/etc/artipie/artipie.yml`, then repo configs will be located in `/tmp/artipie/configs`
 directly.


### PR DESCRIPTION
Fixing wiki links again: they should not have `.md` at the end. Also, in the repository types table they do work, trying different variants. 