### PR TITLE
feat: docs for REST API permissions

### DIFF
--- a/.wiki/Configuration-Policy.md
+++ b/.wiki/Configuration-Policy.md
@@ -188,7 +188,7 @@ and list of operations. Wildcard `*` is supported as for repository name as for 
 Permissions for the REST API control access for API endpoints. There are several permissions types: for repository settings,
 storage aliases, users and roles management. 
 
-Each permission type has slightly different set of actions, but each type support wildcard `*` to allow any action,
+Each permission type has a slightly different set of actions, but each type supports the wildcard `*` to allow any action,
 for example:
 ```yaml
 permissions:

--- a/.wiki/Configuration-Policy.md
+++ b/.wiki/Configuration-Policy.md
@@ -185,7 +185,7 @@ and list of operations. Wildcard `*` is supported as for repository name as for 
 
 ### REST API Permissions
 
-Permissions fo REST API control access for API endpoints. There several permissions types: for repository settings,
+Permissions for the REST API control access for API endpoints. There are several permissions types: for repository settings,
 storage aliases, users and roles management. 
 
 Each permission type has slightly different set of actions, but each type support wildcard `*` to allow any action,

--- a/.wiki/Configuration-Policy.md
+++ b/.wiki/Configuration-Policy.md
@@ -128,13 +128,13 @@ which means that `read` actions is allowed for any repository.
 Note, that in the case of `org` layout repository name is combined from username and repository name and
 should be specified correspondingly: `jane/pypi-public` or `mark/maven-repo`.
 
-#### Adapter all permission
+#### All permission
 
-Artipie also support `adapter_all_permission` type to allow [any actions for any repository](https://github.com/artipie/http/blob/master/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java):
+Artipie also support `all_permission` type to allow [any actions for any repository and API endpoints](https://github.com/artipie/http/blob/master/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java):
 
 ```yaml
 permissions:
-  adapter_all_permission: {}
+  all_permission: {}
 ```
 Grant such permissions carefully.
 
@@ -182,6 +182,74 @@ Wildcard `*` is supported as for repository name as for resource/image name.
 Docker registry permissions are meant to control access to registry-specific operations [base](https://docs.docker.com/registry/spec/api/#base) 
 and [catalog](https://docs.docker.com/registry/spec/api/#catalog). Settings require map of the repositories 
 and list of operations. Wildcard `*` is supported as for repository name as for operations.
+
+### REST API Permissions
+
+Permissions fo REST API control access for API endpoints. There several permissions types: for repository settings,
+storage aliases, users and roles management. 
+
+Each permission type has slightly different set of actions, but each type support wildcard `*` to allow any action,
+for example:
+```yaml
+permissions:
+  api_storage_alias_permissions:
+    - *
+```
+Note, that `all_permission` also grants full access to REST API. Actions synonyms are not supported for REST API 
+permissions, actions should be listed as in the documentation.
+
+#### api_storage_alias_permissions
+
+Permission for endpoints to manage aliases (repository, user and common aliases):
+```yaml
+permissions:
+  api_storage_alias_permissions:
+    - read
+    - create
+    - delete
+```
+
+#### api_repository_permissions 
+
+Permission for endpoints to manage repository:
+```yaml
+permissions:
+  api_repository_permissions:
+    - read # allows to get repos list and repository by specific name
+    - create
+    - update
+    - move
+    - delete
+```
+
+#### api_role_permissions
+
+Permission for endpoints to manage roles:
+```yaml
+permissions:
+  api_role_permissions:
+    - read # allows to get roles' list and role by specific name
+    - create
+    - update
+    - delete
+    - enable # allows enable and disable operations
+```
+
+#### api_user_permissions
+
+Permission for endpoints to manage users:
+```yaml
+permissions:
+  api_user_permissions:
+    - read # allows to get users' list and user by specific name
+    - create
+    - update
+    - delete
+    - enable # allows enable and disable operations
+    - change_password
+```
+
+Endpoints to get token and settings (port and layout) are available for any user, no permissions required.
 
 ## Custom policy
 

--- a/.wiki/Configuration-Policy.md
+++ b/.wiki/Configuration-Policy.md
@@ -195,7 +195,7 @@ permissions:
   api_storage_alias_permissions:
     - *
 ```
-Note, that `all_permission` also grants full access to REST API. Actions synonyms are not supported for REST API 
+Note, that `all_permission` also grants full access to the REST API. Actions synonyms are not supported for the REST API 
 permissions, actions should be listed as in the documentation.
 
 #### api_storage_alias_permissions

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v1.2.9</version>
+      <version>v1.2.10</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/settings/SettingsFromPath.java
+++ b/src/main/java/com/artipie/settings/SettingsFromPath.java
@@ -65,7 +65,9 @@ public final class SettingsFromPath {
                     settings.authz().policyStorage().get()
                 );
                 SettingsFromPath.copyResources(
-                    Arrays.asList("roles/reader.yml", "users/artipie.yaml"), "security", policy
+                    Arrays.asList(
+                        "roles/reader.yml", "roles/api-admin.yaml", "users/artipie.yaml"
+                    ), "security", policy
                 );
             }
             bsto.save(init, "true".getBytes());

--- a/src/main/resources/example/security/roles/api-admin.yaml
+++ b/src/main/resources/example/security/roles/api-admin.yaml
@@ -1,0 +1,9 @@
+permissions:
+  api_storage_alias_permissions:
+    - *
+  api_repository_permissions:
+    - *
+  api_role_permissions:
+    - *
+  api_user_permissions:
+    - *

