### PR TITLE
Conda + s3 bug fix

### DIFF
--- a/artipie-main/examples/run.sh
+++ b/artipie-main/examples/run.sh
@@ -182,6 +182,11 @@ r=0
 grep "FAILED" "$workdir/results.txt" > /dev/null || r="$?"
 if [ "$r" -eq 0 ] ; then
   rm -fv "$pidfile"
+  echo "Artipie container logs:"
+  container=$(docker ps --filter name=artipie -q 2> /dev/null)
+  if [[ -n "$container" ]] ; then
+    docker logs "$container" || echo "failed to log artipie"
+  fi
   die "One or more tests failed"
 else
   rm -fv "$pidfile"

--- a/asto/asto-core/src/main/java/com/artipie/asto/test/ReadWithDelaysStorage.java
+++ b/asto/asto-core/src/main/java/com/artipie/asto/test/ReadWithDelaysStorage.java
@@ -1,0 +1,48 @@
+package com.artipie.asto.test;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Splitting;
+import com.artipie.asto.Storage;
+import io.reactivex.Flowable;
+
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Storage for tests.
+ * <p/>
+ * Reading a value by a key return content that emit chunks of bytes
+ * with random size and random delays.
+ *
+ * @since 1.12
+ */
+public class ReadWithDelaysStorage extends Storage.Wrap {
+    /**
+     * Ctor.
+     *
+     * @param delegate Original storage.
+     */
+    public ReadWithDelaysStorage(final Storage delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public final CompletableFuture<Content> value(final Key key) {
+        final Random random = new Random();
+        return super.value(key)
+            .thenApply(
+                content -> new Content.From(
+                    Flowable.fromPublisher(content)
+                        .flatMap(
+                            buffer -> new Splitting(
+                                buffer,
+                                (random.nextInt(9) + 1) * 1024
+                            ).publisher()
+                        )
+                        .delay(random.nextInt(5_000), TimeUnit.MILLISECONDS)
+                )
+            );
+    }
+}

--- a/asto/asto-core/src/test/java/com/artipie/asto/streams/StorageValuePipelineTest.java
+++ b/asto/asto-core/src/test/java/com/artipie/asto/streams/StorageValuePipelineTest.java
@@ -7,19 +7,18 @@ package com.artipie.asto.streams;
 import com.artipie.asto.ArtipieIOException;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
-import com.artipie.asto.Splitting;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
-import io.reactivex.Flowable;
+import com.artipie.asto.test.ReadWithDelaysStorage;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
@@ -224,40 +223,4 @@ class StorageValuePipelineTest {
         );
     }
 
-    /**
-     * Storage for tests.
-     * <p/>
-     * Reading a value by a key return content that emit chunks of bytes
-     * with random size and random delays.
-     *
-     * @since 1.12
-     */
-    private static class ReadWithDelaysStorage extends Storage.Wrap {
-        /**
-         * Ctor.
-         *
-         * @param delegate Original storage.
-         */
-        ReadWithDelaysStorage(final Storage delegate) {
-            super(delegate);
-        }
-
-        @Override
-        public final CompletableFuture<Content> value(final Key key) {
-            final Random random = new Random();
-            return super.value(key)
-                .thenApply(
-                    content -> new Content.From(
-                        Flowable.fromPublisher(content)
-                            .flatMap(
-                                buffer -> new Splitting(
-                                    buffer,
-                                    (random.nextInt(9) + 1) * 1024
-                                ).publisher()
-                            )
-                            .delay(random.nextInt(5_000), TimeUnit.MILLISECONDS)
-                    )
-                );
-        }
-    }
 }

