### PR TITLE
Helm tests fix

### DIFF
--- a/helm-adapter/src/main/java/com/artipie/helm/RemoveWriter.java
+++ b/helm-adapter/src/main/java/com/artipie/helm/RemoveWriter.java
@@ -99,9 +99,8 @@ public interface RemoveWriter {
                 ).thenCompose(
                     noth ->  {
                         try {
-                            final BufferedWriter bufw = new BufferedWriter(
-                                new OutputStreamWriter(Files.newOutputStream(out))
-                            );
+                            final OutputStreamWriter osw = new OutputStreamWriter(Files.newOutputStream(out));
+                            final BufferedWriter bufw = new BufferedWriter(osw);
                             final TokenizerFlatProc target = new TokenizerFlatProc("\n");
                             return this.contentOfIndex(source)
                                 .thenAccept(cont -> cont.subscribe(target))
@@ -152,6 +151,7 @@ public interface RemoveWriter {
                                             ctx -> {
                                                 try {
                                                     bufw.close();
+                                                    osw.close();
                                                 } catch (final IOException exc) {
                                                     throw new ArtipieIOException(exc);
                                                 }

--- a/helm-adapter/src/test/java/com/artipie/helm/HelmAstoAddTest.java
+++ b/helm-adapter/src/test/java/com/artipie/helm/HelmAstoAddTest.java
@@ -137,7 +137,6 @@ final class HelmAstoAddTest {
         HelmAstoAddTest.assertTmpDirWasRemoved();
     }
 
-    @Disabled
     @Test
     void failsToAddInfoAboutExistedVersion() throws IOException {
         final String ark = "ark-1.0.1.tgz";

--- a/helm-adapter/src/test/java/com/artipie/helm/HelmAstoReindexTest.java
+++ b/helm-adapter/src/test/java/com/artipie/helm/HelmAstoReindexTest.java
@@ -30,11 +30,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Test for {@link Helm.Asto#reindex(Key)}.
  * @since 0.3
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #113:30min Fix reindex operation.
- *  For some cases (about 1-2 of 1000) these tests fail with NPE when
- *  it tries to get entries of a new index. It looks like index does not have
- *  time to copy from temporary written index file to the source one.
- *  It is necessary to address this problem and enable tests.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class HelmAstoReindexTest {
@@ -48,7 +43,6 @@ final class HelmAstoReindexTest {
         this.storage = new InMemoryStorage();
     }
 
-    @Disabled
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void reindexFromRootDirectory(final boolean withindex) throws IOException {
@@ -73,7 +67,6 @@ final class HelmAstoReindexTest {
         HelmAstoReindexTest.assertTmpDirWasRemoved();
     }
 
-    @Disabled
     @Test
     void reindexWithSomePrefix() throws IOException {
         final Key prfx = new Key.From("prefix");


### PR DESCRIPTION
While working on https://github.com/artipie/artipie/issues/1343 I had intermittent helm adapter tests fails. So I investigated it and prepared helm adapter tests fix. The problem was that java `java.io.BufferedWriter` doesn't propagate `close()` call downstream, it just flushes its own data and resets its reference. So, closing streams properly allowed also to enable few other disabled helm tests without intermittent test fails, as yet.
Interestingly, in [JDK7](https://github.com/openjdk/jdk/blob/jdk7-b147/jdk/src/share/classes/java/io/BufferedWriter.java#L258) it would close its stream, but in [JDK8](https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/share/classes/java/io/BufferedWriter.java#L259) it didn't. [JDK21](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/share/classes/java/io/BufferedWriter.java#L375) (last LTS) doesn't close its stream too.