### PR TITLE
feat: composer instance to use permissions policy

### DIFF
--- a/src/main/java/com/artipie/SliceFromConfig.java
+++ b/src/main/java/com/artipie/SliceFromConfig.java
@@ -159,7 +159,10 @@ public final class SliceFromConfig extends Slice.Wrap {
             case "php":
                 slice = new TrimPathSlice(
                     new PhpComposer(
-                        new AstoRepository(cfg.storage(), Optional.of(cfg.url().toString()))
+                        new AstoRepository(cfg.storage(), Optional.of(cfg.url().toString())),
+                        policy,
+                        auth,
+                        cfg.name()
                     ),
                     SliceFromConfig.PTRN
                 );


### PR DESCRIPTION
Composer repository was free of permission check. I try to fix it.
There was a simple class constructor used, which set unrestricted access to repo.

I'm not a java developer, so made by analogy with other policy's changes.
And FYI same situation might be with gem repo.

Part of #1237