### PR TITLE
fix: AuthFromEnv corrected, hamcrest added to the main code

### DIFF
--- a/examples/artipie.yml
+++ b/examples/artipie.yml
@@ -3,3 +3,6 @@ meta:
   storage:
     type: fs
     path: /var/artipie/cfg
+  credentials:
+    type: file
+    path: _credentials.yaml

--- a/examples/conda/run.sh
+++ b/examples/conda/run.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # Login (required by anaconda client)
-anaconda login --username any --password any
+anaconda login --username alice --password qwerty123
 
 # Upload package.
 anaconda upload ./snappy-1.1.3-0.tar.bz2

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,14 @@ SOFTWARE.
           <groupId>com.jcabi</groupId>
           <artifactId>jcabi-xml</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-library</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -335,12 +343,12 @@ SOFTWARE.
       <artifactId>micrometer-registry-prometheus</artifactId>
       <version>1.9.5</version>
     </dependency>
-    <!-- Test scope-->
+    <!-- Hamcrest is required in the main code for github auth -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
     </dependency>
+    <!-- Test scope-->
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>

--- a/src/main/java/com/artipie/auth/AuthFromEnv.java
+++ b/src/main/java/com/artipie/auth/AuthFromEnv.java
@@ -54,7 +54,7 @@ public final class AuthFromEnv implements Authentication {
             && Objects.equals(Objects.requireNonNull(password), this.env.get(AuthFromEnv.ENV_PASS))) {
             result = Optional.of(new Authentication.User(username));
         } else {
-            result = Optional.of(new Authentication.User("anonymous"));
+            result = Optional.empty();
         }
         return result;
     }

--- a/src/test/java/com/artipie/conda/CondaITCase.java
+++ b/src/test/java/com/artipie/conda/CondaITCase.java
@@ -38,6 +38,7 @@ public final class CondaITCase {
     @RegisterExtension
     final TestDeployment containers = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
+            .withCredentials("_credentials.yaml")
             .withRepoConfig("conda/conda.yml", "my-conda")
             .withRepoConfig("conda/conda-port.yml", "my-conda-port")
             .withExposedPorts(8081),
@@ -119,7 +120,7 @@ public final class CondaITCase {
         this.containers.assertExec(
             "Login was not successful",
             new ContainerResultMatcher(),
-            "anaconda", "login", "--username", "any", "--password", "any"
+            "anaconda", "login", "--username", "alice", "--password", "123"
         );
         this.containers.assertExec(
             "Package was not installed successfully",

--- a/src/test/java/com/artipie/conda/CondaITCase.java
+++ b/src/test/java/com/artipie/conda/CondaITCase.java
@@ -131,7 +131,7 @@ public final class CondaITCase {
                         String.format("Using Anaconda API: http://artipie:%s/%s/", port, repo)
                     ),
                     // @checkstyle LineLengthCheck (1 line)
-                    new StringContains("Uploading file \"anonymous/example-package/0.0.1/linux-64/example-package-0.0.1-0.tar.bz2\""),
+                    new StringContains("Uploading file \"alice/example-package/0.0.1/linux-64/example-package-0.0.1-0.tar.bz2\""),
                     new StringContains("Upload complete")
                 )
             ),

--- a/src/test/java/com/artipie/docker/DockerProxyIT.java
+++ b/src/test/java/com/artipie/docker/DockerProxyIT.java
@@ -42,6 +42,7 @@ final class DockerProxyIT {
     @RegisterExtension
     final TestDeployment deployment = new TestDeployment(
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
+            .withCredentials("_credentials.yaml")
             .withRepoConfig("docker/docker-proxy.yml", "my-docker"),
         () -> new TestDeployment.ClientContainer("alpine:3.11")
             .withPrivilegedMode(true)

--- a/src/test/java/com/artipie/settings/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/settings/YamlSettingsTest.java
@@ -149,7 +149,7 @@ class YamlSettingsTest {
     }
 
     @Test
-    void authorizesWithoutCredentialsSection() throws Exception {
+    void doNotAuthorizeWithoutCredentialsSection() throws Exception {
         final YamlSettings settings = new YamlSettings(
             Yaml.createYamlMappingBuilder().add(
                 "meta",
@@ -164,9 +164,8 @@ class YamlSettingsTest {
         );
         MatcherAssert.assertThat(
             settings.auth().toCompletableFuture().get()
-                .user("any_name", "any_password")
-                .get().name(),
-            new IsEqual<>("anonymous")
+                .user("any_name", "any_password").isEmpty(),
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
`AuthFromEnv` should return empty optional if it fails to authorize user and `hamcrest` is required in the main code for `jcabi-github` to work properly.

Had to correct several tests and add credentials settings for smoke tests: `conda` client does not work without users and authorization at all, before the fix, Artipie simply used this anonymous from `AuthFromEnv`, now it uses user from credentials as should.