### PR TITLE
Fixed #1213 - powermock-api-mockito2 seemed to be superfluous

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,12 +407,6 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>wtf.g4s8</groupId>
       <artifactId>matchers-json</artifactId>
       <version>1.0.3</version>

--- a/src/test/java/com/artipie/HttpClientSettingsTest.java
+++ b/src/test/java/com/artipie/HttpClientSettingsTest.java
@@ -14,11 +14,6 @@ import org.junit.jupiter.api.Test;
  * Test for {@link HttpClientSettings}.
  *
  * @since 0.9
- * @todo #429:30min Test `SystemSettings.trustAll` method.
- *  `SystemSettings.trustAll` reads data using static method `System.getenv`.
- *  To test this method in presence of this environment variable it is need to mock static method.
- *  This could be done with Powermock library, however it is tricky at the moment to use it with
- *  JUnit5 as it is not directly supported.
  */
 class HttpClientSettingsTest {
 


### PR DESCRIPTION
- Removed dependency to powermock-api-mockito2 because it is not used anywhere.
- Removed the todo comment in HttpClientSettingsTest because the describe class does not exist anymore.