### PR TITLE
fix: use --release option

### DIFF
--- a/.github/workflows/maven-adapter-release.yml
+++ b/.github/workflows/maven-adapter-release.yml
@@ -2,7 +2,7 @@ name: Create Maven adapter release
 on:
   push:
     tags:
-      - '*_*_*'
+      - '*_*'
 jobs:
   build:
     name: Build release
@@ -55,20 +55,10 @@ jobs:
               }
             ]
       - run: mvn -B install -DskipTests
-      - uses: actions/setup-java@v2
-        with:
-          java-version: ${{steps.split.outputs._2}}
-          distribution: adopt
-      - name: Deploy adapter with java > 8
-        run: mvn deploy -Partipie,publish,sonatype,gpg-sign -DskipTests --errors
+      - run: mvn deploy -Partipie,publish,sonatype,gpg-sign -DskipTests --errors
         working-directory: ${{steps.split.outputs._0}}
-        if: ${{steps.split.outputs._2 != '8'}}
         env:
           MAVEN_OPTS: --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED
-      - name: Deploy adapter with java 8
-        run: mvn deploy -Partipie,publish,sonatype,gpg-sign -DskipTests --errors
-        working-directory: ${{steps.split.outputs._0}}
-        if: ${{steps.split.outputs._2 == '8'}}
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ git push --tags origin
 ```
 Also, each adapter can be released into Maven Central individually. To do that, push git tag of the following format:
 ```text
