### PR TITLE
fix: github auth is broken

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: Integation tests
+name: Integration tests
 "on":
   push:
     branches:

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto-core</artifactId>
-      <version>v1.13.0</version>
+      <version>v1.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,8 @@ SOFTWARE.
       <!-- Do not remove this exclusion! No tests will run if dependency is not excluded! -->
       <exclusions>
         <exclusion>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,13 @@ SOFTWARE.
       <groupId>com.artipie</groupId>
       <artifactId>asto-core</artifactId>
       <version>v1.14.1</version>
+      <!-- Do not remove this exclusion! No tests will run if dependency is not excluded! -->
+      <exclusions>
+        <exclusion>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,19 +159,11 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-github</artifactId>
-      <version>1.1.2</version>
+      <version>1.3.2</version>
       <exclusions>
         <exclusion>
           <groupId>com.jcabi</groupId>
           <artifactId>jcabi-xml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/test/java/com/artipie/settings/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/settings/YamlSettingsTest.java
@@ -86,32 +86,6 @@ class YamlSettingsTest {
     }
 
     @Test
-    void shouldBuildS3StorageFromSettings() throws Exception {
-        final YamlSettings settings = new YamlSettings(
-            Yaml.createYamlInput(
-                String.join(
-                    "",
-                    "meta:\n",
-                    "  storage:\n",
-                    "    type: s3\n",
-                    "    bucket: my-bucket\n",
-                    "    region: my-region\n",
-                    "    endpoint: https://my-s3-provider.com\n",
-                    "    credentials:\n",
-                    "      type: basic\n",
-                    "      accessKeyId: ***\n",
-                    "      secretAccessKey: ***"
-                )
-            ).readYamlMapping(),
-            new SettingsCaches.All()
-        );
-        MatcherAssert.assertThat(
-            settings.storage(),
-            Matchers.notNullValue()
-        );
-    }
-
-    @Test
     void shouldCreateAuthFromEnv() throws Exception {
         final YamlSettings settings = new YamlSettings(
             this.config("some/path", this.credentials("env")),

--- a/src/test/java/com/artipie/settings/YamlStorageTest.java
+++ b/src/test/java/com/artipie/settings/YamlStorageTest.java
@@ -6,7 +6,6 @@ package com.artipie.settings;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.fs.FileStorage;
-import com.artipie.asto.s3.S3Storage;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -32,51 +31,6 @@ class YamlStorageTest {
         MatcherAssert.assertThat(
             settings.storage(),
             Matchers.instanceOf(FileStorage.class)
-        );
-    }
-
-    @Test
-    public void shouldBuildS3StorageFromFullSettings() throws Exception {
-        final YamlStorage settings = new YamlStorage(
-            Yaml.createYamlInput(
-                String.join(
-                    "",
-                    "type: s3\n",
-                    "bucket: my-bucket\n",
-                    "region: my-region\n",
-                    "endpoint: https://my-s3-provider.com\n",
-                    "credentials:\n",
-                    "  type: basic\n",
-                    "  accessKeyId: ***\n",
-                    "  secretAccessKey: ***\n"
-                )
-            ).readYamlMapping()
-        );
-        MatcherAssert.assertThat(
-            settings.storage(),
-            Matchers.instanceOf(S3Storage.class)
-        );
-    }
-
-    @Test
-    public void shouldBuildS3StorageFromMinimalSettings() throws Exception {
-        System.getProperties().put("aws.region", "my-region");
-        final YamlStorage settings = new YamlStorage(
-            Yaml.createYamlInput(
-                String.join(
-                    "",
-                    "type: s3\n",
-                    "bucket: my-bucket\n",
-                    "credentials:\n",
-                    "  type: basic\n",
-                    "  accessKeyId: ***\n",
-                    "  secretAccessKey: ***\n"
-                )
-            ).readYamlMapping()
-        );
-        MatcherAssert.assertThat(
-            settings.storage(),
-            Matchers.instanceOf(S3Storage.class)
         );
     }
 


### PR DESCRIPTION
I've caught the following exception on Central:
```
java.util.concurrent.CompletionException: com.google.common.util.concurrent.ExecutionError: java.lang.NoClassDefFoundError: org/hamcrest/Matcher
java.util.concurrent.CompletionException: com.google.common.util.concurrent.ExecutionError: java.lang.NoClassDefFoundError: org/hamcrest/Matcher
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:653)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: com.google.common.util.concurrent.ExecutionError: java.lang.NoClassDefFoundError: org/hamcrest/Matcher
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4848)
	at com.artipie.settings.cache.CachedUsers.lambda$user$0(CachedUsers.java:64)
	at com.artipie.asto.misc.UncheckedScalar.value(UncheckedScalar.java:34)
	at com.artipie.settings.cache.CachedUsers.user(CachedUsers.java:65)
	at com.artipie.settings.YamlSettings$Cached.user(YamlSettings.java:322)
	at com.artipie.http.auth.Authentication$Joined.lambda$user$0(Authentication.java:224)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1002)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at com.artipie.http.auth.Authentication$Joined.user(Authentication.java:226)
	at com.artipie.auth.LoggingAuth.user(LoggingAuth.java:49)
	at com.artipie.http.auth.BasicAuthScheme.lambda$user$3(BasicAuthScheme.java:59)
	at java.base/java.util.Optional.flatMap(Optional.java:289)
	at com.artipie.http.auth.BasicAuthScheme.user(BasicAuthScheme.java:59)
	at com.artipie.http.auth.BasicAuthScheme.authenticate(BasicAuthScheme.java:44)
	at com.artipie.http.auth.AuthSlice.response(AuthSlice.java:65)
	at com.artipie.http.Slice$Wrap.response(Slice.java:62)
	at com.artipie.http.rt.RtRulePath.response(RtRulePath.java:53)
	at com.artipie.http.rt.SliceRoute.lambda$response$0(SliceRoute.java:69)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1002)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at com.artipie.http.rt.SliceRoute.response(SliceRoute.java:72)
	at com.artipie.http.Slice$Wrap.response(Slice.java:62)
	at com.artipie.http.slice.TrimPathSlice.response(TrimPathSlice.java:95)
	at com.artipie.http.ContinueSlice.response(ContinueSlice.java:45)
	at com.artipie.http.async.AsyncSlice.lambda$response$0(AsyncSlice.java:44)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 5 more
Caused by: java.lang.NoClassDefFoundError: org/hamcrest/Matcher
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3373)
	at java.base/java.lang.Class.getConstructor0(Class.java:3578)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2754)
	at com.jcabi.http.request.DefaultResponse.as(DefaultResponse.java:161)
	at com.jcabi.github.RtJson.fetch(RtJson.java:76)
	at com.jcabi.github.RtUser.json(RtUser.java:166)
	at com.jcabi.github.RtUser.login(RtUser.java:121)
	at com.artipie.auth.GithubAuth.lambda$new$0(GithubAuth.java:47)
	at com.artipie.auth.GithubAuth.user(GithubAuth.java:69)
	at com.artipie.settings.cache.CachedUsers$Data.user(CachedUsers.java:137)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4853)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
	... 46 more
Caused by: java.lang.ClassNotFoundException: org.hamcrest.Matcher
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 62 more
```
From stack trace, it's clear that `jcabi-github` uses `hamcrest` in the main code and it's not correct to exclude the library. 
Also, I've updated asto. As s3 is now in a separate module, I've removed tests related to s3.