### PR TITLE
Optional '--jmx' for debug/test purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /var/artipie
 EXPOSE 8080 8086
 CMD [ \
   "java", \
+  $JVM_ARGS, \
   "--add-opens", "java.base/java.util=ALL-UNNAMED", \
   "--add-opens", "java.base/java.security=ALL-UNNAMED", \
   "-cp", "/usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/*", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,5 @@ COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
 VOLUME /var/artipie /etc/artipie
 WORKDIR /var/artipie
 EXPOSE 8080 8086
-CMD [ \
-  "java", \
-  $JVM_ARGS, \
-  "--add-opens", "java.base/java.util=ALL-UNNAMED", \
-  "--add-opens", "java.base/java.security=ALL-UNNAMED", \
-  "-cp", "/usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/*", \
-  "com.artipie.VertxMain", \
-  "--config-file=/etc/artipie/artipie.yml", \
-  "--port=8080", \
-  "--api-port=8086" \
-]
+CMD [ "sh", "-c", "java $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]
+


### PR DESCRIPTION
I suggest adding optional `--jmx` flag for debug/test purposes. It will be disabled by default. Usage:
`docker run .... -p 8888:8888 artipie/artipie --jmx`