### PR TITLE
feat: artipie-ubuntu docker release

### DIFF
--- a/.github/workflows/docker-ubuntu-release.yml
+++ b/.github/workflows/docker-ubuntu-release.yml
@@ -27,11 +27,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: mvn versions:set -DnewVersion=${{ env.RELEASE_VERSION }}
       - run: mvn install -DskipTests
-      - run: mvn -B deploy -Pdocker-ubuntu -DskipTests
+      - run: mvn -B deploy -Pubuntu-docker -DskipTests
         working-directory: artipie-main
       - run: mvn versions:set -DnewVersion=latest
       - run: mvn install -DskipTests
-      - run: mvn -B deploy -Pdocker-build -DskipTests
+      - run: mvn -B deploy -Pubuntu-docker -DskipTests
         working-directory: artipie-main
       - name: Create Github Release
         id: create_release

--- a/.github/workflows/docker-ubuntu-release.yml
+++ b/.github/workflows/docker-ubuntu-release.yml
@@ -1,0 +1,45 @@
+name: Release Docker images
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 21
+          distribution: adopt
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-jdk-21-maven-
+          runs-on: ubuntu-latest
+      - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: mvn versions:set -DnewVersion=${{ env.RELEASE_VERSION }}
+      - run: mvn install -DskipTests
+      - run: mvn -B deploy -Pdocker-ubuntu -DskipTests
+        working-directory: artipie-main
+      - run: mvn versions:set -DnewVersion=latest
+      - run: mvn install -DskipTests
+      - run: mvn -B deploy -Pdocker-build -DskipTests
+        working-directory: artipie-main
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false

--- a/artipie-main/Dockerfile-ubuntu
+++ b/artipie-main/Dockerfile-ubuntu
@@ -1,0 +1,46 @@
+
+FROM ubuntu:22.04
+
+# this is a non-interactive automated build - avoid some warning messages
+ENV DEBIAN_FRONTEND noninteractive
+
+# update dpkg repositories
+RUN apt-get update
+
+# install wget
+RUN apt-get install -y wget
+
+# set shell variables for java installation
+ENV java_version 21
+ENV filename jdk-21_linux-x64_bin.tar.gz
+ENV downloadlink https://download.oracle.com/java/21/latest/$filename
+
+# download java, accepting the license agreement
+RUN wget --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" -O /tmp/$filename $downloadlink
+
+# unpack java
+RUN mkdir /opt/java-oracle/ && mkdir /opt/java-oracle/jdk21/ && tar -zxf /tmp/$filename -C /opt/java-oracle/jdk21/ --strip-components 1
+ENV JAVA_HOME /opt/java-oracle/jdk21
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# configure symbolic links for the java and javac executables
+RUN update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 20000 && update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 20000
+
+ARG JAR_FILE
+ENV JVM_OPTS=""
+
+RUN groupadd -r -g 2020 artipie && \
+    useradd -M -r -g artipie -u 2021 -s /sbin/nologin artipie && \
+    mkdir -p /etc/artipie /usr/lib/artipie /var/artipie && \
+    chown artipie:artipie -R /etc/artipie /usr/lib/artipie /var/artipie
+USER 2021:2020
+
+COPY target/dependency  /usr/lib/artipie/lib
+COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
+COPY src/test/resources/ssl/keystore.jks /var/artipie/keystore.jks
+
+VOLUME /var/artipie /etc/artipie
+WORKDIR /var/artipie
+EXPOSE 8080 8086 8091
+CMD [ "sh", "-c", "java $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]
+

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -365,9 +365,7 @@ SOFTWARE.
         <profile>
             <id>ubuntu-docker</id>
             <activation>
-                <file>
-                    <exists>/var/run/docker.sock</exists>
-                </file>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -363,7 +363,7 @@ SOFTWARE.
             </build>
         </profile>
         <profile>
-            <id>docker-ubuntu</id>
+            <id>ubuntu-docker</id>
             <activation>
                 <file>
                     <exists>/var/run/docker.sock</exists>

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -34,6 +34,7 @@ SOFTWARE.
     <properties>
         <jettyVersion>12.0.3</jettyVersion>
         <docker.image.name>artipie/artipie</docker.image.name>
+        <docker.ubuntu.image.name>artipie/artipie-ubuntu</docker.ubuntu.image.name>
     </properties>
     <dependencies>
         <dependency>
@@ -197,7 +198,7 @@ SOFTWARE.
         <dependency>
             <groupId>com.artipie</groupId>
             <artifactId>gem-adapter</artifactId>
-            <version>v1.3.7</version>
+            <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -340,6 +341,80 @@ SOFTWARE.
                             <repository>${docker.image.name}</repository>
                             <tag>${project.version}</tag>
                             <dockerfile>Dockerfile</dockerfile>
+                            <buildArgs>
+                                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>21</source>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker-ubuntu</id>
+            <activation>
+                <file>
+                    <exists>/var/run/docker.sock</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.artipie.VertxMain</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-dependencies</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.4.13</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>${docker.ubuntu.image.name}</repository>
+                            <tag>${project.version}</tag>
+                            <dockerfile>Dockerfile-ubuntu</dockerfile>
                             <buildArgs>
                                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
                             </buildArgs>

--- a/maven-adapter/src/main/java/com/artipie/maven/http/CachedProxySlice.java
+++ b/maven-adapter/src/main/java/com/artipie/maven/http/CachedProxySlice.java
@@ -109,7 +109,7 @@ final class CachedProxySlice implements Slice {
         final Publisher<ByteBuffer> body) {
         final RequestLineFrom req = new RequestLineFrom(line);
         final Key key = new KeyFromPath(req.uri().getPath());
-        final AtomicReference<Headers> rshdr = new AtomicReference<>();
+        final AtomicReference<Headers> rshdr = new AtomicReference<>(Headers.EMPTY);
         return new AsyncResponse(
             new RepoHead(this.client)
                 .head(req.uri().getPath()).thenCompose(
@@ -157,8 +157,10 @@ final class CachedProxySlice implements Slice {
                                     new Content.From(content.get())
                                 );
                             } else {
-                                Logger.error(this, throwable.getMessage());
                                 result = StandardRs.NOT_FOUND;
+                                if (throwable != null) {
+                                    Logger.error(this, throwable.getMessage());
+                                }
                             }
                             return result;
                         }

--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,6 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>2.0.9</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>2.0.9</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,6 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.9</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <version>2.0.9</version>
     </dependency>


### PR DESCRIPTION
part of https://github.com/artipie/maven-resolver-http3-plugin/issues/12 


- As http3 does not work on standard jdk image, I've added configuration to release artipie based on ubuntu docker image
- Fixed maven adapter to send to client headers received from proxy server  
- Removed log4j which were moved to reload4j