### PR TITLE
docker-adapter: fixed async copy without waiting

### DIFF
--- a/docker-adapter/src/main/java/com/artipie/docker/cache/CacheManifests.java
+++ b/docker-adapter/src/main/java/com/artipie/docker/cache/CacheManifests.java
@@ -92,8 +92,7 @@ public final class CacheManifests implements Manifests {
                 final CompletionStage<Optional<Manifest>> result;
                 if (throwable == null) {
                     if (original.isPresent()) {
-                        this.copy(ref);
-                        result = CompletableFuture.completedFuture(original);
+                        result = this.copy(ref).thenApply(unused -> original);
                     } else {
                         result = this.cache.manifests().get(ref).exceptionally(ignored -> original);
                     }


### PR DESCRIPTION
docker-adapter: fixed async copy without proper waiting. Could also fix intermittent test fail. Usually happens in "CI checks / maven-build (windows-latest) ".

```
........
Error:  Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.179 s <<< FAILURE! -- in com.artipie.docker.cache.CacheManifestsTest
Error:  com.artipie.docker.cache.CacheManifestsTest.shouldCacheManifest -- Time elapsed: 0.132 s <<< FAILURE!
java.lang.AssertionError: Artifact metadata were added to queue
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:26)
	at com.artipie.docker.cache.CacheManifestsTest.shouldCacheManifest(CacheManifestsTest.java:108)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```