### PR TITLE
feat: test for rest api permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v1.2.8</version>
+      <version>v1.2.9</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/api/perms/ApiAliasPermission.java
+++ b/src/main/java/com/artipie/api/perms/ApiAliasPermission.java
@@ -50,6 +50,30 @@ public final class ApiAliasPermission extends RestApiPermission {
         );
     }
 
+    @Override
+    public ApiAliasPermissionCollection newPermissionCollection() {
+        return new ApiAliasPermissionCollection();
+    }
+
+    /**
+     * Collection of the alias permissions.
+     * @since 0.30
+     */
+    static final class ApiAliasPermissionCollection extends RestApiPermissionCollection {
+
+        /**
+         * Required serial.
+         */
+        private static final long serialVersionUID = 3010962571451212361L;
+
+        /**
+         * Ctor.
+         */
+        ApiAliasPermissionCollection() {
+            super(ApiAliasPermission.class);
+        }
+    }
+
     /**
      * Alias actions.
      * @since 0.29

--- a/src/main/java/com/artipie/api/perms/ApiRepositoryPermission.java
+++ b/src/main/java/com/artipie/api/perms/ApiRepositoryPermission.java
@@ -49,6 +49,30 @@ public final class ApiRepositoryPermission extends RestApiPermission {
         );
     }
 
+    @Override
+    public ApiRepositoryPermissionCollection newPermissionCollection() {
+        return new ApiRepositoryPermissionCollection();
+    }
+
+    /**
+     * Collection of the repository permissions.
+     * @since 0.30
+     */
+    static final class ApiRepositoryPermissionCollection extends RestApiPermissionCollection {
+
+        /**
+         * Required serial.
+         */
+        private static final long serialVersionUID = -1010962571451212361L;
+
+        /**
+         * Ctor.
+         */
+        ApiRepositoryPermissionCollection() {
+            super(ApiRepositoryPermission.class);
+        }
+    }
+
     /**
      * Repository actions.
      * @since 0.29

--- a/src/main/java/com/artipie/api/perms/ApiRolePermission.java
+++ b/src/main/java/com/artipie/api/perms/ApiRolePermission.java
@@ -50,6 +50,30 @@ public final class ApiRolePermission extends RestApiPermission {
         );
     }
 
+    @Override
+    public ApiRolePermissionCollection newPermissionCollection() {
+        return new ApiRolePermissionCollection();
+    }
+
+    /**
+     * Collection of the role permissions.
+     * @since 0.30
+     */
+    static final class ApiRolePermissionCollection extends RestApiPermissionCollection {
+
+        /**
+         * Required serial.
+         */
+        private static final long serialVersionUID = 3010962571451212361L;
+
+        /**
+         * Ctor.
+         */
+        ApiRolePermissionCollection() {
+            super(ApiRolePermission.class);
+        }
+    }
+
     /**
      * Alias actions.
      * @since 0.29
@@ -60,10 +84,9 @@ public final class ApiRolePermission extends RestApiPermission {
         READ(0x4),
         CREATE(0x2),
         UPDATE(0x1),
-        MOVE(0x10),
         DELETE(0x8),
-        ENABLE(0x20),
-        ALL(0x4 | 0x2 | 0x8 | 0x10 | 0x1 | 0x20);
+        ENABLE(0x10),
+        ALL(0x4 | 0x2 | 0x8 | 0x10 | 0x1);
 
         /**
          * Action mask.

--- a/src/main/java/com/artipie/api/perms/ApiUserPermission.java
+++ b/src/main/java/com/artipie/api/perms/ApiUserPermission.java
@@ -50,6 +50,30 @@ public final class ApiUserPermission extends RestApiPermission {
         );
     }
 
+    @Override
+    public ApiUserPermissionCollection newPermissionCollection() {
+        return new ApiUserPermissionCollection();
+    }
+
+    /**
+     * Collection of the user permissions.
+     * @since 0.30
+     */
+    static final class ApiUserPermissionCollection extends RestApiPermissionCollection {
+
+        /**
+         * Required serial.
+         */
+        private static final long serialVersionUID = -3000962571451212361L;
+
+        /**
+         * Ctor.
+         */
+        ApiUserPermissionCollection() {
+            super(ApiUserPermission.class);
+        }
+    }
+
     /**
      * User actions.
      * @since 0.29
@@ -60,11 +84,10 @@ public final class ApiUserPermission extends RestApiPermission {
         READ(0x4),
         CREATE(0x2),
         UPDATE(0x1),
-        MOVE(0x10),
         DELETE(0x8),
-        ENABLE(0x20),
-        CHANGE_PASSWORD(0x40),
-        ALL(0x4 | 0x2 | 0x8 | 0x20 | 0x1 | 0x40 | 0x10);
+        ENABLE(0x10),
+        CHANGE_PASSWORD(0x20),
+        ALL(0x4 | 0x2 | 0x8 | 0x20 | 0x1 | 0x10);
 
         /**
          * Action mask.

--- a/src/test/java/com/artipie/api/perms/RestApiPermissionCollectionTest.java
+++ b/src/test/java/com/artipie/api/perms/RestApiPermissionCollectionTest.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.api.perms;
 
+import java.util.Set;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
@@ -25,7 +26,7 @@ public class RestApiPermissionCollectionTest {
         final ApiRepositoryPermission.RepositoryAction action
     ) {
         final ApiRepositoryPermission.RestApiPermissionCollection collection =
-            new RestApiPermission.RestApiPermissionCollection(ApiRepositoryPermission.class);
+            new ApiRepositoryPermission.ApiRepositoryPermissionCollection();
         collection.add(new ApiRepositoryPermission(ApiRepositoryPermission.RepositoryAction.ALL));
         MatcherAssert.assertThat(
             collection.implies(new ApiRepositoryPermission(action)),
@@ -36,9 +37,9 @@ public class RestApiPermissionCollectionTest {
     @Test
     void addsAndImplies() {
         final RestApiPermission.RestApiPermissionCollection collection =
-            new RestApiPermission.RestApiPermissionCollection(ApiUserPermission.class);
+            new ApiUserPermission.ApiUserPermissionCollection();
         collection.add(new ApiUserPermission(ApiUserPermission.UserAction.CREATE));
-        collection.add(new ApiUserPermission(ApiUserPermission.UserAction.UPDATE));
+        collection.add(new ApiUserPermission(Set.of("update", "enable")));
         MatcherAssert.assertThat(
             "Implies permission with added action",
             collection.implies(new ApiUserPermission(ApiUserPermission.UserAction.CREATE)),
@@ -50,8 +51,13 @@ public class RestApiPermissionCollectionTest {
             new IsEqual<>(true)
         );
         MatcherAssert.assertThat(
+            "Implies permission with added action",
+            collection.implies(new ApiUserPermission(ApiUserPermission.UserAction.ENABLE)),
+            new IsEqual<>(true)
+        );
+        MatcherAssert.assertThat(
             "Not implies permission with not added action",
-            collection.implies(new ApiUserPermission(ApiUserPermission.UserAction.MOVE)),
+            collection.implies(new ApiUserPermission(ApiUserPermission.UserAction.DELETE)),
             new IsEqual<>(false)
         );
         MatcherAssert.assertThat(
@@ -67,7 +73,7 @@ public class RestApiPermissionCollectionTest {
     void throwsErrorIfAnotherClassAdded() {
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> new RestApiPermission.RestApiPermissionCollection(ApiUserPermission.class)
+            () -> new ApiAliasPermission.ApiAliasPermissionCollection()
                 .add(new ApiRepositoryPermission(ApiRepositoryPermission.RepositoryAction.UPDATE))
         );
     }


### PR DESCRIPTION
Part of #1273 

Added test for rest api with permissions and corrected rest api permission collection. As we use heterogeneous collection `java.security.Permissions` each permission class must have his own collection class. 

Also initial collection implementation was not correct because permission key contained action mask. Mask can differ depending on allowed actions list (it can be `create and delete` or `update and enable` or etc), thus checking for action `create` we will never get suitable permission from collection map by key.