### PR TITLE
`Content` wrapper that allows to get chunks count and received data size

### DIFF
--- a/src/main/java/com/artipie/jfr/ChunksAndSizeMetricsContent.java
+++ b/src/main/java/com/artipie/jfr/ChunksAndSizeMetricsContent.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.jfr;
+
+import com.artipie.asto.Content;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.reactivestreams.Subscriber;
+
+/**
+ * Content wrapper that allows to get byte buffers count and size of content’s data.
+ * @since 0.28.0
+ */
+public final class ChunksAndSizeMetricsContent implements Content {
+    /**
+     * Original content.
+     */
+    private final Content original;
+
+    /**
+     * Callback consumer.
+     * The first attribute is chunks count, the second is size of received data.
+     */
+    private final BiConsumer<Integer, Long> callback;
+
+    /**
+     * Ctor.
+     * The first attribute of callback consumer is chunks count,
+     * the second is size of received data.
+     *
+     * @param original Original Content.
+     * @param callback Callback consumer.
+     */
+    public ChunksAndSizeMetricsContent(
+        final Content original,
+        final BiConsumer<Integer, Long> callback) {
+        this.original = original;
+        this.callback = callback;
+    }
+
+    @Override
+    public Optional<Long> size() {
+        return this.original.size();
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+        this.original.subscribe(
+            new ChunksAndSizeSubscriber(subscriber, this.callback)
+        );
+    }
+}

--- a/src/main/java/com/artipie/jfr/ChunksAndSizeSubscriber.java
+++ b/src/main/java/com/artipie/jfr/ChunksAndSizeSubscriber.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.jfr;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Subscriber wrapper that allows to get byte buffers count and size of received data.
+ *
+ * @since 0.28.0
+ */
+public final class ChunksAndSizeSubscriber implements Subscriber<ByteBuffer> {
+
+    /**
+     * Original subscriber.
+     */
+    private final Subscriber<? super ByteBuffer> original;
+
+    /**
+     * Callback consumer.
+     * The first attribute is chunks count, the second is size of received data.
+     */
+    private final BiConsumer<Integer, Long> callback;
+
+    /**
+     * Chunks counter.
+     */
+    private final AtomicInteger chunks;
+
+    /**
+     * Size of received data.
+     */
+    private final AtomicLong received;
+
+    /**
+     * Ctor.
+     * The first attribute of callback consumer is chunks count,
+     * the second is size of received data.
+     *
+     * @param original Original subscriber.
+     * @param callback Callback consumer.
+     */
+    public ChunksAndSizeSubscriber(final Subscriber<? super ByteBuffer> original,
+        final BiConsumer<Integer, Long> callback) {
+        this.original = original;
+        this.callback = callback;
+        this.chunks = new AtomicInteger(0);
+        this.received = new AtomicLong(0);
+    }
+
+    @Override
+    public void onSubscribe(final Subscription sub) {
+        this.original.onSubscribe(
+            new Subscription() {
+                @Override
+                public void request(final long num) {
+                    sub.request(num);
+                }
+
+                @Override
+                public void cancel() {
+                    sub.cancel();
+                }
+            }
+        );
+    }
+
+    @Override
+    public void onNext(final ByteBuffer buffer) {
+        this.chunks.incrementAndGet();
+        this.received.addAndGet(buffer.remaining());
+        this.original.onNext(buffer);
+    }
+
+    @Override
+    public void onError(final Throwable err) {
+        this.callback.accept(-1, 0L);
+        this.original.onError(err);
+    }
+
+    @Override
+    public void onComplete() {
+        this.callback.accept(
+            this.chunks.get(),
+            this.received.get()
+        );
+        this.original.onComplete();
+    }
+}

--- a/src/main/java/com/artipie/jfr/package-info.java
+++ b/src/main/java/com/artipie/jfr/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+
+/**
+ * Artipie files related to JFR.
+ *
+ * @since 0.28.0
+ */
+package com.artipie.jfr;

