### PR TITLE
feat: added consumer and tests

### DIFF
--- a/examples/artipie.yml
+++ b/examples/artipie.yml
@@ -5,4 +5,4 @@ meta:
   credentials:
     - type: env
   artifacts_database:
-    sqlite_data_file_path: /var/artipie/artifacts.db
+    sqlite_data_file_path: /var/artipie/cfg/database.db

--- a/examples/artipie.yml
+++ b/examples/artipie.yml
@@ -4,3 +4,5 @@ meta:
     path: /var/artipie/cfg
   credentials:
     - type: env
+  artifacts_database:
+    sqlite_data_file_path: /var/artipie/artifacts.db

--- a/examples/artipie.yml
+++ b/examples/artipie.yml
@@ -5,4 +5,4 @@ meta:
   credentials:
     - type: env
   artifacts_database:
-    sqlite_data_file_path: /var/artipie/cfg/database.db
+    sqlite_data_file_path: /var/artipie/data/database.db

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>helm-adapter</artifactId>
-      <version>v1.1.3</version>
+      <version>v1.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ SOFTWARE.
     <maven.compiler.target>17</maven.compiler.target>
     <docker.image.name>artipie/artipie</docker.image.name>
     <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
-    <vertx.version>4.3.4</vertx.version>
+    <vertx.version>4.4.2</vertx.version>
     <asto.version>v1.16.0</asto.version>
   </properties>
   <dependencies>
@@ -145,7 +145,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v1.2.15</version>
+      <version>v1.2.16</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -252,7 +252,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>gem-adapter</artifactId>
-      <version>v1.3.3</version>
+      <version>v1.3.4</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -332,7 +332,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.1</version>
+      <version>2.15.2</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v1.2.12</version>
+      <version>v1.2.15</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -46,6 +46,8 @@ import com.artipie.npm.proxy.http.NpmProxySlice;
 import com.artipie.nuget.http.NuGet;
 import com.artipie.pypi.http.PySlice;
 import com.artipie.rpm.http.RpmSlice;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.security.policy.Policy;
 import com.artipie.settings.Settings;
 import com.artipie.settings.repo.RepoConfig;
@@ -78,15 +80,17 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @param config Repo config
      * @param standalone Standalone flag
      * @param tokens Tokens: authentication and generation
+     * @param events Events queue
      */
     public SliceFromConfig(
         final ClientSlices http,
         final Settings settings, final RepoConfig config,
-        final boolean standalone, final Tokens tokens) {
+        final boolean standalone, final Tokens tokens,
+        final EventQueue<ArtifactEvent> events) {
         super(
             SliceFromConfig.build(
                 http, settings, new LoggingAuth(settings.authz().authentication()), tokens,
-                settings.authz().policy(), config, standalone
+                settings.authz().policy(), config, standalone, events
             )
         );
     }
@@ -101,6 +105,7 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @param policy Security policy
      * @param cfg Repository config
      * @param standalone Standalone flag
+     * @param events Events queue
      * @return Slice completionStage
      * @checkstyle LineLengthCheck (150 lines)
      * @checkstyle ExecutableStatementCountCheck (100 lines)
