### PR TITLE
Do not create metrics related slices when metrics are not defined

### DIFF
--- a/src/main/java/com/artipie/http/BaseSlice.java
+++ b/src/main/java/com/artipie/http/BaseSlice.java
@@ -8,6 +8,7 @@ import com.artipie.MeasuredSlice;
 import com.artipie.http.slice.LoggingSlice;
 import com.artipie.metrics.Metrics;
 import com.artipie.metrics.PrefixedMetrics;
+import com.artipie.metrics.nop.NopMetrics;
 import java.util.logging.Level;
 
 /**
@@ -29,20 +30,40 @@ public final class BaseSlice extends Slice.Wrap {
      */
     public BaseSlice(final Metrics metrics, final Slice origin) {
         super(
-            new TrafficMetricSlice(
-                new ResponseMetricsSlice(
-                    new SafeSlice(
-                        new MeasuredSlice(
-                            new LoggingSlice(
-                                Level.INFO,
-                                origin
-                            )
+            BaseSlice.wrapToBaseMetricsSlices(
+                metrics,
+                new SafeSlice(
+                    new MeasuredSlice(
+                        new LoggingSlice(
+                            Level.INFO,
+                            origin
                         )
-                    ),
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Wraps slice to metric related slices when {@code Metrics} is defined.
+     *
+     * @param metrics Defined metrics.
+     * @param origin Original slice.
+     * @return Wrapped slice.
+     */
+    private static Slice wrapToBaseMetricsSlices(final Metrics metrics, final Slice origin) {
+        final Slice res;
+        if (metrics instanceof NopMetrics) {
+            res = origin;
+        } else {
+            res = new TrafficMetricSlice(
+                new ResponseMetricsSlice(
+                    origin,
                     new PrefixedMetrics(metrics, "http.response.")
                 ),
                 new PrefixedMetrics(metrics, "http.")
-            )
-        );
+            );
+        }
+        return res;
     }
 }

--- a/src/main/java/com/artipie/http/MainSlice.java
+++ b/src/main/java/com/artipie/http/MainSlice.java
@@ -5,6 +5,7 @@
 package com.artipie.http;
 
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.amihaiemil.eoyaml.YamlNode;
 import com.artipie.asto.Key;
 import com.artipie.asto.SubStorage;
 import com.artipie.http.client.ClientSlices;
@@ -24,6 +25,7 @@ import com.artipie.metrics.MetricsFromConfig;
 import com.artipie.misc.ArtipieProperties;
 import com.artipie.settings.Settings;
 import com.artipie.settings.YamlStorage;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -112,6 +114,23 @@ public final class MainSlice extends Slice.Wrap {
     }
 
     /**
+     * Checks that metrics are collected by Prometheus.
+     *
+     * @param settings Artipie settings
+     * @return True if metrics are collected by Prometheus.
+     */
+    static boolean isPrometheusConfigAvailable(final Settings settings) {
+        return settings
+            .meta()
+            .yamlSequence("metrics")
+            .values()
+            .stream()
+            .filter(Objects::nonNull)
+            .map(YamlNode::asMapping)
+            .anyMatch(mapping -> MetricsFromConfig.PROMETHEUS.equals(mapping.string("type")));
+    }
+
+    /**
      * Metrics storage Yaml node.
      * @param settings Artipie settings
      * @return Yaml node, could be null
@@ -119,20 +138,5 @@ public final class MainSlice extends Slice.Wrap {
     private static Optional<YamlMapping> metricsStorage(final Settings settings) {
         return Optional.ofNullable(settings.meta().yamlMapping("metrics"))
             .flatMap(metrics -> Optional.ofNullable(metrics.yamlMapping("storage")));
-    }
-
-    /**
-     * Checks that metrics are collected by Prometheus.
-     *
-     * @param settings Artipie settings
-     * @return True if metrics are collected by Prometheus.
-     */
-    private static boolean isPrometheusConfigAvailable(final Settings settings) {
-        boolean res = false;
-        final YamlMapping metrics = settings.meta().yamlMapping("metrics");
-        if (metrics != null) {
-            res = MetricsFromConfig.PROMETHEUS.equals(metrics.string("type"));
-        }
-        return res;
     }
 }

--- a/src/main/java/com/artipie/http/MainSlice.java
+++ b/src/main/java/com/artipie/http/MainSlice.java
@@ -125,7 +125,7 @@ public final class MainSlice extends Slice.Wrap {
      * Checks that metrics are collected by Prometheus.
      *
      * @param settings Artipie settings
-     * @return true if metrics are collected by Prometheus.
+     * @return True if metrics are collected by Prometheus.
      */
     private static boolean isPrometheusConfigAvailable(final Settings settings) {
         boolean res = false;

--- a/src/main/java/com/artipie/http/MainSlice.java
+++ b/src/main/java/com/artipie/http/MainSlice.java
@@ -93,7 +93,7 @@ public final class MainSlice extends Slice.Wrap {
                     new SliceOptional<>(
                         settings,
                         MainSlice::isPrometheusConfigAvailable,
-                        available -> new PromuSlice(metrics)
+                        available -> new PrometheusSlice(metrics)
                     )
                 ),
                 new RtRulePath(
@@ -123,19 +123,16 @@ public final class MainSlice extends Slice.Wrap {
 
     /**
      * Checks that metrics are collected by Prometheus.
+     *
      * @param settings Artipie settings
-     * @return Yaml node, could be null
+     * @return true if metrics are collected by Prometheus.
      */
     private static boolean isPrometheusConfigAvailable(final Settings settings) {
-        final Optional<YamlMapping> myml =
-            Optional.ofNullable(settings.meta().yamlMapping("metrics"));
-        final boolean available;
-        if (myml.isPresent()) {
-            final String type = myml.get().string("type");
-            available = MetricsFromConfig.PROMETHEUS.equals(type);
-        } else {
-            available = false;
+        boolean res = false;
+        final YamlMapping metrics = settings.meta().yamlMapping("metrics");
+        if (metrics != null) {
+            res = MetricsFromConfig.PROMETHEUS.equals(metrics.string("type"));
         }
-        return available;
+        return res;
     }
 }

--- a/src/main/java/com/artipie/http/PrometheusSlice.java
+++ b/src/main/java/com/artipie/http/PrometheusSlice.java
@@ -30,7 +30,7 @@ import org.reactivestreams.Publisher;
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class PromuSlice implements Slice {
+public final class PrometheusSlice implements Slice {
 
     /**
      * Metrics.
@@ -41,7 +41,7 @@ public final class PromuSlice implements Slice {
      * New slice with metrics.
      * @param metrics Metrics
      */
-    public PromuSlice(final Metrics metrics) {
+    public PrometheusSlice(final Metrics metrics) {
         this.metrics = metrics;
     }
 

--- a/src/main/java/com/artipie/metrics/Metrics.java
+++ b/src/main/java/com/artipie/metrics/Metrics.java
@@ -31,6 +31,7 @@ public interface Metrics {
 
     /**
      * Publish metrics to output.
+     *
      * @param out Metrics output
      */
     void publish(MetricsOutput out);

--- a/src/main/java/com/artipie/metrics/MetricsFromConfig.java
+++ b/src/main/java/com/artipie/metrics/MetricsFromConfig.java
@@ -45,10 +45,10 @@ public final class MetricsFromConfig {
 
     /**
      * Ctor.
-     * @param metrics Yaml settings
+     * @param settings Yaml settings
      */
-    public MetricsFromConfig(final YamlSequence metrics) {
-        this.settings = metrics;
+    public MetricsFromConfig(final YamlSequence settings) {
+        this.settings = settings;
     }
 
     /**
@@ -88,7 +88,7 @@ public final class MetricsFromConfig {
      * @return Interval
      * @checkstyle MagicNumberCheck (500 lines)
      */
-    static Duration interval(final YamlNode node) {
+    private static Duration interval(final YamlNode node) {
         return Optional.ofNullable(node.asMapping().string("interval"))
             .map(interval -> Duration.ofSeconds(Integer.parseInt(interval)))
             .orElse(Duration.ofSeconds(5));
@@ -100,8 +100,8 @@ public final class MetricsFromConfig {
      * @return Metrics output if configured
      */
     private static Optional<MetricsOutput> metricsOutput(final YamlNode node) {
+        Optional<MetricsOutput> res = Optional.empty();
         final String type = node.asMapping().string(MetricsFromConfig.TYPE);
-        final Optional<MetricsOutput> res;
         if ("log".equals(type)) {
             res = Optional.of(new MetricsLogOutput(LoggerFactory.getLogger(Metrics.class)));
         } else if ("asto".equals(type)) {
@@ -113,8 +113,6 @@ public final class MetricsFromConfig {
                     )
                 )
             );
-        } else {
-            res = Optional.empty();
         }
         return res;
     }

--- a/src/main/java/com/artipie/metrics/memory/InMemoryMetrics.java
+++ b/src/main/java/com/artipie/metrics/memory/InMemoryMetrics.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /**
  * {@link Metrics} implementation storing data in memory.
@@ -21,34 +22,44 @@ public final class InMemoryMetrics implements Metrics {
     /**
      * Counters by name.
      */
-    private final ConcurrentMap<String, InMemoryCounter> cnts = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InMemoryCounter> counters = new ConcurrentHashMap<>();
 
     /**
      * Gauges by name.
      */
-    private final ConcurrentMap<String, InMemoryGauge> ggs = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InMemoryGauge> gauges = new ConcurrentHashMap<>();
 
     @Override
     public InMemoryCounter counter(final String name) {
-        return this.cnts.computeIfAbsent(name, ignored -> new InMemoryCounter());
+        return this.counters.computeIfAbsent(name, ignored -> new InMemoryCounter());
     }
 
     @Override
     public InMemoryGauge gauge(final String name) {
-        return this.ggs.computeIfAbsent(name, ignored -> new InMemoryGauge());
+        return this.gauges.computeIfAbsent(name, ignored -> new InMemoryGauge());
     }
 
     @Override
     public void publish(final MetricsOutput out) {
-        final Map<String, Long> counters = new HashMap<>(this.cnts.size());
-        for (final Map.Entry<String, InMemoryCounter> entry : this.cnts.entrySet()) {
-            counters.put(entry.getKey(), entry.getValue().value());
+        out.counters(InMemoryMetrics.metricToMap(this.counters, InMemoryCounter::value));
+        out.gauges(InMemoryMetrics.metricToMap(this.gauges, InMemoryGauge::value));
+    }
+
+    /**
+     * Get metrics data map by metrics map.
+     *
+     * @param source Metrics map.
+     * @param transform Function to transform metric to long value.
+     * @param <T> Metric type.
+     * @return Metric data map.
+     */
+    private static <T> Map<String, Long> metricToMap(
+        final Map<String, T> source,
+        final Function<T, Long> transform) {
+        final Map<String, Long> res = new HashMap<>(source.size());
+        for (final Map.Entry<String, T> entry : source.entrySet()) {
+            res.put(entry.getKey(), transform.apply(entry.getValue()));
         }
-        out.counters(counters);
-        final Map<String, Long> gauges = new HashMap<>(this.ggs.size());
-        for (final Map.Entry<String, InMemoryGauge> entry : this.ggs.entrySet()) {
-            gauges.put(entry.getKey(), entry.getValue().value());
-        }
-        out.gauges(gauges);
+        return res;
     }
 }

--- a/src/main/java/com/artipie/metrics/nop/NopMetrics.java
+++ b/src/main/java/com/artipie/metrics/nop/NopMetrics.java
@@ -37,6 +37,6 @@ public final class NopMetrics implements Metrics {
 
     @Override
     public void publish(final MetricsOutput out) {
-        // nothing to publish
+        throw new IllegalStateException("NopMetrics should not be used to publish metrics");
     }
 }

--- a/src/main/java/com/artipie/metrics/publish/MetricsOutput.java
+++ b/src/main/java/com/artipie/metrics/publish/MetricsOutput.java
@@ -7,7 +7,7 @@ package com.artipie.metrics.publish;
 import java.util.Map;
 
 /**
- * Metrics output to accepts published data.
+ * Metrics output to accept published data.
  * @since 0.19
  */
 public interface MetricsOutput {

--- a/src/test/java/com/artipie/PrometheusSliceITCase.java
+++ b/src/test/java/com/artipie/PrometheusSliceITCase.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @since 0.23
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class PromuSliceITCase {
+final class PrometheusSliceITCase {
 
     /**
      * Test deployments.

--- a/src/test/java/com/artipie/http/MainSliceTest.java
+++ b/src/test/java/com/artipie/http/MainSliceTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.http;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlSequenceBuilder;
+import com.artipie.metrics.MetricsFromConfig;
+import com.artipie.settings.Settings;
+import com.artipie.settings.users.UsersFromEnv;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MainSlice tests.
+ * @since 0.11
+ */
+public class MainSliceTest {
+
+    @Test
+    public void isPrometheusConfigAvailableShouldReturnFalseWhenPrometheusIsNotDefined() {
+        Assertions.assertFalse(
+            MainSlice.isPrometheusConfigAvailable(
+                MainSliceTest.createSettings("log")
+            ));
+    }
+
+    @Test
+    public void isPrometheusConfigAvailableShouldReturnFalseWhenPrometheusIsDefined() {
+        Assertions.assertTrue(
+            MainSlice.isPrometheusConfigAvailable(
+                MainSliceTest.createSettings("asto", MetricsFromConfig.PROMETHEUS)
+            ));
+    }
+
+    /**
+     * Creates settings.
+     *
+     * @param metrics Array of metric types.
+     * @return Settings.
+     */
+    private static Settings createSettings(final String... metrics) {
+        YamlSequenceBuilder seq = Yaml.createYamlSequenceBuilder();
+        for (final String type : metrics) {
+            seq = seq.add(
+                Yaml.createYamlMappingBuilder()
+                    .add("type", type).build()
+            );
+        }
+        return new Settings.Fake(
+            new UsersFromEnv(),
+            Yaml.createYamlMappingBuilder()
+                .add(
+                    "metrics",
+                    seq.build()
+                ).build()
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/http/PrometheusSliceTest.java
+++ b/src/test/java/com/artipie/http/PrometheusSliceTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Test case for {@link PromuSlice}.
+ * Test case for {@link PrometheusSlice}.
  *
  * @see <a href="https://sysdig.com/blog/prometheus-metrics/"/>
  * @since 0.23
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  * @checkstyle MethodNameCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-final class PromuSliceTest {
+final class PrometheusSliceTest {
 
     /**
      * Openmetrics text mime type.
@@ -71,7 +71,7 @@ final class PromuSliceTest {
         final Metrics metrics = new InMemoryMetrics();
         collect(metrics, name, value, type);
         MatcherAssert.assertThat(
-            new PromuSlice(metrics),
+            new PrometheusSlice(metrics),
             new SliceHasResponse(
                 new AllOf<>(
                     Arrays.asList(
@@ -104,7 +104,7 @@ final class PromuSliceTest {
         metrics.gauge("http.response.content").set(5000L);
         metrics.gauge("app.workload").set(300L);
         MatcherAssert.assertThat(
-            new PromuSlice(metrics),
+            new PrometheusSlice(metrics),
             new SliceHasResponse(
                 new RsHasBody(
                     new AnyOf<>(
@@ -140,7 +140,7 @@ final class PromuSliceTest {
                     "/prometheus/metrics?name=http_response_content&name=app_workload"
                 ),
                 new Headers.From(
-                    new Header(Accept.NAME, PromuSliceTest.PLAIN_TEXT)
+                    new Header(Accept.NAME, PrometheusSliceTest.PLAIN_TEXT)
                 ),
                 Content.EMPTY
             )
@@ -292,10 +292,10 @@ final class PromuSliceTest {
     ) {
         final String body;
         switch (mimetype) {
-            case PromuSliceTest.PLAIN_TEXT:
+            case PrometheusSliceTest.PLAIN_TEXT:
                 body = metricInPlainText(name, value, type);
                 break;
-            case PromuSliceTest.OPENMETRICS_TEXT:
+            case PrometheusSliceTest.OPENMETRICS_TEXT:
                 body = metricInOpenmetricsText(name, value, type);
                 break;
             default:

--- a/src/test/resources/artipie-metrics-prometheus.yaml
+++ b/src/test/resources/artipie-metrics-prometheus.yaml
@@ -8,4 +8,5 @@ meta:
     type: file
     path: _credentials.yaml
   metrics:
-    type: prometheus
+    -
+      type: prometheus


### PR DESCRIPTION
Closes #1174

- Do not create metrics related slices when metrics are not defined
- Added exception when `NopMetrics` is used to publish metrics
- `PromuXXX` rename to `PrometheusXXX`
- `InMemoryMetrics` refactoring