### PR TITLE
Restored lost 'then' + spelling

### DIFF
--- a/.github/workflows/perftest-client.yml
+++ b/.github/workflows/perftest-client.yml
@@ -157,7 +157,7 @@ jobs:
 
           rm -rfv "$tmpDir"
 
-      - name: Check perfromance difference stability
+      - name: Check performance difference stability
         env:
           GITHUB_TAG: ${{ github.event.workflow_run.head_branch }}
         working-directory: benchmarks/loadtests
@@ -183,7 +183,7 @@ jobs:
 
           diffLimit="15.0" # wsl client <--> wsl server currently less stable
           ls -lah perftests_repo/perftests
-          if ./checkstats.py perftests_repo/perftests "$diffLimit"
+          if ./checkstats.py perftests_repo/perftests "$diffLimit" ; then
             echo "Performance difference withit limit range"
           else
             echo "WARNING: Performance difference out of range. Sending emails..."

--- a/.github/workflows/perftest-server.yml
+++ b/.github/workflows/perftest-server.yml
@@ -170,7 +170,7 @@ jobs:
 
           rm -rfv "$tmpDir"
 
-      - name: Check perfromance difference stability
+      - name: Check performance difference stability
         working-directory: benchmarks/loadtests
         run: |
           tag="$GITHUB_REF_NAME" # GITHUB_TAG
@@ -194,7 +194,7 @@ jobs:
 
           diffLimit="7.0"
           ls -lah perftests_repo/perftests
-          if ./checkstats.py perftests_repo/perftests "$diffLimit"
+          if ./checkstats.py perftests_repo/perftests "$diffLimit" ; then
             echo "Performance difference withit limit range"
           else
             echo "WARNING: Performance difference out of range. Sending emails..."


### PR DESCRIPTION
Restored lost 'then' (when removed TODOs) + spelling. Part of  https://github.com/artipie/benchmarks/issues/64