### PR TITLE
fix: correct default settings copy

### DIFF
--- a/src/main/java/com/artipie/settings/SettingsFromPath.java
+++ b/src/main/java/com/artipie/settings/SettingsFromPath.java
@@ -54,7 +54,7 @@ public final class SettingsFromPath {
         final Key init = new Key.From(".artipie", "initialized");
         if (initialize && !bsto.exists(init)) {
             final List<String> resources = Arrays.asList(
-                AliasSettings.FILE_NAME,
+                String.format("repo/%s", AliasSettings.FILE_NAME),
                 "repo/artipie/my-bin.yaml", "repo/artipie/my-docker.yaml",
                 "repo/artipie/my-maven.yaml",
                 "security/roles/reader.yml", "security/users/artipie.yaml"

--- a/src/main/resources/example/repo/artipie/my-docker.yaml
+++ b/src/main/resources/example/repo/artipie/my-docker.yaml
@@ -1,6 +1,3 @@
 repo:
   type: docker
   storage: default
-  permissions:
-    "*":
-      - "*"

--- a/src/main/resources/example/repo/artipie/my-maven.yaml
+++ b/src/main/resources/example/repo/artipie/my-maven.yaml
@@ -1,6 +1,3 @@
 repo:
   type: maven
   storage: default
-  permissions:
-    "*":
-      - "*"

--- a/src/main/resources/example/security/roles/reader.yml
+++ b/src/main/resources/example/security/roles/reader.yml
@@ -1,5 +1,9 @@
 reader:
   permissions:
     adapter_basic_permissions:
-      artipie/my-bin:
+      "*":
         - read
+    docker_repository_permissions:
+      "*":
+        "*":
+          - pull


### PR DESCRIPTION
part of #1237 

corrected copying of default settings:
1) storage aliases file is located inside repo dir now
2) permissions sections removed from repo settings
3) added read permissions for any repo