--- a/asto/asto-s3/src/test/java/com/artipie/asto/StorageValuePipelineS3Test.java
+++ b/asto/asto-s3/src/test/java/com/artipie/asto/StorageValuePipelineS3Test.java
@@ -1,0 +1,179 @@
+package com.artipie.asto;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amihaiemil.eoyaml.Yaml;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.factory.Config;
+import com.artipie.asto.factory.StoragesLoader;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.s3.S3Storage;
+import com.artipie.asto.streams.StorageValuePipeline;
+import com.artipie.asto.test.ReadWithDelaysStorage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Test for {@link StorageValuePipeline} backed by {@link S3Storage}
+ */
+public class StorageValuePipelineTest {
+
+    /**
+     * Mock S3 server.
+     */
+    @RegisterExtension
+    static final S3MockExtension MOCK = S3MockExtension.builder()
+        .withSecureConnection(false)
+        .build();
+
+    /**
+     * Bucket to use in tests.
+     */
+    private String bucket;
+
+    @BeforeEach
+    void setUp(final AmazonS3 client) {
+        this.bucket = UUID.randomUUID().toString();
+        client.createBucket(this.bucket);
+        asto = new StoragesLoader()
+            .newObject(
+                "s3",
+                new Config.YamlStorageConfig(
+                    Yaml.createYamlMappingBuilder()
+                        .add("region", "us-east-1")
+                        .add("bucket", this.bucket)
+                        .add("endpoint", String.format("http://localhost:%d", MOCK.getHttpPort()))
+                        .add(
+                            "credentials",
+                            Yaml.createYamlMappingBuilder()
+                                .add("type", "basic")
+                                .add("accessKeyId", "foo")
+                                .add("secretAccessKey", "bar")
+                                .build()
+                        )
+                        .build()
+                )
+            );
+    }
+
+    /**
+     * Test storage.
+     */
+    private Storage asto;
+
+    @BeforeEach
+    void init() {
+        this.asto = new InMemoryStorage();
+    }
+
+    @Test
+    void processesExistingItemAndReturnsResult() {
+        final Key key = new Key.From("test.txt");
+        final Charset charset = StandardCharsets.US_ASCII;
+        this.asto.save(key, new Content.From("five\nsix\neight".getBytes(charset))).join();
+        MatcherAssert.assertThat(
+            "Resulting lines count should be 4",
+            new StorageValuePipeline<Integer>(this.asto, key).processWithResult(
+                (input, out) -> {
+                    try {
+                        final List<String> list = IOUtils.readLines(input.get(), charset);
+                        list.add(2, "seven");
+                        IOUtils.writeLines(list, "\n", out, charset);
+                        return list.size();
+                    } catch (final IOException err) {
+                        throw new ArtipieIOException(err);
+                    }
+                }
+            ).toCompletableFuture().join(),
+            new IsEqual<>(4)
+        );
+        MatcherAssert.assertThat(
+            "Storage item was not updated",
+            new String(new BlockingStorage(this.asto).value(key), charset),
+            new IsEqual<>("five\nsix\nseven\neight\n")
+        );
+    }
+
+    @Test
+    void processesExistingItemAndReturnsResultWithThen() {
+        final Key key = new Key.From("test.txt");
+        final Charset charset = StandardCharsets.US_ASCII;
+
+        MatcherAssert.assertThat(
+            "Resulting lines count should be 4",
+            this.asto.save(key, new Content.From("five\nsix\neight".getBytes(charset))).thenCompose(unused -> {
+                return new StorageValuePipeline<Integer>(this.asto, key).processWithResult(
+                    (input, out) -> {
+                        try {
+                            final List<String> list = IOUtils.readLines(input.get(), charset);
+                            list.add(2, "seven");
+                            IOUtils.writeLines(list, "\n", out, charset);
+                            return list.size();
+                        } catch (final IOException err) {
+                            throw new ArtipieIOException(err);
+                        }
+                    }
+                );
+            }).join(),
+            new IsEqual<>(4)
+        );
+        MatcherAssert.assertThat(
+            "Storage item was not updated",
+            new String(new BlockingStorage(this.asto).value(key), charset),
+            new IsEqual<>("five\nsix\nseven\neight\n")
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "key_from,key_to",
+        "key_from,key_from"
+    })
+    void processesExistingLargeSizeItem(
+        final String read, final String write
+    ) {
+        final int size = 1024 * 1024;
+        final int bufsize = 128;
+        final byte[] data = new byte[size];
+        new Random().nextBytes(data);
+        final Key kfrom = new Key.From(read);
+        final Key kto = new Key.From(write);
+        this.asto.save(kfrom, new Content.From(data)).join();
+        new StorageValuePipeline<String>(new ReadWithDelaysStorage(this.asto), kfrom, kto)
+            .processWithResult(
+                (input, out) -> {
+                    final byte[] buffer = new byte[bufsize];
+                    try {
+                        final InputStream stream = input.get();
+                        while (stream.read(buffer) != -1) {
+                            IOUtils.write(buffer, out);
+                            out.flush();
+                        }
+                        new Random().nextBytes(buffer);
+                        IOUtils.write(buffer, out);
+                        out.flush();
+                    } catch (final IOException err) {
+                        throw new ArtipieIOException(err);
+                    }
+                    return "res";
+                }
+            ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            new BlockingStorage(this.asto).value(kto).length,
+            new IsEqual<>(size + bufsize)
+        );
+    }
+}

--- a/asto/asto-s3/src/test/java/com/artipie/asto/StorageValuePipelineS3Test.java
+++ b/asto/asto-s3/src/test/java/com/artipie/asto/StorageValuePipelineS3Test.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 /**
  * Test for {@link StorageValuePipeline} backed by {@link S3Storage}
  */
