### PR TITLE
Fixing smoke test fails

### DIFF
--- a/examples/maven/run.sh
+++ b/examples/maven/run.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 
 # Upload a maven project
-mvn -B --quiet -f sample-for-deployment deploy -Dmaven.install.skip=true
+mvn -V -B --quiet -f sample-for-deployment deploy -Dmaven.install.skip=true
 
 # Upload the sample-for-deployment
-mvn -B --quiet -f sample-consumer -U clean install
+mvn -V -B --quiet -f sample-consumer -U clean install

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -159,7 +159,7 @@ create_network
 create_volume
 start_artipie
 
-sleep 1 #sometimes artipie container needs extra time to load
+sleep 3 #sometimes artipie container needs extra time to load
 
 if [[ -z "$1" ]]; then
   declare -a tests=(binary debian docker go helm maven npm nuget php rpm conda pypi hexpm)


### PR DESCRIPTION
Fixing smoke test fails. This should fix smoke test fails + provide more logs in the future. I think Artipie server sometimes initializing longer than expected in the tests.