### PR TITLE
Removed redundant line in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,6 @@ SOFTWARE.
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Removed redundant line in `pom.xml`
Parameter `maven.compiler.target` doesn't exist in the maven javadoc plugin.