### PR TITLE
Disable tests & docker operations for maven publish

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -50,4 +50,4 @@ jobs:
               }
             ]
       - name: Deploy artifacts
-        run: mvn deploy -Partipie-central,jar-build,sonatype,gpg-sign -DskipITs --errors
+        run: mvn deploy -Partipie-central,jar-build,sonatype,gpg-sign -Ddockerfile.skip=true -Dmaven.test.skip=true --errors


### PR DESCRIPTION
Disable tests & docker operations for maven publish.
Part of https://github.com/artipie/artipie/issues/1206
