### PR TITLE
Don't release .jar to GitHub, since we release it to maven central now.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,6 @@ jobs:
           release_name: Release ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: false
-      - name: Create jar with dependencies
-        run: mvn package -Pjar-build -DskipTests
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/artipie-latest-jar-with-dependencies.jar
-          asset_name: artipie-${{ env.RELEASE_VERSION }}-jar-with-dependencies.jar
-          asset_content_type: application/jar
   # run-benchmarks:
   #   runs-on: ubuntu-latest
   #   needs: docker-publish

--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -27,7 +27,7 @@ To start Artipie Docker check [Quickstart](https://github.com/artipie/artipie#qu
 ## How to start Artipie service with a maven-proxy repository
 
 In this section we will start Artipie service with a `maven-proxy` repository using JVM. 
-Executable `jar` file can be found on the [releases page](https://github.com/artipie/artipie/releases). 
+Executable `jar` file can be found on the [Maven Central](https://mvnrepository.com/artifact/com.artipie/artipie). 
 Before running the `jar`, it's necessary to create main Artipie config `yaml` file and 
 repository config file. The simplest main Artipie config file `my-artipie.yaml`
 has the following content:


### PR DESCRIPTION
Don't release .jar to GitHub, since we release it to maven central now.
Part of #1206