-public class StorageValuePipelineTest {
+public class StorageValuePipelineS3Test {
 
     /**
      * Mock S3 server.

--- a/conda-adapter/src/main/java/com/artipie/conda/asto/AstoMergedJson.java
+++ b/conda-adapter/src/main/java/com/artipie/conda/asto/AstoMergedJson.java
@@ -5,24 +5,17 @@
 package com.artipie.conda.asto;
 
 import com.artipie.asto.ArtipieIOException;
-import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.misc.UncheckedIOFunc;
+import com.artipie.asto.streams.StorageValuePipeline;
 import com.artipie.conda.meta.MergedJson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import javax.json.JsonObject;
 
 /**
@@ -59,7 +52,7 @@ public final class AstoMergedJson {
      * @return Completable operation
      */
     public CompletionStage<Void> merge(final Map<String, JsonObject> items) {
-        return new StorageValuePipeline<>(this.asto, this.key).processData(
+        return new StorageValuePipeline<>(this.asto, this.key).process(
             (opt, out) -> {
                 try {
                     final JsonFactory factory = new JsonFactory();
@@ -78,116 +71,5 @@ public final class AstoMergedJson {
                 }
             }
         );
-    }
-
-    /**
-     * Processes storage value content as optional input data and
-     * saves the result back as output stream.
-     *
-     * @param <R> Result type
-     * @since 1.5
-     * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
-     */
-    private static final class StorageValuePipeline<R> {
-
-        /**
-         * Abstract storage.
-         */
-        private final Storage asto;
-
-        /**
-         * Storage item key to read from.
-         */
-        private final Key read;
-
-        /**
-         * Storage item key to write to.
-         */
-        private final Key write;
-
-        /**
-         * Ctor.
-         *
-         * @param asto Abstract storage
-         * @param read Storage item key to read from
-         * @param write Storage item key to write to
-         */
-        StorageValuePipeline(final Storage asto, final Key read, final Key write) {
-            this.asto = asto;
-            this.read = read;
-            this.write = write;
-        }
-
-        /**
-         * Ctor.
-         *
-         * @param asto Abstract storage
-         * @param key Item key
-         */
-        StorageValuePipeline(final Storage asto, final Key key) {
-            this(asto, key, key);
-        }
-
-        /**
-         * Process storage item and save it back.
-         *
-         * @param action Action to perform with storage content if exists and write back as
-         *  output stream.
-         * @return Completion action
-         * @throws ArtipieIOException On Error
-         */
-        public CompletionStage<Void> processData(
-            final BiConsumer<Optional<byte[]>, OutputStream> action
-        ) {
-            return this.processWithBytesResult(
-                (opt, input) -> {
-                    action.accept(opt, input);
-                    return null;
-                }
-            ).thenAccept(
-                nothing -> {
-                }
-            );
-        }
-
-        /**
-         * Process storage item, save it back and return some result.
-         *
-         * @param action Action to perform with storage content if exists and write back as
-         *  output stream.
-         * @return Completion action with the result
-         * @throws ArtipieIOException On Error
-         */
-        public CompletionStage<R> processWithBytesResult(
-            final BiFunction<Optional<byte[]>, OutputStream, R> action
-        ) {
-            final AtomicReference<R> res = new AtomicReference<>();
-            return this.asto.exists(this.read)
-                .thenCompose(
-                    exists -> {
-                        final CompletionStage<Optional<byte[]>> stage;
-                        if (exists) {
-                            stage = this.asto.value(this.read)
-                                .thenCompose(
-                                    content -> new PublisherAs(content).bytes()
-                                ).thenApply(bytes -> Optional.of(bytes));
-                        } else {
-                            stage = CompletableFuture.completedFuture(Optional.empty());
-                        }
-                        return stage;
-                    }
-                ).thenCompose(
-                    optional -> {
-                        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-                            res.set(action.apply(optional, output));
-                            return this.asto.save(
-                                this.write, new Content.From(output.toByteArray())
-                            );
-                        } catch (final IOException err) {
-                            throw new ArtipieIOException(err);
-                        }
-                    }
-                ).thenApply(nothing -> res.get());
-        }
     }
 }


### PR DESCRIPTION
Fixing deadlock in `StorageValuePipeline.java` + test in asto-s3. Hotfix is removed.
Deadlock happens when Publisher for the `InputStream` produces data in the same thread as `action` callback by several chunks, and `action` callback actually does blocking `read()` on provided `InputStream`. Since plain `read()` is blocking, event loop doesn't get called, Publisher doesn't provide next part of the data and `read()` gets stuck. This situation always happens for S3Storage, since AWS S3 SDK invokes callback in one of its AWS threads and provides Publisher from that same thread too. The solution was to call `action` with the blocking `read()` in async block, from different thread.
Also, I had problems with `PublishingOutputStream` being stuck or incorretly callbacked, if `onComplete()` wasn't called in time.

Part of https://github.com/artipie/artipie/issues/1343