### PR TITLE
Support build & publish to maven central

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -1,0 +1,63 @@
+name: Create Maven release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    name: Build release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: adopt
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set env
+        run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set version
+        run: mvn -B versions:set -DnewVersion=${{ env.TAG }} versions:commit
+      - name: Create settings.xml
+        uses: whelk-io/maven-settings-xml-action@v15
+        with:
+          servers: |
+            [
+              {
+                "id": "oss.sonatype.org",
+                "username": "${{ secrets.SONATYPE_USER }}",
+                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              }
+            ]
+          profiles: |
+            [
+              {
+                "id": "artipie",
+                "properties": {
+                  "gpg.keyname": "${{ secrets.GPG_KEYNAME }}",
+                  "gpg.passphrase": "${{ secrets.GPG_PASSPHRASE }}"
+                }
+              }
+            ]
+      - name: Deploy artifacts
+        run: mvn deploy -Partipie-central,sonatype,gpg-sign -DskipITs --errors
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.TAG }}
+          draft: false
+          prerelease: false

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,22 @@ SOFTWARE.
               <javaVersion>${maven.compiler.source}</javaVersion>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>${maven.compiler.source}</source>
+              <target>${maven.compiler.target}</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>${maven.compiler.source}</source>
+              <target>${maven.compiler.target}</target>
+            </configuration>
+          </plugin>  
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Support build & publish to maven central.

Currently, java versions are set explicitly, or it may give errors due to defaulting to Java 8.
