### PR TITLE
fix: ignore not proper files from repo config storage

### DIFF
--- a/src/main/java/com/artipie/settings/ConfigFile.java
+++ b/src/main/java/com/artipie/settings/ConfigFile.java
@@ -31,7 +31,8 @@ public final class ConfigFile {
     /**
      * Pattern to divide all filenames into two groups: name and extension.
      */
-    private static final Pattern PTN_ALL = Pattern.compile("(?<name>.+?)(?<extension>\\.[^.]*$|$)");
+    private static final Pattern PTN_ALL =
+        Pattern.compile("(?<name>.+?)(?<extension>(?<!/)\\.[^./]*$|$)");
 
     /**
      * Filename.

--- a/src/test/java/com/artipie/settings/ConfigFileTest.java
+++ b/src/test/java/com/artipie/settings/ConfigFileTest.java
@@ -84,7 +84,55 @@ final class ConfigFileTest {
     @ParameterizedTest
     @ValueSource(strings = {".yaml", ".yml", ".jar", ".json", ""})
     void getFilenameAndExtensionCorrect(final String extension) {
-        final String name = "filename";
+        final String simple = "filename";
+        MatcherAssert.assertThat(
+            "Correct name",
+            new ConfigFile(String.join("", simple, extension)).name(),
+            new IsEqual<>(simple)
+        );
+        MatcherAssert.assertThat(
+            "Correct extension",
+            new ConfigFile(String.join("", simple, extension)).extension().orElse(""),
+            new IsEqual<>(extension)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {".yaml", ".yml", ".jar", ".json", ""})
+    void getFilenameAndExtensionCorrectFromHiddenDir(final String extension) {
+        final String name = "..2023_02_06_09_57_10.2284382907/filename";
+        MatcherAssert.assertThat(
+            "Correct name",
+            new ConfigFile(String.join("", name, extension)).name(),
+            new IsEqual<>(name)
+        );
+        MatcherAssert.assertThat(
+            "Correct extension",
+            new ConfigFile(String.join("", name, extension)).extension().orElse(""),
+            new IsEqual<>(extension)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {".yaml", ".yml", ".jar", ".json", ""})
+    void getFilenameAndExtensionCorrectFromHiddenFile(final String extension) {
+        final String name = "some_dir/.filename";
+        MatcherAssert.assertThat(
+            "Correct name",
+            new ConfigFile(String.join("", name, extension)).name(),
+            new IsEqual<>(name)
+        );
+        MatcherAssert.assertThat(
+            "Correct extension",
+            new ConfigFile(String.join("", name, extension)).extension().orElse(""),
+            new IsEqual<>(extension)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {".yaml", ".yml", ".jar", ".json", ""})
+    void getFilenameAndExtensionCorrectFromHiddenFileInHiddenDir(final String extension) {
+        final String name = ".some_dir/.filename";
         MatcherAssert.assertThat(
             "Correct name",
             new ConfigFile(String.join("", name, extension)).name(),
@@ -128,7 +176,9 @@ final class ConfigFileTest {
         "file.yaml,true",
         "name.yml,true",
         "name.xml,false",
-        "name,false"
+        "name,false",
+        ".some.yaml,true",
+        "..hidden_dir/any.yml,true"
     })
     void yamlOrYmlDeterminedCorrectly(final String filename, final boolean yaml) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
closes #1241 

Fixed `ConfigFile` to check extension of hidden files properly. On start Artipie scans configs directory looking for repository configs and tries to create repositories from `.yml` and `.yaml` files. If yaml file content is invalid, it writes an exception into log and continue the work. 
Note, that in the case, when hidden file is valid repository config, the repository will be started and will have path with dot, for example: `artipie/.my-hidden-bin-repo`.
Basically, we do not expect users to have any other files except for repository and artipie configs in the configuration storage.