--- a/src/test/java/com/artipie/jfr/ChunksAndSizeMetricsContentTest.java
+++ b/src/test/java/com/artipie/jfr/ChunksAndSizeMetricsContentTest.java
@@ -10,7 +10,6 @@ import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/com/artipie/jfr/ChunksAndSizeMetricsContentTest.java
+++ b/src/test/java/com/artipie/jfr/ChunksAndSizeMetricsContentTest.java
@@ -1,0 +1,169 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.jfr;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Splitting;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ChunksAndSizeMetricsContent.
+ *
+ * @since 0.28.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle ParameterNameCheck (500 lines)
+ * @checkstyle LocalFinalVariableNameCheck (500 lines)
+ * @checkstyle IllegalCatchCheck (500 lines)
+ */
+@SuppressWarnings(
+    {
+        "PMD.AvoidCatchingGenericException",
+        "PMD.AvoidThrowingRawExceptionTypes",
+        "PMD.EmptyCatchBlock",
+        "PMD.AvoidDuplicateLiterals"
+    }
+)
+class ChunksAndSizeMetricsContentTest {
+
+    /**
+     * Random one for all tests.
+     */
+    private static final Random RANDOM = new Random();
+
+    /**
+     * To check chunk count.
+     */
+    private AtomicInteger count;
+
+    /**
+     * To check size of content`s data.
+     */
+    private AtomicLong sum;
+
+    @BeforeEach
+    void init() {
+        this.count = new AtomicInteger();
+        this.sum = new AtomicLong();
+    }
+
+    @Test
+    void shouldPassToCallbackChunkCountAndReceivedBytesWithDelay() {
+        final int size = 10 * 1024 * 1024;
+        final int chunks = 15;
+        Flowable.fromPublisher(
+            new ChunksAndSizeMetricsContent(
+                this.content(size, chunks, true),
+                (c, w) -> {
+                    this.count.set(c);
+                    this.sum.set(w);
+                }
+            )
+        ).blockingSubscribe();
+        this.assertResults(chunks, size);
+    }
+
+    @Test
+    void shouldPassToCallbackChunkCountAndReceivedBytesWithoutDelay() {
+        final int size = 5 * 1024 * 1024;
+        final int chunks = 24;
+        Flowable.fromPublisher(
+            new ChunksAndSizeMetricsContent(
+                this.content(size, chunks, false),
+                (c, w) -> {
+                    this.count.set(c);
+                    this.sum.set(w);
+                }
+            )
+        ).blockingSubscribe();
+        this.assertResults(chunks, size);
+    }
+
+    @Test
+    void shouldPassToCallbackMinisOneChunkCountWhenErrorIsOccurred() {
+        final byte[] data = new byte[2 * 1024];
+        RANDOM.nextBytes(data);
+        final AtomicInteger called = new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
+        try {
+            final Content content = new Content.From(Flowable.fromPublisher(new Content.From(data))
+                .flatMap(
+                    buffer -> new Splitting(
+                        buffer,
+                        1024
+                    ).publisher()
+                ).filter(
+                    buf -> {
+                        if (called.getAndIncrement() == 1) {
+                            throw new RuntimeException("Stop!");
+                        }
+                        return true;
+                    }));
+            Flowable.fromPublisher(
+                new ChunksAndSizeMetricsContent(
+                    content,
+                    (c, w) -> {
+                        MatcherAssert.assertThat(c, Is.is(-1));
+                        MatcherAssert.assertThat(w, Is.is(0L));
+                        counter.getAndIncrement();
+                    }
+                )
+            ).blockingSubscribe();
+            Assertions.fail();
+        } catch (final RuntimeException err) {
+            // @checkstyle MethodBodyCommentsCheck (1 lines)
+            // No-op.
+        }
+        MatcherAssert.assertThat(counter.get(), Is.is(1));
+    }
+
+    /**
+     * Asserts Chunks count & data size.
+     *
+     * @param chunks Chunks count.
+     * @param size Size of data.
+     */
+    private void assertResults(final int chunks, final long size) {
+        MatcherAssert.assertThat(this.count.get(), Is.is(chunks));
+        MatcherAssert.assertThat(this.sum.get(), Is.is(size));
+    }
+
+    /**
+     * Creates content.
+     *
+     * @param size Size of content's data.
+     * @param chunks Chunks count.
+     * @param withDelay Emulate  delay.
+     * @return Content.
+     */
+    private Content content(final int size, final int chunks, final boolean withDelay) {
+        final byte[] data = new byte[size];
+        RANDOM.nextBytes(data);
+        final int rest = size % chunks;
+        final int chunkSize = size / chunks + rest;
+        Flowable<ByteBuffer> flowable = Flowable.fromPublisher(new Content.From(data))
+            .flatMap(
+                buffer -> new Splitting(
+                    buffer,
+                    chunkSize
+                ).publisher()
+            );
+        if (withDelay) {
+            flowable = flowable.delay(RANDOM.nextInt(5_000), TimeUnit.MILLISECONDS);
+        }
+        return new Content.From(flowable);
+    }
+}

--- a/src/test/java/com/artipie/jfr/package-info.java
+++ b/src/test/java/com/artipie/jfr/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+
+/**
+ * Artipie files, tests.
+ *
+ * @since 0.1
+ */
+package com.artipie.jfr;


### PR DESCRIPTION
part of #1183

implemented ChunksAndSizeMetricsContent allows getting chunks count and received data size.
tests to check ChunksAndSizeMetricsContent