-[adapter-name]_[version]_[java-version]
-rpm-adapter_v1.2.3_8 
+[adapter-name]_[version]
+rpm-adapter_v1.2.3
 ```
 On this tag, GitHub action [maven-adapter-release.yml](.github%2Fworkflows%2Fmaven-adapter-release.yml) will run to
-release specified adapter using specified java version. Note, that required Java Version is also set in adapters' pom 
-files and should correspond to version in release tag. 
+release specified adapter. Note, that some of the adapters should be compatible with java 8. To achieve that, we use 
+[--release=8](https://www.baeldung.com/java-compiler-release-option) option for the main code.

--- a/artipie-core/src/main/java/com/artipie/security/perms/UserPermissions.java
+++ b/artipie-core/src/main/java/com/artipie/security/perms/UserPermissions.java
@@ -4,7 +4,6 @@
  */
 package com.artipie.security.perms;
 
-import java.io.Serial;
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Enumeration;
@@ -48,7 +47,6 @@ public final class UserPermissions extends PermissionCollection {
     /**
      * Required serial.
      */
-    @Serial
     private static final long serialVersionUID = -7546496571951236695L;
 
     /**

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -275,6 +275,17 @@ SOFTWARE.
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>docker-build</id>
@@ -342,17 +353,9 @@ SOFTWARE.
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>${maven.compiler.source}</source>
-                            <target>${maven.compiler.target}</target>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>${maven.compiler.source}</source>
+                            <source>21</source>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/artipie-main/src/main/resources/example/artipie.yaml
+++ b/artipie-main/src/main/resources/example/artipie.yaml
@@ -4,10 +4,14 @@ meta:
     path: /var/artipie/repo
   credentials:
     - type: env
+    - type: github
+    - type: artipie
+  policy:
+    type: artipie
+    storage:
+      type: fs
+      path: /var/artipie/security
   base_url: http://central.artipie.com/
-  crontab:
-    - path: C:\Users\g00563573\IdeaProjects\artipie\data\del_docker.rb
-      cronexp: "*/1 * * * * ?"
   metrics:
     port: 8087
     endpoint: "/metrics"

--- a/composer-adapter/pom.xml
+++ b/composer-adapter/pom.xml
@@ -34,10 +34,6 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>composer-files</name>
   <description>Turns your files/objects into PHP Composer artifacts</description>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/conan-adapter/pom.xml
+++ b/conan-adapter/pom.xml
@@ -31,10 +31,6 @@ SOFTWARE.
   </parent>
   <artifactId>conan-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/conda-adapter/pom.xml
+++ b/conda-adapter/pom.xml
@@ -34,10 +34,6 @@ SOFTWARE.
   <name>conda-adapter</name>
   <description>Turns your files/objects into conda repository</description>
   <inceptionYear>2021</inceptionYear>
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/debian-adapter/pom.xml
+++ b/debian-adapter/pom.xml
@@ -36,8 +36,6 @@ SOFTWARE.
   <description>Debian adapter</description>
   <inceptionYear>2020</inceptionYear>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <org.bouncycastle.version>1.70</org.bouncycastle.version>
     <jmh.version>1.29</jmh.version>
   </properties>

--- a/files-adapter/src/test/java/com/artipie/files/FileProxySliceITCase.java
+++ b/files-adapter/src/test/java/com/artipie/files/FileProxySliceITCase.java
@@ -21,7 +21,9 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.client.utils.URIBuilder;
+import org.awaitility.Awaitility;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.AfterEach;
@@ -131,7 +133,7 @@ final class FileProxySliceITCase {
             new BlockingStorage(cache).value(new Key.From("any")),
             new IsEqual<>(data)
         );
-        MatcherAssert.assertThat("Event was added to queue", events.size() == 1);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> events.size() == 1);
         final ArtifactEvent item = events.element();
         MatcherAssert.assertThat(
             item.artifactName(),

--- a/gem-adapter/pom.xml
+++ b/gem-adapter/pom.xml
@@ -34,10 +34,6 @@ SOFTWARE.
   <name>gem-adapter</name>
   <description>An Artipie adapter for Ruby Gem packages</description>
   <inceptionYear>2020</inceptionYear>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/helm-adapter/pom.xml
+++ b/helm-adapter/pom.xml
@@ -32,10 +32,6 @@ SOFTWARE.
   <artifactId>helm-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>helm-adapter</name>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/hexpm-adapter/pom.xml
+++ b/hexpm-adapter/pom.xml
@@ -61,4 +61,15 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>21</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-adapter/pom.xml
+++ b/maven-adapter/pom.xml
@@ -75,5 +75,14 @@ SOFTWARE.
         <filtering>false</filtering>
       </testResource>
     </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>21</release>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/npm-adapter/pom.xml
+++ b/npm-adapter/pom.xml
@@ -35,10 +35,6 @@ SOFTWARE.
   <name>npm-adapter</name>
   <description>Turns your files/objects into NPM artifacts</description>
   <inceptionYear>2019</inceptionYear>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/nuget-adapter/pom.xml
+++ b/nuget-adapter/pom.xml
@@ -35,10 +35,6 @@ SOFTWARE.
   <name>nuget-adapter</name>
   <description>Turns your files/objects into NuGet artifacts</description>
   <inceptionYear>2020</inceptionYear>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,6 @@ SOFTWARE.
     <url>https://github.com/artipie/artipie</url>
   </scm>
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <docker.image.name>artipie/artipie</docker.image.name>
     <qulice.license>${project.basedir}/../LICENSE.header</qulice.license>
     <asto.version>v1.16.0</asto.version>
@@ -235,6 +233,29 @@ SOFTWARE.
     </dependency>
   </dependencies>
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+<!--          <source>21</source>-->
+<!--          <target>21</target>-->
+          <release>8</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <release>21</release>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -238,8 +238,6 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-<!--          <source>21</source>-->
-<!--          <target>21</target>-->
           <release>8</release>
         </configuration>
         <executions>

--- a/rpm-adapter/pom.xml
+++ b/rpm-adapter/pom.xml
@@ -34,10 +34,6 @@ SOFTWARE.
   <name>rpm-adapter</name>
   <description>Turns your files/objects into RPM artifacts</description>
   <inceptionYear>2019</inceptionYear>
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.artipie</groupId>


### PR DESCRIPTION
Corrected approach with different java versions for different modules: 
- it's more correct to use [`--release`](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html) javac option instead of `target` and `source` and there is no need to compile with lower java version, [java will do all the magic itself](https://www.baeldung.com/java-compiler-release-option) 
- used `maven-compiler-plugin` to set different release version for tests. Thus, our test code does not have to be compatible with java 8, we can use new classes and features. 
- If any not java8 compatible feature was used in the main code, compilation will fail
- artipie-main, hex and maven adapters can use java 21 in the main code (these modules are not used by Chinees team) 