### PR TITLE
feat: validate JWT tokens

### DIFF
--- a/src/main/java/com/artipie/api/AuthTokenRest.java
+++ b/src/main/java/com/artipie/api/AuthTokenRest.java
@@ -20,6 +20,16 @@ import org.eclipse.jetty.http.HttpStatus;
 public final class AuthTokenRest extends BaseRest {
 
     /**
+     * Token field with username.
+     */
+    public static final String SUB = "sub";
+
+    /**
+     * Token field with user groups.
+     */
+    public static final String GROUPS = "groups";
+
+    /**
      * JWT auth provider.
      */
     private final JWTAuth provider;
@@ -68,7 +78,8 @@ public final class AuthTokenRest extends BaseRest {
                 new JsonObject().put(
                     "token",
                     this.provider.generateToken(
-                        new JsonObject().put("sub", user.get().name())
+                        new JsonObject().put(AuthTokenRest.SUB, user.get().name())
+                            .put(AuthTokenRest.GROUPS, user.get().groups())
                     )
                 ).encode()
             );

--- a/src/main/java/com/artipie/auth/JwtTokenAuth.java
+++ b/src/main/java/com/artipie/auth/JwtTokenAuth.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.auth;
+
+import com.artipie.api.AuthTokenRest;
+import com.artipie.http.auth.Authentication;
+import com.artipie.http.auth.TokenAuthentication;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+/**
+ * Token authentication with Vert.x {@link io.vertx.ext.auth.jwt.JWTAuth} under the hood.
+ * @since 0.29
+ */
+public final class JwtTokenAuth implements TokenAuthentication {
+
+    /**
+     * Jwt auth provider.
+     */
+    private final JWTAuth provider;
+
+    /**
+     * Ctor.
+     * @param provider Jwt auth provider
+     */
+    public JwtTokenAuth(final JWTAuth provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    public CompletionStage<Optional<Authentication.User>> user(final String token) {
+        return this.provider.authenticate(new JsonObject().put("token", token)).map(
+            user -> {
+                Optional<Authentication.User> res = Optional.empty();
+                if (user.principal().containsKey(AuthTokenRest.SUB)
+                    && user.containsKey(AuthTokenRest.GROUPS)) {
+                    res = Optional.of(
+                        new Authentication.User(
+                            user.principal().getString(AuthTokenRest.SUB),
+                            user.principal().getJsonArray(AuthTokenRest.GROUPS).stream()
+                                .map(Object::toString).collect(Collectors.toList())
+                        )
+                    );
+                }
+                return res;
+            }
+        ).otherwise(Optional.empty()).toCompletionStage();
+    }
+}

--- a/src/test/java/com/artipie/auth/JwtTokenAuthTest.java
+++ b/src/test/java/com/artipie/auth/JwtTokenAuthTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.auth;
+
+import com.artipie.http.auth.Authentication;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
+import java.util.Collections;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link JwtTokenAuth}.
+ * @since 0.29
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class JwtTokenAuthTest {
+
+    /**
+     * Test JWT provider.
+     */
+    private JWTAuth provider;
+
+    @BeforeEach
+    void init() {
+        this.provider = JWTAuth.create(
+            Vertx.vertx(),
+            new JWTAuthOptions().addPubSecKey(
+                new PubSecKeyOptions().setAlgorithm("HS256").setBuffer("some secret")
+            )
+        );
+    }
+
+    @Test
+    void returnsUser() {
+        final String name = "Alice";
+        final List<String> groups = List.of("admin");
+        MatcherAssert.assertThat(
+            new JwtTokenAuth(this.provider).user(
+                this.provider.generateToken(new JsonObject().put("sub", name).put("groups", groups))
+            ).toCompletableFuture().join().get(),
+            new IsEqual<>(new Authentication.User(name, groups))
+        );
+    }
+
+    @Test
+    void returnsUserWhenGroupsAreEmpty() {
+        final String name = "John";
+        MatcherAssert.assertThat(
+            new JwtTokenAuth(this.provider).user(
+                this.provider.generateToken(
+                    new JsonObject().put("sub", name).put("groups", Collections.emptyList())
+                )
+            ).toCompletableFuture().join().get(),
+            new IsEqual<>(new Authentication.User(name))
+        );
+    }
+
+    @Test
+    void returnsEmptyWhenSubIsNotPresent() {
+        MatcherAssert.assertThat(
+            new JwtTokenAuth(this.provider).user(
+                this.provider.generateToken(new JsonObject().put("groups", List.of("reader")))
+            ).toCompletableFuture().join().isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void returnsEmptyWhenGroupsAreNotPresent() {
+        MatcherAssert.assertThat(
+            new JwtTokenAuth(this.provider).user(
+                this.provider.generateToken(new JsonObject().put("sub", "Alex"))
+            ).toCompletableFuture().join().isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void returnsEmptyWhenTokenIsNotValid() {
+        MatcherAssert.assertThat(
+            new JwtTokenAuth(this.provider).user("not valid token")
+                .toCompletableFuture().join().isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+}


### PR DESCRIPTION
Part of #1227 

Added implementation of `TokenAuthentication` from our `http` to authenticate user by JWT token issued by our rest api. This implementation will be used in npm-adapter later. 

Also, 
- added user groups to the token as they are part of authorization process 
- corrected `com.artipie.api.RestApi#addJwtAuth` method and its usage to use auth in all rest api methods