### PR TITLE
feat: auth from storage

### DIFF
--- a/src/main/java/com/artipie/auth/AuthFromStorage.java
+++ b/src/main/java/com/artipie/auth/AuthFromStorage.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.auth;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.http.auth.Authentication;
+import com.jcabi.log.Logger;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * Authentication from abstract storage.
+ * The storage is expected to have yaml files with credentials in the following structure:
+ * <pre>
+ * ..
+ * ├── users
+ * │   ├── david.yaml
+ * │   ├── jane.yml
+ * │   ├── ...
+ * </pre>
+ * where the name of the file is username (case-sensitive), both yml and yaml extensions are
+ * supported. The yaml format file is the following:
+ * <pre>{@code
+ * david:
+ *   type: plain # plain and sha256 types are supported
+ *   pass: qwerty
+ *   email: david@example.com # Optional
+ *   enabled: true # optional default true
+ *   roles:
+ *     - java-dev
+ *   permissions:
+ *     artipie_basic_permission:
+ *       rpm-repo:
+ *         - read
+ * }</pre>
+ * @since 1.29
+ */
+public final class AuthFromStorage implements Authentication {
+
+    /**
+     * The storage to obtain users files from.
+     */
+    private final BlockingStorage asto;
+
+    /**
+     * Ctor.
+     * @param asto Abstract blocking storage
+     */
+    public AuthFromStorage(final BlockingStorage asto) {
+        this.asto = asto;
+    }
+
+    @Override
+    public Optional<User> user(final String name, final String pass) {
+        final Optional<byte[]> res;
+        final Key yaml = new Key.From(String.format("users/%s.yaml", name));
+        final Key yml = new Key.From(String.format("users/%s.yml", name));
+        if (this.asto.exists(yaml)) {
+            res = Optional.of(this.asto.value(yaml));
+        } else if (this.asto.exists(yml)) {
+            res = Optional.of(this.asto.value(yml));
+        } else {
+            res = Optional.empty();
+        }
+        return res.map(bytes -> AuthFromStorage.readAndCheckFromYaml(bytes, name, pass))
+            .flatMap(opt -> opt);
+    }
+
+    /**
+     * Reads bytes as yaml and check the password.
+     * @param bytes Yaml bytes
+     * @param name Username
+     * @param pass Password to check
+     * @return User if yaml parsed and password is correct
+     */
+    private static Optional<User> readAndCheckFromYaml(final byte[] bytes, final String name,
+        final String pass) {
+        Optional<User> res = Optional.empty();
+        try {
+            final YamlMapping yaml = Yaml.createYamlInput(new ByteArrayInputStream(bytes))
+                .readYamlMapping();
+            final YamlMapping info = yaml.yamlMapping(name);
+            if (info != null
+                && !Boolean.FALSE.toString().equalsIgnoreCase(info.string("enabled"))) {
+                final String type = info.string("type");
+                final String origin = info.string("pass");
+                if ("plain".equals(type) && Objects.equals(origin, pass)) {
+                    res = Optional.of(new User(name));
+                } else if ("sha256".equals(type) && DigestUtils.sha256Hex(pass).equals(origin)) {
+                    res = Optional.of(new User(name));
+                }
+            }
+        } catch (final IOException err) {
+            Logger.error(AuthFromStorage.class, "Failed to parse yaml for user %s", name);
+        }
+        return res;
+    }
+}

--- a/src/test/java/com/artipie/auth/AuthFromStorageTest.java
+++ b/src/test/java/com/artipie/auth/AuthFromStorageTest.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.auth;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.auth.Authentication;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test for {@link AuthFromStorage}.
+ * @since 1.29
+ * @checkstyle MethodNameCheck (500 lines)
+ */
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+class AuthFromStorageTest {
+
+    /**
+     * Test storage.
+     */
+    private BlockingStorage asto;
+
+    @BeforeEach
+    void init() {
+        this.asto = new BlockingStorage(new InMemoryStorage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"users/alice.yaml", "users/alice.yml"})
+    void authorisesUserWithPlainPassword(final String key) {
+        this.asto.save(new Key.From(key), this.aliceConfig());
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("alice", "qwerty").get(),
+            new IsEqual<>(new Authentication.User("alice"))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"users/alice.yaml", "users/alice.yml"})
+    void notAuthorisesUserWithPlainPasswordIfPasswordNotCorrect(final String key) {
+        this.asto.save(new Key.From(key), this.aliceConfig());
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("alice", "not_correct").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"users/david.yaml", "users/david.yml"})
+    void authorisesUserWithSha256Password(final String key) {
+        this.asto.save(new Key.From(key), this.davidConfig());
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("david", "abc123").get(),
+            new IsEqual<>(new Authentication.User("david"))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"users/david.yaml", "users/david.yml"})
+    void notAuthorisesUserWithSha256PasswordIfPasswordNotCorrect(final String key) {
+        this.asto.save(new Key.From(key), this.davidConfig());
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("david", "not_valid").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void doesNotAuthoriseDisabledUser() {
+        this.asto.save(new Key.From("users/jane.yml"), this.janeConfig());
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("jane", "qwerty").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void doesNotAuthoriseIfUserNotExists() {
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("notPresent", "any").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void doesNotAuthoriseIfUserYamlIsNotValid() {
+        this.asto.save(new Key.From("users/olga.yml"), "any text".getBytes(StandardCharsets.UTF_8));
+        MatcherAssert.assertThat(
+            new AuthFromStorage(this.asto).user("olga", "any").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    private byte[] aliceConfig() {
+        return String.join(
+            "\n",
+            "alice:",
+            "  type: plain",
+            "  pass: qwerty",
+            "  email: alice@example.com"
+        ).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private byte[] davidConfig() {
+        return String.join(
+            "\n",
+            "david:",
+            "  type: sha256",
+            String.format("  pass: %s", DigestUtils.sha256Hex("abc123")),
+            "  enabled: true"
+        ).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private byte[] janeConfig() {
+        return String.join(
+            "\n",
+            "jane:",
+            "  type: plain",
+            "  pass: qwerty",
+            "  enabled: false"
+        ).getBytes(StandardCharsets.UTF_8);
+    }
+
+}


### PR DESCRIPTION
part of #1237 

Added `Authentication` implementation to check user password from storage. It will be used with new policy/permissions implementation.

Also, I think it would be better to correct `Authentication` and `Policy` interfaces to return `CompletionStage`. Now implementations use `BlockingStorage` and thus blocking operations occurs in the chain of non-blocking requests. What do you say?