@@ -120,7 +125,8 @@ public final class SliceFromConfig extends Slice.Wrap {
         final Tokens tokens,
         final Policy<?> policy,
         final RepoConfig cfg,
-        final boolean standalone
+        final boolean standalone,
+        final EventQueue<ArtifactEvent> events
     ) {
         final Slice slice;
         switch (cfg.type()) {
@@ -198,7 +204,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                                         .config(name)
                                         .thenApply(
                                             sub -> new SliceFromConfig(
-                                                http, settings, sub, standalone, tokens
+                                                http, settings, sub, standalone, tokens, events
                                             )
                                         )
                                 )

--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -46,8 +46,6 @@ import com.artipie.npm.proxy.http.NpmProxySlice;
 import com.artipie.nuget.http.NuGet;
 import com.artipie.pypi.http.PySlice;
 import com.artipie.rpm.http.RpmSlice;
-import com.artipie.scheduling.ArtifactEvent;
-import com.artipie.scheduling.EventQueue;
 import com.artipie.security.policy.Policy;
 import com.artipie.settings.Settings;
 import com.artipie.settings.repo.RepoConfig;
@@ -80,17 +78,16 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @param config Repo config
      * @param standalone Standalone flag
      * @param tokens Tokens: authentication and generation
-     * @param events Events queue
      */
     public SliceFromConfig(
         final ClientSlices http,
         final Settings settings, final RepoConfig config,
-        final boolean standalone, final Tokens tokens,
-        final EventQueue<ArtifactEvent> events) {
+        final boolean standalone, final Tokens tokens
+    ) {
         super(
             SliceFromConfig.build(
                 http, settings, new LoggingAuth(settings.authz().authentication()), tokens,
-                settings.authz().policy(), config, standalone, events
+                settings.authz().policy(), config, standalone
             )
         );
     }
@@ -105,7 +102,6 @@ public final class SliceFromConfig extends Slice.Wrap {
      * @param policy Security policy
      * @param cfg Repository config
      * @param standalone Standalone flag
-     * @param events Events queue
      * @return Slice completionStage
      * @checkstyle LineLengthCheck (150 lines)
      * @checkstyle ExecutableStatementCountCheck (100 lines)
@@ -125,8 +121,7 @@ public final class SliceFromConfig extends Slice.Wrap {
         final Tokens tokens,
         final Policy<?> policy,
         final RepoConfig cfg,
-        final boolean standalone,
-        final EventQueue<ArtifactEvent> events
+        final boolean standalone
     ) {
         final Slice slice;
         switch (cfg.type()) {
@@ -204,7 +199,7 @@ public final class SliceFromConfig extends Slice.Wrap {
                                         .config(name)
                                         .thenApply(
                                             sub -> new SliceFromConfig(
-                                                http, settings, sub, standalone, tokens, events
+                                                http, settings, sub, standalone, tokens
                                             )
                                         )
                                 )

--- a/src/main/java/com/artipie/VertxMain.java
+++ b/src/main/java/com/artipie/VertxMain.java
@@ -5,9 +5,12 @@
 
 package com.artipie;
 
+import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.api.RestApi;
 import com.artipie.asto.Key;
 import com.artipie.auth.JwtTokens;
+import com.artipie.db.ArtifactDbFactory;
+import com.artipie.db.DbConsumer;
 import com.artipie.http.ArtipieRepositories;
 import com.artipie.http.BaseSlice;
 import com.artipie.http.MainSlice;
@@ -15,6 +18,9 @@ import com.artipie.http.Slice;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.misc.ArtipieProperties;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
+import com.artipie.scheduling.QuartsService;
 import com.artipie.settings.ConfigFile;
 import com.artipie.settings.MetricsContext;
 import com.artipie.settings.Settings;
@@ -40,17 +46,20 @@ import io.vertx.micrometer.backends.BackendRegistries;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.tuple.Pair;
+import org.quartz.SchedulerException;
 
 /**
  * Vertx server entry point.
@@ -116,14 +125,15 @@ public final class VertxMain {
                 new PubSecKeyOptions().setAlgorithm("HS256").setBuffer("some secret")
             )
         );
+        final EventQueue<ArtifactEvent> events = this.initArtifactsEvents(settings.meta());
         final int main = this.listenOn(
-            new MainSlice(this.http, settings, new JwtTokens(jwt)),
+            new MainSlice(this.http, settings, new JwtTokens(jwt), events),
             this.port,
             vertx,
             settings.metrics()
         );
         Logger.info(VertxMain.class, "Artipie was started on port %d", main);
-        this.startRepos(vertx, settings, this.port, jwt);
+        this.startRepos(vertx, settings, this.port, jwt, events);
         vertx.deployVerticle(new RestApi(settings, apiport, jwt));
         return main;
     }
@@ -184,13 +194,15 @@ public final class VertxMain {
      * @param settings Settings.
      * @param mport Artipie service main port
      * @param jwt Jwt authentication
+     * @param events Artifact events
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     private void startRepos(
         final Vertx vertx,
         final Settings settings,
         final int mport,
-        final JWTAuth jwt
+        final JWTAuth jwt,
+        final EventQueue<ArtifactEvent> events
     ) {
         final Collection<RepoConfig> configs = settings.repoConfigsStorage().list(Key.ROOT)
             .thenApply(
@@ -208,7 +220,7 @@ public final class VertxMain {
                         final String name = new ConfigFile(repo.name()).name();
                         this.listenOn(
                             new ArtipieRepositories(
-                                this.http, settings, new JwtTokens(jwt)
+                                this.http, settings, new JwtTokens(jwt), events
                             ).slice(new Key.From(name), prt),
                             prt, vertx, settings.metrics()
                         );
@@ -295,5 +307,37 @@ public final class VertxMain {
             res = Vertx.vertx();
         }
         return res;
+    }
+
+    /**
+     * Initialize artifacts sqlite database and schedule mechanism to gather artifact events
+     * (adding and removing artifacts) and add corresponding records into db.
+     * @param settings Artipie settings
+     * @return Event queue to gather artifacts events
+     */
+    private EventQueue<ArtifactEvent> initArtifactsEvents(final YamlMapping settings) {
+        try {
+            final DataSource source =
+                new ArtifactDbFactory(settings, this.config.getParent()).initialize();
+            final QuartsService quarts = new QuartsService();
+            final YamlMapping prop = settings.yamlMapping("artifacts_database");
+            final int threads;
+            final int interval;
+            if (prop == null) {
+                threads = 1;
+                interval = 1;
+            } else {
+                threads = Math.max(1, prop.integer("threads_count"));
+                interval = Math.max(1, prop.integer("interval_seconds"));
+            }
+            final EventQueue<ArtifactEvent> res = quarts.addPeriodicEventsProcessor(
+                new DbConsumer(source.getConnection()),
+                threads, interval
+            );
+            quarts.start();
+            return res;
+        } catch (final SQLException | SchedulerException error) {
+            throw new ArtipieException(error);
+        }
     }
 }

--- a/src/main/java/com/artipie/db/ArtifactDbFactory.java
+++ b/src/main/java/com/artipie/db/ArtifactDbFactory.java
@@ -100,7 +100,7 @@ public final class ArtifactDbFactory {
                     "   name VARCHAR NOT NULL,",
                     "   version CHAR(20) NOT NULL,",
                     "   size DOUBLE NOT NULL,",
-                    "   created_date REAL NOT NULL,",
+                    "   created_date DATETIME NOT NULL,",
                     "   owner VARCHAR NOT NULL,",
                     "   UNIQUE (repo_name, name, version) ",
                     ");"

--- a/src/main/java/com/artipie/db/ArtifactDbFactory.java
+++ b/src/main/java/com/artipie/db/ArtifactDbFactory.java
@@ -5,6 +5,7 @@
 package com.artipie.db;
 
 import com.amihaiemil.eoyaml.YamlMapping;
+import com.artipie.ArtipieException;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -66,9 +67,9 @@ public final class ArtifactDbFactory {
      * write to db.
      * If yaml settings are absent, default path and db name are used.
      * @return Queue to add artifacts metadata into
-     * @throws SQLException On error
+     * @throws ArtipieException On error
      */
-    public DataSource initialize() throws SQLException {
+    public DataSource initialize() {
         final YamlMapping config = this.yaml.yamlMapping("artifacts_database");
         final String path;
         if (config == null || config.string(ArtifactDbFactory.YAML_PATH) == null) {
@@ -85,9 +86,9 @@ public final class ArtifactDbFactory {
     /**
      * Create db structure to write artifacts data.
      * @param source Database source
-     * @throws SQLException On error
+     * @throws ArtipieException On error
      */
-    private static void createStructure(final DataSource source) throws SQLException {
+    private static void createStructure(final DataSource source) {
         try (Connection conn = source.getConnection();
             Statement statement = conn.createStatement()) {
             statement.executeUpdate(
@@ -106,6 +107,8 @@ public final class ArtifactDbFactory {
                     ");"
                 )
             );
+        } catch (final SQLException error) {
+            throw new ArtipieException(error);
         }
     }
 }

--- a/src/main/java/com/artipie/db/DbConsumer.java
+++ b/src/main/java/com/artipie/db/DbConsumer.java
@@ -5,12 +5,21 @@
 package com.artipie.db;
 
 import com.artipie.scheduling.ArtifactEvent;
-import com.artipie.scheduling.EventProcessingError;
+import com.jcabi.log.Logger;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.subjects.PublishSubject;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.sql.DataSource;
 
 /**
  * Consumer for artifact records which writes the records into db.
@@ -19,53 +28,107 @@ import java.util.function.Consumer;
 public final class DbConsumer implements Consumer<ArtifactEvent> {
 
     /**
+     * Publish subject
+     * <a href="https://reactivex.io/documentation/subject.html">Docs</a>.
+     */
+    private final PublishSubject<ArtifactEvent> subject;
+
+    /**
      * Database source.
      */
-    private final Connection conn;
+    private final DataSource source;
 
     /**
      * Ctor.
-     * @param conn Database source
+     * @param source Database source
      */
-    public DbConsumer(final Connection conn) {
-        this.conn = conn;
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public DbConsumer(final DataSource source) {
+        this.source = source;
+        this.subject = PublishSubject.create();
+        // @checkstyle MagicNumberCheck (5 lines)
+        this.subject.subscribeOn(Schedulers.io())
+            .buffer(2, TimeUnit.SECONDS, 50)
+            .subscribe(new DbObserver());
     }
 
     @Override
     public void accept(final ArtifactEvent record) {
-        if (record.eventType() == ArtifactEvent.Type.INSERT) {
-            try (
-                //@checkstyle LineLengthCheck (2 lines)
-                PreparedStatement statement = this.conn.prepareStatement(
-                    "insert into artifacts (repo_type, repo_name, name, version, size, created_date, owner) VALUES (?,?,?,?,?,?,?);"
-                )
-            ) {
-                //@checkstyle MagicNumberCheck (10 lines)
-                statement.setString(1, record.repoType());
-                statement.setString(2, record.repoName());
-                statement.setString(3, record.artifactName());
-                statement.setString(4, record.artifactVersion());
-                statement.setDouble(5, record.size());
-                statement.setDate(6, new Date(record.createdDate()));
-                statement.setString(7, record.owner());
-                statement.execute();
-            } catch (final SQLException error) {
-                throw new EventProcessingError("Error while inserting record", error);
+        this.subject.onNext(record);
+    }
+
+    /**
+     * Database observer. Writes pack into database.
+     * @since 0.31
+     */
+    private final class DbObserver implements Observer<List<ArtifactEvent>> {
+
+        @Override
+        public void onSubscribe(final @NonNull Disposable disposable) {
+            Logger.debug(this, "Subscribed to insert/delete db records");
+        }
+
+        // @checkstyle ExecutableStatementCountCheck (40 lines)
+        @Override
+        public void onNext(final @NonNull List<ArtifactEvent> events) {
+            if (events.isEmpty()) {
+                return;
             }
-        } else if (record.eventType() == ArtifactEvent.Type.DELETE) {
+            final List<ArtifactEvent> errors = new ArrayList<>(events.size());
+            boolean error = false;
             try (
-                PreparedStatement statement = this.conn.prepareStatement(
+                Connection conn = DbConsumer.this.source.getConnection();
+                PreparedStatement insert = conn.prepareStatement(
+                    // @checkstyle LineLengthCheck (1 line)
+                    "insert into artifacts (repo_type, repo_name, name, version, size, created_date, owner) VALUES (?,?,?,?,?,?,?);"
+                );
+                PreparedStatement delete = conn.prepareStatement(
                     "delete from artifacts where repo_name = ? and name = ? and version = ?;"
                 )
             ) {
-                //@checkstyle MagicNumberCheck (10 lines)
-                statement.setString(1, record.repoName());
-                statement.setString(2, record.artifactName());
-                statement.setString(3, record.artifactVersion());
-                statement.execute();
-            } catch (final SQLException error) {
-                throw new EventProcessingError("Error while removing record", error);
+                conn.setAutoCommit(false);
+                for (final ArtifactEvent record : events) {
+                    try {
+                        if (record.eventType() == ArtifactEvent.Type.INSERT) {
+                            //@checkstyle MagicNumberCheck (20 lines)
+                            insert.setString(1, record.repoType());
+                            insert.setString(2, record.repoName());
+                            insert.setString(3, record.artifactName());
+                            insert.setString(4, record.artifactVersion());
+                            insert.setDouble(5, record.size());
+                            insert.setDate(6, new Date(record.createdDate()));
+                            insert.setString(7, record.owner());
+                            insert.execute();
+                        } else if (record.eventType() == ArtifactEvent.Type.DELETE) {
+                            delete.setString(1, record.repoName());
+                            delete.setString(2, record.artifactName());
+                            delete.setString(3, record.artifactVersion());
+                            delete.execute();
+                        }
+                    } catch (final SQLException ex) {
+                        Logger.error(this, ex.getMessage());
+                        errors.add(record);
+                    }
+                }
+                conn.commit();
+            } catch (final SQLException ex) {
+                Logger.error(this, ex.getMessage());
+                events.forEach(DbConsumer.this.subject::onNext);
+                error = true;
             }
+            if (!error) {
+                errors.forEach(DbConsumer.this.subject::onNext);
+            }
+        }
+
+        @Override
+        public void onError(final @NonNull Throwable error) {
+            Logger.error(this, "Fatal error!");
+        }
+
+        @Override
+        public void onComplete() {
+            Logger.debug(this, "Subscription cancelled");
         }
     }
 }

--- a/src/main/java/com/artipie/db/DbConsumer.java
+++ b/src/main/java/com/artipie/db/DbConsumer.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.db;
+
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventProcessingError;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Consumer;
+
+/**
+ * Consumer for artifact records which writes the records into db.
+ * @since 0.31
+ */
+public final class DbConsumer implements Consumer<ArtifactEvent> {
+
+    /**
+     * Database source.
+     */
+    private final Connection conn;
+
+    /**
+     * Ctor.
+     * @param conn Database source
+     */
+    public DbConsumer(final Connection conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public void accept(final ArtifactEvent record) {
+        if (record.eventType() == ArtifactEvent.Type.INSERT) {
+            try (
+                //@checkstyle LineLengthCheck (2 lines)
+                PreparedStatement statement = this.conn.prepareStatement(
+                    "insert into artifacts (repo_type, repo_name, name, version, size, created_date, owner) VALUES (?,?,?,?,?,?,?);"
+                )
+            ) {
+                //@checkstyle MagicNumberCheck (10 lines)
+                statement.setString(1, record.repoType());
+                statement.setString(2, record.repoName());
+                statement.setString(3, record.artifactName());
+                statement.setString(4, record.artifactVersion());
+                statement.setDouble(5, record.size());
+                statement.setDate(6, new Date(record.createdDate()));
+                statement.setString(7, record.owner());
+                statement.execute();
+            } catch (final SQLException error) {
+                throw new EventProcessingError("Error while inserting record", error);
+            }
+        } else if (record.eventType() == ArtifactEvent.Type.DELETE) {
+            try (
+                PreparedStatement statement = this.conn.prepareStatement(
+                    "delete from artifacts where repo_name = ? and name = ? and version = ?;"
+                )
+            ) {
+                //@checkstyle MagicNumberCheck (10 lines)
+                statement.setString(1, record.repoName());
+                statement.setString(2, record.artifactName());
+                statement.setString(3, record.artifactVersion());
+                statement.execute();
+            } catch (final SQLException error) {
+                throw new EventProcessingError("Error while removing record", error);
+            }
+        }
+    }
+}

--- a/src/main/java/com/artipie/http/ArtipieRepositories.java
+++ b/src/main/java/com/artipie/http/ArtipieRepositories.java
@@ -12,6 +12,8 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.StandardRs;
 import com.artipie.http.slice.SliceSimple;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.ConfigFile;
 import com.artipie.settings.Settings;
 import com.artipie.settings.repo.RepositoriesFromStorage;
@@ -41,19 +43,28 @@ public final class ArtipieRepositories {
     private final Tokens tokens;
 
     /**
+     * Events queue.
+     */
+    private final EventQueue<ArtifactEvent> events;
+
+    /**
      * New Artipie repositories.
      * @param http HTTP client
      * @param settings Artipie settings
      * @param tokens Tokens: authentication and generation
+     * @param events Events queue
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
     public ArtipieRepositories(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens
+        final Tokens tokens,
+        final EventQueue<ArtifactEvent> events
     ) {
         this.http = http;
         this.settings = settings;
         this.tokens = tokens;
+        this.events = events;
     }
 
     /**
@@ -99,7 +110,8 @@ public final class ArtipieRepositories {
                             this.settings,
                             config,
                             config.port().isPresent(),
-                            this.tokens
+                            this.tokens,
+                            this.events
                         );
                     } else {
                         res = new SliceSimple(new RsRepoNotFound(name));

--- a/src/main/java/com/artipie/http/ArtipieRepositories.java
+++ b/src/main/java/com/artipie/http/ArtipieRepositories.java
@@ -12,8 +12,6 @@ import com.artipie.http.client.ClientSlices;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.StandardRs;
 import com.artipie.http.slice.SliceSimple;
-import com.artipie.scheduling.ArtifactEvent;
-import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.ConfigFile;
 import com.artipie.settings.Settings;
 import com.artipie.settings.repo.RepositoriesFromStorage;
@@ -43,28 +41,19 @@ public final class ArtipieRepositories {
     private final Tokens tokens;
 
     /**
-     * Events queue.
-     */
-    private final EventQueue<ArtifactEvent> events;
-
-    /**
      * New Artipie repositories.
      * @param http HTTP client
      * @param settings Artipie settings
      * @param tokens Tokens: authentication and generation
-     * @param events Events queue
-     * @checkstyle ParameterNumberCheck (10 lines)
      */
     public ArtipieRepositories(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens,
-        final EventQueue<ArtifactEvent> events
+        final Tokens tokens
     ) {
         this.http = http;
         this.settings = settings;
         this.tokens = tokens;
-        this.events = events;
     }
 
     /**
@@ -110,8 +99,7 @@ public final class ArtipieRepositories {
                             this.settings,
                             config,
                             config.port().isPresent(),
-                            this.tokens,
-                            this.events
+                            this.tokens
                         );
                     } else {
                         res = new SliceSimple(new RsRepoNotFound(name));

--- a/src/main/java/com/artipie/http/MainSlice.java
+++ b/src/main/java/com/artipie/http/MainSlice.java
@@ -16,6 +16,8 @@ import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
 import com.artipie.misc.ArtipieProperties;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.Settings;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -52,12 +54,14 @@ public final class MainSlice extends Slice.Wrap {
      * @param http HTTP client.
      * @param settings Artipie settings.
      * @param tokens Tokens: authentication and generation
+     * @param events Artifacts event
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public MainSlice(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens
+        final Tokens tokens,
+        final EventQueue<ArtifactEvent> events
     ) {
         super(
             new SliceRoute(
@@ -75,7 +79,9 @@ public final class MainSlice extends Slice.Wrap {
                 ),
                 new RtRulePath(
                     RtRule.FALLBACK,
-                    new DockerRoutingSlice(settings, new SliceByPath(http, settings, tokens))
+                    new DockerRoutingSlice(
+                        settings, new SliceByPath(http, settings, tokens, events)
+                    )
                 )
             )
         );

--- a/src/main/java/com/artipie/http/MainSlice.java
+++ b/src/main/java/com/artipie/http/MainSlice.java
@@ -16,8 +16,6 @@ import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
 import com.artipie.misc.ArtipieProperties;
-import com.artipie.scheduling.ArtifactEvent;
-import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.Settings;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -54,14 +52,12 @@ public final class MainSlice extends Slice.Wrap {
      * @param http HTTP client.
      * @param settings Artipie settings.
      * @param tokens Tokens: authentication and generation
-     * @param events Artifacts event
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public MainSlice(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens,
-        final EventQueue<ArtifactEvent> events
+        final Tokens tokens
     ) {
         super(
             new SliceRoute(
@@ -80,7 +76,7 @@ public final class MainSlice extends Slice.Wrap {
                 new RtRulePath(
                     RtRule.FALLBACK,
                     new DockerRoutingSlice(
-                        settings, new SliceByPath(http, settings, tokens, events)
+                        settings, new SliceByPath(http, settings, tokens)
                     )
                 )
             )

--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -12,8 +12,6 @@ import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
-import com.artipie.scheduling.ArtifactEvent;
-import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.Settings;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -43,29 +41,20 @@ final class SliceByPath implements Slice {
     private final Tokens tokens;
 
     /**
-     * Events queue.
-     */
-    private final EventQueue<ArtifactEvent> events;
-
-    /**
      * New slice from settings.
      *
      * @param http HTTP client
      * @param settings Artipie settings
      * @param tokens Tokens: authentication and generation
-     * @param events Artifacts event
-     * @checkstyle ParameterNumberCheck (10 lines)
      */
     SliceByPath(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens,
-        final EventQueue<ArtifactEvent> events
+        final Tokens tokens
     ) {
         this.http = http;
         this.settings = settings;
         this.tokens = tokens;
-        this.events = events;
     }
 
     // @checkstyle ReturnCountCheck (20 lines)
@@ -83,7 +72,7 @@ final class SliceByPath implements Slice {
                 StandardCharsets.UTF_8
             );
         }
-        return new ArtipieRepositories(this.http, this.settings, this.tokens, this.events)
+        return new ArtipieRepositories(this.http, this.settings, this.tokens)
             .slice(key.get(), new RequestLineFrom(line).uri().getPort())
             .response(line, headers, body);
     }

--- a/src/main/java/com/artipie/http/SliceByPath.java
+++ b/src/main/java/com/artipie/http/SliceByPath.java
@@ -12,6 +12,8 @@ import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.Settings;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -41,21 +43,29 @@ final class SliceByPath implements Slice {
     private final Tokens tokens;
 
     /**
+     * Events queue.
+     */
+    private final EventQueue<ArtifactEvent> events;
+
+    /**
      * New slice from settings.
      *
      * @param http HTTP client
      * @param settings Artipie settings
      * @param tokens Tokens: authentication and generation
+     * @param events Artifacts event
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     SliceByPath(
         final ClientSlices http,
         final Settings settings,
-        final Tokens tokens
+        final Tokens tokens,
+        final EventQueue<ArtifactEvent> events
     ) {
         this.http = http;
         this.settings = settings;
         this.tokens = tokens;
+        this.events = events;
     }
 
     // @checkstyle ReturnCountCheck (20 lines)
@@ -73,7 +83,7 @@ final class SliceByPath implements Slice {
                 StandardCharsets.UTF_8
             );
         }
-        return new ArtipieRepositories(this.http, this.settings, this.tokens)
+        return new ArtipieRepositories(this.http, this.settings, this.tokens, this.events)
             .slice(key.get(), new RequestLineFrom(line).uri().getPort())
             .response(line, headers, body);
     }

--- a/src/main/java/com/artipie/settings/Settings.java
+++ b/src/main/java/com/artipie/settings/Settings.java
@@ -7,8 +7,11 @@ package com.artipie.settings;
 import com.amihaiemil.eoyaml.YamlMapping;
 import com.artipie.api.ssl.KeyStore;
 import com.artipie.asto.Storage;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.settings.cache.ArtipieCaches;
 import java.util.Optional;
+import javax.sql.DataSource;
 
 /**
  * Application settings.
@@ -60,5 +63,17 @@ public interface Settings {
      * @return The caches
      */
     ArtipieCaches caches();
+
+    /**
+     * Database source.
+     * @return Database
+     */
+    DataSource databaseSource();
+
+    /**
+     * Artifact events queue.
+     * @return Artifact events queue
+     */
+    EventQueue<ArtifactEvent> events();
 
 }

--- a/src/main/java/com/artipie/settings/SettingsFromPath.java
+++ b/src/main/java/com/artipie/settings/SettingsFromPath.java
@@ -48,7 +48,7 @@ public final class SettingsFromPath {
             initialize = true;
         }
         final Settings settings = new YamlSettings(
-            Yaml.createYamlInput(this.path.toFile()).readYamlMapping()
+            Yaml.createYamlInput(this.path.toFile()).readYamlMapping(), this.path.getParent()
         );
         final BlockingStorage bsto = new BlockingStorage(settings.configStorage());
         final Key init = new Key.From(".artipie", "initialized");

--- a/src/test/java/com/artipie/SchedulerDbTest.java
+++ b/src/test/java/com/artipie/SchedulerDbTest.java
@@ -73,7 +73,7 @@ public final class SchedulerDbTest {
                 Thread.sleep(990);
             }
         }
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+        Awaitility.await().atMost(20, TimeUnit.SECONDS).until(
             () -> {
                 try (Statement stat = this.connection.createStatement()) {
                     stat.execute("select count(*) from artifacts");

--- a/src/test/java/com/artipie/SchedulerDbTest.java
+++ b/src/test/java/com/artipie/SchedulerDbTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.db.ArtifactDbFactory;
+import com.artipie.db.DbConsumer;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
+import com.artipie.scheduling.QuartsService;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.quartz.SchedulerException;
+
+/**
+ * Test for {@link com.artipie.scheduling.QuartsService} and
+ * {@link com.artipie.db.DbConsumer}.
+ * @since 0.31
+ * @checkstyle MagicNumberCheck (1000 lines)
+ * @checkstyle IllegalTokenCheck (1000 lines)
+ * @checkstyle LocalVariableNameCheck (1000 lines)
+ */
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+public final class SchedulerDbTest {
+
+    /**
+     * Test directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @TempDir
+    Path path;
+
+    /**
+     * Test connection.
+     */
+    private Connection connection;
+
+    /**
+     * Quartz service to test.
+     */
+    private QuartsService service;
+
+    @BeforeEach
+    void init() throws SQLException {
+        this.connection = new ArtifactDbFactory(Yaml.createYamlMappingBuilder().build(), this.path)
+            .initialize().getConnection();
+        this.service = new QuartsService();
+    }
+
+    @Test
+    void insertsRecords() throws SchedulerException, InterruptedException {
+        final EventQueue<ArtifactEvent> queue =
+            this.service.addPeriodicEventsProcessor(new DbConsumer(this.connection), 4, 1);
+        final long created = System.currentTimeMillis();
+        this.service.start();
+        for (int i = 0; i < 1000; i++) {
+            queue.put(
+                new ArtifactEvent(
+                    "rpm", "my-rpm", "Alice", "org.time", String.valueOf(i), 1250L, created
+                )
+            );
+            if (i % 50 == 0) {
+                Thread.sleep(990);
+            }
+        }
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+            () -> {
+                try (Statement stat = this.connection.createStatement()) {
+                    stat.execute("select count(*) from artifacts");
+                    return stat.getResultSet().getInt(1) == 1000;
+                }
+            }
+        );
+    }
+
+    @AfterEach
+    void close() throws SQLException {
+        this.connection.close();
+    }
+
+}

--- a/src/test/java/com/artipie/api/SSLJksRestTest.java
+++ b/src/test/java/com/artipie/api/SSLJksRestTest.java
@@ -8,7 +8,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.api.ssl.KeyStore;
 import com.artipie.asto.Key;
 import com.artipie.asto.test.TestResource;
-import com.artipie.settings.YamlSettings;
+import com.artipie.test.TestSettings;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -30,7 +30,7 @@ final class SSLJksRestTest extends SSLBaseRestTest {
             new Key.From(SSLJksRestTest.JKS),
             new TestResource(String.format("ssl/%s", SSLJksRestTest.JKS)).asBytes()
         );
-        return new YamlSettings(
+        return new TestSettings(
             Yaml.createYamlInput(
                 String.join(
                     "",

--- a/src/test/java/com/artipie/api/SSLPemRestTest.java
+++ b/src/test/java/com/artipie/api/SSLPemRestTest.java
@@ -8,7 +8,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.api.ssl.KeyStore;
 import com.artipie.asto.Key;
 import com.artipie.asto.test.TestResource;
-import com.artipie.settings.YamlSettings;
+import com.artipie.test.TestSettings;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -39,7 +39,7 @@ final class SSLPemRestTest extends SSLBaseRestTest {
             new Key.From(SSLPemRestTest.CERT_PEM),
             new TestResource(String.format("ssl/%s", SSLPemRestTest.CERT_PEM)).asBytes()
         );
-        return new YamlSettings(
+        return new TestSettings(
             Yaml.createYamlInput(
                 String.join(
                     "",

--- a/src/test/java/com/artipie/api/SSLPfxRestTest.java
+++ b/src/test/java/com/artipie/api/SSLPfxRestTest.java
@@ -8,7 +8,7 @@ import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.api.ssl.KeyStore;
 import com.artipie.asto.Key;
 import com.artipie.asto.test.TestResource;
-import com.artipie.settings.YamlSettings;
+import com.artipie.test.TestSettings;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -30,7 +30,7 @@ final class SSLPfxRestTest extends SSLBaseRestTest {
             new Key.From(SSLPfxRestTest.CERT_PFX),
             new TestResource(String.format("ssl/%s", SSLPfxRestTest.CERT_PFX)).asBytes()
         );
-        return new YamlSettings(
+        return new TestSettings(
             Yaml.createYamlInput(
                 String.join(
                     "",

--- a/src/test/java/com/artipie/auth/AuthFromKeycloakTest.java
+++ b/src/test/java/com/artipie/auth/AuthFromKeycloakTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -105,6 +106,13 @@ public class AuthFromKeycloakTest {
     private static Set<URL> sources;
 
     /**
+     * Test directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @TempDir
+    Path path;
+
+    /**
      * Compiles, loads 'keycloak.KeycloakDockerInitializer' class and start 'main'-method.
      * Runtime compilation is required because 'keycloak.KeycloakDockerInitializer' class
      * has a clash of dependencies with Artipie's dependency 'com.jcabi:jcabi-github:1.3.2'.
@@ -126,7 +134,7 @@ public class AuthFromKeycloakTest {
     void authenticateExistingUserReturnsUserWithRealm() {
         final String login = "user1";
         final String password = "password";
-        final YamlSettings settings = AuthFromKeycloakTest.settings(
+        final YamlSettings settings = this.settings(
             AuthFromKeycloakTest.keycloakUrl(),
             AuthFromKeycloakTest.REALM,
             AuthFromKeycloakTest.CLIENT_ID,
@@ -147,7 +155,7 @@ public class AuthFromKeycloakTest {
     @Test
     void authenticateNoExistingUser() {
         final String fake = "fake";
-        final YamlSettings settings = AuthFromKeycloakTest.settings(
+        final YamlSettings settings = this.settings(
             AuthFromKeycloakTest.keycloakUrl(),
             AuthFromKeycloakTest.REALM,
             AuthFromKeycloakTest.CLIENT_ID,
@@ -169,7 +177,7 @@ public class AuthFromKeycloakTest {
      * @checkstyle ParameterNumberCheck (3 lines)
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
-    private static YamlSettings settings(final String url, final String realm,
+    private YamlSettings settings(final String url, final String realm,
         final String client, final String password) {
         return new YamlSettings(
             Yaml.createYamlMappingBuilder().add(
@@ -187,7 +195,8 @@ public class AuthFromKeycloakTest {
                                 .build()
                         ).build()
                 ).build()
-            ).build()
+            ).build(),
+            this.path
         );
     }
 

--- a/src/test/java/com/artipie/db/DbConsumerTest.java
+++ b/src/test/java/com/artipie/db/DbConsumerTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.db;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.scheduling.ArtifactEvent;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Record consumer.
+ * @since 0.31
+ * @checkstyle MagicNumberCheck (1000 lines)
+ */
+@SuppressWarnings(
+    {"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods", "PMD.CheckResultSet", "PMD.CloseResource"}
+)
+class DbConsumerTest {
+
+    /**
+     * Test directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @TempDir
+    Path path;
+
+    /**
+     * Test connection.
+     */
+    private Connection connection;
+
+    @BeforeEach
+    void init() throws SQLException {
+        this.connection = new ArtifactDbFactory(Yaml.createYamlMappingBuilder().build(), this.path)
+            .initialize().getConnection();
+    }
+
+    @Test
+    void addsAndRemovesRecord() throws SQLException {
+        final long created = System.currentTimeMillis();
+        final ArtifactEvent record = new ArtifactEvent(
+            "rpm", "my-rpm", "Alice", "org.time", "1.2", 1250L, created
+        );
+        new DbConsumer(this.connection).accept(record);
+        try (Statement stat = this.connection.createStatement()) {
+            stat.execute("select * from artifacts");
+            final ResultSet res = stat.getResultSet();
+            res.next();
+            MatcherAssert.assertThat(
+                res.getString("repo_type"),
+                new IsEqual<>(record.repoType())
+            );
+            MatcherAssert.assertThat(
+                res.getString("repo_name"),
+                new IsEqual<>(record.repoName())
+            );
+            MatcherAssert.assertThat(
+                res.getString("name"),
+                new IsEqual<>(record.artifactName())
+            );
+            MatcherAssert.assertThat(
+                res.getString("version"),
+                new IsEqual<>(record.artifactVersion())
+            );
+            MatcherAssert.assertThat(
+                res.getString("owner"),
+                new IsEqual<>(record.owner())
+            );
+            MatcherAssert.assertThat(
+                res.getLong("size"),
+                new IsEqual<>(record.size())
+            );
+            MatcherAssert.assertThat(
+                res.getDate("created_date"),
+                new IsEqual<>(new Date(record.createdDate()))
+            );
+            MatcherAssert.assertThat(
+                "ResultSet does not have more records",
+                res.next(), new IsEqual<>(false)
+            );
+        }
+        new DbConsumer(this.connection).accept(
+            new ArtifactEvent(
+                "rpm", "my-rpm", "Alice", "org.time", "1.2", 1250L, created,
+                ArtifactEvent.Type.DELETE
+            )
+        );
+        try (Statement stat = this.connection.createStatement()) {
+            stat.execute("select count(*) from artifacts");
+            MatcherAssert.assertThat(
+                stat.getResultSet().getInt(1),
+                new IsEqual<>(0)
+            );
+        }
+    }
+
+    @AfterEach
+    void close() throws SQLException {
+        this.connection.close();
+    }
+}

--- a/src/test/java/com/artipie/db/DbConsumerTest.java
+++ b/src/test/java/com/artipie/db/DbConsumerTest.java
@@ -12,9 +12,11 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.awaitility.Awaitility;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -23,6 +25,9 @@ import org.junit.jupiter.api.io.TempDir;
  * Record consumer.
  * @since 0.31
  * @checkstyle MagicNumberCheck (1000 lines)
+ * @checkstyle ExecutableStatementCountCheck (1000 lines)
+ * @checkstyle LocalVariableNameCheck (1000 lines)
+ * @checkstyle IllegalTokenCheck (1000 lines)
  */
 @SuppressWarnings(
     {"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods", "PMD.CheckResultSet", "PMD.CloseResource"}
@@ -39,22 +44,37 @@ class DbConsumerTest {
     /**
      * Test connection.
      */
-    private Connection connection;
+    private DataSource source;
 
     @BeforeEach
-    void init() throws SQLException {
-        this.connection = new ArtifactDbFactory(Yaml.createYamlMappingBuilder().build(), this.path)
-            .initialize().getConnection();
+    void init() {
+        this.source = new ArtifactDbFactory(Yaml.createYamlMappingBuilder().build(), this.path)
+            .initialize();
     }
 
     @Test
     void addsAndRemovesRecord() throws SQLException {
+        final DbConsumer consumer = new DbConsumer(this.source);
         final long created = System.currentTimeMillis();
         final ArtifactEvent record = new ArtifactEvent(
             "rpm", "my-rpm", "Alice", "org.time", "1.2", 1250L, created
         );
-        new DbConsumer(this.connection).accept(record);
-        try (Statement stat = this.connection.createStatement()) {
+        consumer.accept(record);
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+            () -> {
+                try (
+                    Connection conn = this.source.getConnection();
+                    Statement stat = conn.createStatement()
+                ) {
+                    stat.execute("select count(*) from artifacts");
+                    return stat.getResultSet().getInt(1) == 1;
+                }
+            }
+        );
+        try (
+            Connection conn = this.source.getConnection();
+            Statement stat = conn.createStatement()
+        ) {
             stat.execute("select * from artifacts");
             final ResultSet res = stat.getResultSet();
             res.next();
@@ -91,23 +111,79 @@ class DbConsumerTest {
                 res.next(), new IsEqual<>(false)
             );
         }
-        new DbConsumer(this.connection).accept(
+        consumer.accept(
             new ArtifactEvent(
                 "rpm", "my-rpm", "Alice", "org.time", "1.2", 1250L, created,
                 ArtifactEvent.Type.DELETE
             )
         );
-        try (Statement stat = this.connection.createStatement()) {
-            stat.execute("select count(*) from artifacts");
-            MatcherAssert.assertThat(
-                stat.getResultSet().getInt(1),
-                new IsEqual<>(0)
-            );
-        }
+        Awaitility.await().atMost(20, TimeUnit.SECONDS).until(
+            () -> {
+                try (
+                    Connection conn = this.source.getConnection();
+                    Statement stat = conn.createStatement()
+                ) {
+                    stat.execute("select count(*) from artifacts");
+                    return stat.getResultSet().getInt(1) == 0;
+                }
+            }
+        );
     }
 
-    @AfterEach
-    void close() throws SQLException {
-        this.connection.close();
+    @Test
+    void insertsAndRemovesRecords() throws InterruptedException {
+        final DbConsumer consumer = new DbConsumer(this.source);
+        Thread.sleep(1000);
+        final long created = System.currentTimeMillis();
+        for (int i = 0; i < 500; i++) {
+            consumer.accept(
+                new ArtifactEvent(
+                    "rpm", "my-rpm", "Alice", "org.time", String.valueOf(i), 1250L, created - i
+                )
+            );
+            if (i % 99 == 0) {
+                Thread.sleep(1000);
+            }
+        }
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+            () -> {
+                try (
+                    Connection conn = this.source.getConnection();
+                    Statement stat = conn.createStatement()
+                ) {
+                    stat.execute("select count(*) from artifacts");
+                    return stat.getResultSet().getInt(1) == 500;
+                }
+            }
+        );
+        for (int i = 500; i <= 1000; i++) {
+            consumer.accept(
+                new ArtifactEvent(
+                    "rpm", "my-rpm", "Alice", "org.time", String.valueOf(i), 1250L, created - i
+                )
+            );
+            if (i % 99 == 0) {
+                Thread.sleep(1000);
+            }
+            if (i % 20 == 0) {
+                consumer.accept(
+                    new ArtifactEvent(
+                        "rpm", "my-rpm", "Alice", "org.time", String.valueOf(i - 500), 1250L,
+                        created - i, ArtifactEvent.Type.DELETE
+                    )
+                );
+            }
+        }
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(
+            () -> {
+                try (
+                    Connection conn = this.source.getConnection();
+                    Statement stat = conn.createStatement()
+                ) {
+                    stat.execute("select count(*) from artifacts");
+                    return stat.getResultSet().getInt(1) == 975;
+                }
+            }
+        );
     }
 }

--- a/src/test/java/com/artipie/db/DbConsumerTest.java
+++ b/src/test/java/com/artipie/db/DbConsumerTest.java
@@ -53,8 +53,9 @@ class DbConsumerTest {
     }
 
     @Test
-    void addsAndRemovesRecord() throws SQLException {
+    void addsAndRemovesRecord() throws SQLException, InterruptedException {
         final DbConsumer consumer = new DbConsumer(this.source);
+        Thread.sleep(1000);
         final long created = System.currentTimeMillis();
         final ArtifactEvent record = new ArtifactEvent(
             "rpm", "my-rpm", "Alice", "org.time", "1.2", 1250L, created

--- a/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
+++ b/src/test/java/com/artipie/http/DockerRoutingSliceTest.java
@@ -18,6 +18,8 @@ import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.scheduling.ArtifactEvent;
+import com.artipie.scheduling.EventQueue;
 import com.artipie.security.policy.Policy;
 import com.artipie.settings.ArtipieSecurity;
 import com.artipie.settings.MetricsContext;
@@ -31,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import javax.sql.DataSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
@@ -200,6 +203,16 @@ final class DockerRoutingSliceTest {
         @Override
         public ArtipieCaches caches() {
             return new TestArtipieCaches();
+        }
+
+        @Override
+        public DataSource databaseSource() {
+            return null;
+        }
+
+        @Override
+        public EventQueue<ArtifactEvent> events() {
+            return null;
         }
     }
 }

--- a/src/test/java/com/artipie/settings/YamlSettingsTest.java
+++ b/src/test/java/com/artipie/settings/YamlSettingsTest.java
@@ -32,10 +32,17 @@ import org.junit.jupiter.params.provider.ValueSource;
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class YamlSettingsTest {
 
+    /**
+     * Test directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @TempDir
+    Path temp;
+
     @Test
     void shouldBuildFileStorageFromSettings() throws Exception {
         final YamlSettings settings = new YamlSettings(
-            this.config("some/path")
+            this.config("some/path"), this.temp
         );
         MatcherAssert.assertThat(
             settings.configStorage(),
@@ -47,7 +54,7 @@ class YamlSettingsTest {
     void returnsRepoConfigs(@TempDir final Path tmp) {
         MatcherAssert.assertThat(
             new YamlSettings(
-                this.config(tmp.toString())
+                this.config(tmp.toString()), tmp
             ).repoConfigsStorage(),
             new IsInstanceOf(SubStorage.class)
         );
@@ -57,7 +64,7 @@ class YamlSettingsTest {
     @MethodSource("badYamls")
     void shouldFailProvideStorageFromBadYaml(final String yaml) throws IOException {
         final YamlSettings settings = new YamlSettings(
-            Yaml.createYamlInput(yaml).readYamlMapping()
+            Yaml.createYamlInput(yaml).readYamlMapping(), this.temp
         );
         Assertions.assertThrows(RuntimeException.class, settings::configStorage);
     }
@@ -67,14 +74,14 @@ class YamlSettingsTest {
     void throwsErrorIfMetaSectionIsAbsentOrEmpty(final String yaml) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new YamlSettings(Yaml.createYamlInput(yaml).readYamlMapping()).meta()
+            () -> new YamlSettings(Yaml.createYamlInput(yaml).readYamlMapping(), this.temp).meta()
         );
     }
 
     @Test
     void initializesEnvAuth() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.envCreds()).readYamlMapping()
+            Yaml.createYamlInput(this.envCreds()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Env credentials are initialized",
@@ -95,7 +102,7 @@ class YamlSettingsTest {
     @Test
     void initializesGithubAuth() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.githubCreds()).readYamlMapping()
+            Yaml.createYamlInput(this.githubCreds()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Github auth created",
@@ -116,7 +123,7 @@ class YamlSettingsTest {
     @Test
     void initializesKeycloakAuth() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.keycloakCreds()).readYamlMapping()
+            Yaml.createYamlInput(this.keycloakCreds()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Keycloak storage created",
@@ -137,7 +144,7 @@ class YamlSettingsTest {
     @Test
     void initializesArtipieAuth() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.artipieCreds()).readYamlMapping()
+            Yaml.createYamlInput(this.artipieCreds()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Auth from storage initiated",
@@ -158,7 +165,7 @@ class YamlSettingsTest {
     @Test
     void initializesArtipieAuthAndPolicy() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.artipieCredsWithPolicy()).readYamlMapping()
+            Yaml.createYamlInput(this.artipieCredsWithPolicy()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Auth from storage initiated",
@@ -179,7 +186,7 @@ class YamlSettingsTest {
     @Test
     void initializesAllAuths() throws IOException {
         final YamlSettings authz = new YamlSettings(
-            Yaml.createYamlInput(this.artipieGithubKeycloakEnvCreds()).readYamlMapping()
+            Yaml.createYamlInput(this.artipieGithubKeycloakEnvCreds()).readYamlMapping(), this.temp
         );
         MatcherAssert.assertThat(
             "Auth from storage, github, env and keycloak initiated",
@@ -205,7 +212,8 @@ class YamlSettingsTest {
     @Test
     void initializesAllAuthsAndPolicy() throws IOException {
         final YamlSettings settings = new YamlSettings(
-            Yaml.createYamlInput(this.artipieGithubKeycloakEnvCredsAndPolicy()).readYamlMapping()
+            Yaml.createYamlInput(this.artipieGithubKeycloakEnvCredsAndPolicy()).readYamlMapping(),
+            this.temp
         );
         MatcherAssert.assertThat(
             "Auth from storage, github, env and keycloak initiated",

--- a/src/test/java/com/artipie/settings/cache/CachedStoragesTest.java
+++ b/src/test/java/com/artipie/settings/cache/CachedStoragesTest.java
@@ -9,10 +9,12 @@ import com.artipie.ArtipieException;
 import com.artipie.asto.Storage;
 import com.artipie.settings.Settings;
 import com.artipie.settings.YamlSettings;
+import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link CachedStorages}.
@@ -21,12 +23,19 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class CachedStoragesTest {
 
+    /**
+     * Test directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @TempDir
+    Path temp;
+
     @Test
     void getsValueFromCache() {
         final String path = "same/path/for/storage";
         final CachedStorages cache = new CachedStorages();
-        final Storage strg = cache.storage(CachedStoragesTest.config(path));
-        final Storage same = cache.storage(CachedStoragesTest.config(path));
+        final Storage strg = cache.storage(this.config(path));
+        final Storage same = cache.storage(this.config(path));
         MatcherAssert.assertThat(
             "Obtained configurations were different",
             strg.equals(same),
@@ -42,8 +51,8 @@ final class CachedStoragesTest {
     @Test
     void getsOriginForDifferentConfiguration() {
         final CachedStorages cache = new CachedStorages();
-        final Storage frst = cache.storage(CachedStoragesTest.config("first"));
-        final Storage scnd = cache.storage(CachedStoragesTest.config("second"));
+        final Storage frst = cache.storage(this.config("first"));
+        final Storage scnd = cache.storage(this.config("second"));
         MatcherAssert.assertThat(
             "Obtained configurations were the same",
             frst.equals(scnd),
@@ -64,13 +73,13 @@ final class CachedStoragesTest {
                 new YamlSettings(
                     Yaml.createYamlMappingBuilder()
                         .add("meta", Yaml.createYamlMappingBuilder().build())
-                        .build()
+                        .build(), Path.of("a/b/c")
                 )
             )
         );
     }
 
-    private static Settings config(final String stpath) {
+    private Settings config(final String stpath) {
         return new YamlSettings(
             Yaml.createYamlMappingBuilder()
                 .add(
@@ -81,7 +90,7 @@ final class CachedStoragesTest {
                             .add("type", "fs")
                             .add("path", stpath).build()
                     ).build()
-                ).build()
+                ).build(), this.temp
         );
     }
 }

--- a/src/test/resources/artipie-repo-config-key.yaml
+++ b/src/test/resources/artipie-repo-config-key.yaml
@@ -4,3 +4,5 @@ meta:
     path: /var/artipie/repo
   base_url: http://artipie:8080/
   repo_configs: my_configs
+  artifacts_database:
+    sqlite_data_file_path: /var/artipie/artifacts.db

--- a/src/test/resources/artipie.yaml
+++ b/src/test/resources/artipie.yaml
@@ -8,3 +8,5 @@ meta:
       storage:
         type: fs
         path: /var/artipie/security
+  artifacts_database:
+    sqlite_data_file_path: /var/artipie/artifacts.db

--- a/src/test/resources/artipie_with_policy.yaml
+++ b/src/test/resources/artipie_with_policy.yaml
@@ -10,3 +10,5 @@ meta:
     storage:
       type: fs
       path: /var/artipie/security
+  artifacts_database:
+    sqlite_data_file_path: /var/artipie/artifacts.db


### PR DESCRIPTION
part of #1291 
Added consumer to insert and remove records from database, provided queue to adapters and added initiation of scheduler.

Also added tests. 

Note, that consumer accepts connection, not data source. Such approach is good for [sqlite db](https://stackoverflow.com/questions/15822778/sqlite-connection-pool-in-java-locked-database), but will not be suitable for connection pool and normal db (as postgresql or mysql). 