### PR TITLE
fix: use cached auth properly

### DIFF
--- a/src/main/resources/example/artipie.yaml
+++ b/src/main/resources/example/artipie.yaml
@@ -9,7 +9,7 @@ meta:
       type: github
     -
       type: file
-      path: _credentials.yml
+      path: _credentials.yaml
   layout: org
   base_url: http://central.artipie.com/
   metrics:


### PR DESCRIPTION
While reviewing https://github.com/artipie/front/pull/106 I run to guava cache "Recursive load" error in the case of specific auth configuration. The error was caused by double caching of github auth, which should not be done. Removed extra caching and corresponding classes, now all the caching is implemented via `SettingsCaches.All` class.