--- a/src/main/resources/example/security/users/artipie.yaml
+++ b/src/main/resources/example/security/users/artipie.yaml
@@ -3,6 +3,7 @@ pass: artipie
 email: artipie@example.com
 roles:
   - reader
+  - api-admin
 permissions:
   adapter_basic_permissions:
     artipie/my-bin:

--- a/src/main/resources/swagger-ui/swagger-initializer-flat.js
+++ b/src/main/resources/swagger-ui/swagger-initializer-flat.js
@@ -8,6 +8,7 @@ window.onload = function() {
           {url: "./yaml/repo-flat.yaml", name: "Repositories"},
           {url: "./yaml/token-gen.yaml", name: "Auth tokens"},
           {url: "./yaml/users.yaml", name: "Users"},
+          {url: "./yaml/roles.yaml", name: "Roles"},
           {url: "./yaml/settings.yaml", name: "Settings"},
         ],
     dom_id: '#swagger-ui',

--- a/src/main/resources/swagger-ui/swagger-initializer-org.js
+++ b/src/main/resources/swagger-ui/swagger-initializer-org.js
@@ -8,6 +8,7 @@ window.onload = function() {
               {url: "./yaml/repo-org.yaml", name: "Repositories"},
               {url: "./yaml/token-gen.yaml", name: "Auth tokens"},
               {url: "./yaml/users.yaml", name: "Users"},
+              {url: "./yaml/roles.yaml", name: "Roles"},
               {url: "./yaml/settings.yaml", name: "Settings"},
             ],
     dom_id: '#swagger-ui',

--- a/src/test/java/com/artipie/api/AuthRestOrgTest.java
+++ b/src/test/java/com/artipie/api/AuthRestOrgTest.java
@@ -183,7 +183,7 @@ public final class AuthRestOrgTest extends RestApiServerBase {
             vertx, ctx, new TestRequest(
                 HttpMethod.PUT, path,
                 new JsonObject().put(
-                    "permissions", new JsonObject().put("adapter_all_permission", new JsonObject())
+                    "permissions", new JsonObject().put("all_permission", new JsonObject())
                 )
             ), Optional.of(token.get()),
             response -> MatcherAssert.assertThat(
@@ -266,7 +266,7 @@ public final class AuthRestOrgTest extends RestApiServerBase {
                     String.join(
                         "\n",
                         "permissions:",
-                        "  adapter_all_permission: {}"
+                        "  all_permission: {}"
                     ).getBytes(StandardCharsets.UTF_8)
                 );
                 // @checkstyle MagicNumberCheck (1 line)

--- a/src/test/java/com/artipie/api/RepositoryRestOrgTest.java
+++ b/src/test/java/com/artipie/api/RepositoryRestOrgTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Test for {@link RepositoryRest} with `org` laout.
+ * Test for {@link RepositoryRest} with `org` layout.
  * @since 0.26
  */
 @ExtendWith(VertxExtension.class)

--- a/src/test/java/com/artipie/api/RestApiPermissionsTest.java
+++ b/src/test/java/com/artipie/api/RestApiPermissionsTest.java
@@ -71,7 +71,7 @@ public final class RestApiPermissionsTest extends RestApiServerBase {
             new TestRequest(HttpMethod.POST, "/api/v1/users/David/enable"),
             new TestRequest(HttpMethod.POST, "/api/v1/users/David/disable"),
             new TestRequest(HttpMethod.GET, "/api/v1/roles/java-dev"),
-            new TestRequest(HttpMethod.PUT, "/api/v1/roles/admin", new JsonObject().put("permissions", new JsonObject().put("adapter_all_permission", new JsonObject()))),
+            new TestRequest(HttpMethod.PUT, "/api/v1/roles/admin", new JsonObject().put("permissions", new JsonObject().put("all_permission", new JsonObject()))),
             new TestRequest(HttpMethod.DELETE, "/api/v1/roles/tester"),
             new TestRequest(HttpMethod.POST, "/api/v1/roles/tester/enable"),
             new TestRequest(HttpMethod.POST, "/api/v1/roles/tester/disable"),
@@ -185,7 +185,7 @@ public final class RestApiPermissionsTest extends RestApiServerBase {
             vertx, ctx, new TestRequest(
                 HttpMethod.PUT, path,
                 new JsonObject().put(
-                    "permissions", new JsonObject().put("adapter_all_permission", new JsonObject())
+                    "permissions", new JsonObject().put("all_permission", new JsonObject())
                 )
             ), Optional.of(token.get()),
             response -> MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/api/RolesRestTest.java
+++ b/src/test/java/com/artipie/api/RolesRestTest.java
@@ -55,7 +55,7 @@ final class RolesRestTest extends RestApiServerBase {
                     String.join(
                         "\n",
                         "permissions:",
-                        "  adapter_all_permission: {}"
+                        "  all_permission: {}"
                     ).getBytes(StandardCharsets.UTF_8)
                 );
                 // @checkstyle MagicNumberCheck (1 line)

--- a/src/test/resources/security/roles/admin.yaml
+++ b/src/test/resources/security/roles/admin.yaml
@@ -1,2 +1,2 @@
 permissions:
-  adapter_all_permission: {}
+  all_permission: {}


### PR DESCRIPTION
closes #1237

added docs, updated http and `all_permission` name, added role for example settings