### PR TITLE
composer optimization/intermittent test fail fix

### DIFF
--- a/composer-adapter/src/main/java/com/artipie/composer/AstoRepository.java
+++ b/composer-adapter/src/main/java/com/artipie/composer/AstoRepository.java
@@ -80,7 +80,7 @@ public final class AstoRepository implements Repository {
                 .thenCompose(PublisherAs::bytes)
                 .thenCompose(
                     bytes -> {
-                        final Package pack = new JsonPackage(new Content.From(bytes));
+                        final Package pack = new JsonPackage(bytes);
                         return CompletableFuture.allOf(
                             this.packages().thenCompose(
                                 packages -> packages.orElse(new JsonPackages())
@@ -133,9 +133,7 @@ public final class AstoRepository implements Repository {
                                     this.packages(),
                                     (noth, packages) -> packages.orElse(new JsonPackages())
                                         .add(
-                                            new JsonPackage(
-                                                new Content.From(this.addDist(compos, key))
-                                            ),
+                                            new JsonPackage(this.addDist(compos, key)),
                                             Optional.empty()
                                         )
                                         .thenCompose(

--- a/composer-adapter/src/main/java/com/artipie/composer/JsonPackage.java
+++ b/composer-adapter/src/main/java/com/artipie/composer/JsonPackage.java
@@ -4,12 +4,14 @@
  */
 package com.artipie.composer;
 
-import com.artipie.asto.Content;
-import com.artipie.composer.misc.ContentAsJson;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
 
 /**
  * PHP Composer package built from JSON.
@@ -25,15 +27,24 @@ public final class JsonPackage implements Package {
     /**
      * Package binary content.
      */
-    private final Content content;
+    private final JsonObject json;
 
     /**
      * Ctor.
      *
-     * @param content Package binary content.
+     * @param data Package binary content.
      */
-    public JsonPackage(final Content content) {
-        this.content = content;
+    public JsonPackage(final byte[] data) {
+        this(JsonPackage.loadJson(data));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param json Package json content.
+     */
+    public JsonPackage(final JsonObject json) {
+        this.json = json;
     }
 
     @Override
@@ -52,7 +63,20 @@ public final class JsonPackage implements Package {
 
     @Override
     public CompletionStage<JsonObject> json() {
-        return new ContentAsJson(this.content).value();
+        return CompletableFuture.completedFuture(this.json);
+    }
+
+    /**
+     * Load JsonObject from binary data.
+     * @param data Json object content.
+     * @return JsonObject instance.
+     */
+    private static JsonObject loadJson(final byte[] data) {
+        try (JsonReader reader = Json.createReader(
+            new StringReader(new String(data, StandardCharsets.UTF_8))
+        )) {
+            return reader.readObject();
+        }
     }
 
     /**

--- a/composer-adapter/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
+++ b/composer-adapter/src/test/java/com/artipie/composer/AstoRepositoryAddJsonTest.java
@@ -52,11 +52,7 @@ class AstoRepositoryAddJsonTest {
     @BeforeEach
     void init() {
         this.storage = new InMemoryStorage();
-        this.pack = new JsonPackage(
-            new Content.From(
-                new TestResource("minimal-package.json").asBytes()
-            )
-        );
+        this.pack = new JsonPackage(new TestResource("minimal-package.json").asBytes());
         this.version = this.pack.version(Optional.empty())
             .toCompletableFuture().join()
             .get();

--- a/composer-adapter/src/test/java/com/artipie/composer/JsonPackageTest.java
+++ b/composer-adapter/src/test/java/com/artipie/composer/JsonPackageTest.java
@@ -26,11 +26,7 @@ class JsonPackageTest {
 
     @BeforeEach
     void init()  {
-        this.pack = new JsonPackage(
-            new Content.From(
-                new TestResource("minimal-package.json").asBytes()
-            )
-        );
+        this.pack = new JsonPackage(new TestResource("minimal-package.json").asBytes());
     }
 
     @Test

--- a/composer-adapter/src/test/java/com/artipie/composer/JsonPackagesTest.java
+++ b/composer-adapter/src/test/java/com/artipie/composer/JsonPackagesTest.java
@@ -46,11 +46,7 @@ class JsonPackagesTest {
     @BeforeEach
     void init() {
         this.storage = new InMemoryStorage();
-        this.pack = new JsonPackage(
-            new Content.From(
-                new TestResource("minimal-package.json").asBytes()
-            )
-        );
+        this.pack = new JsonPackage(new TestResource("minimal-package.json").asBytes());
         this.name = this.pack.name().toCompletableFuture().join();
     }
 


### PR DESCRIPTION
composer adapter optimization/possible intermittent test fail fix. Found out that json data gets parsed to JsonObject multiple times, on every getter-like function, so I switched to parsing it only once in the constructor. Also may fix intermittent test fails like below.

```
.............
Caused by: javax.json.stream.JsonParsingException: Invalid token=EOF at (line no=1, column no=0, offset=-1). Expected tokens are: [CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]
	at org.glassfish.json.JsonParserImpl.parsingException(JsonParserImpl.java:450)
	at org.glassfish.json.JsonParserImpl.access$1100(JsonParserImpl.java:79)
	at org.glassfish.json.JsonParserImpl$NoneContext.getNextEvent(JsonParserImpl.java:438)
	at org.glassfish.json.JsonParserImpl.next(JsonParserImpl.java:376)
	at org.glassfish.json.JsonReaderImpl.readObject(JsonReaderImpl.java:111)
	at com.artipie.composer.misc.ContentAsJson.lambda$value$0(ContentAsJson.java:43)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684)
	... 24 more

Error:  Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.092 s <<< FAILURE! -- in com.artipie.composer.http.RepositoryHttpIT
Error:  com.artipie.composer.http.RepositoryHttpIT.shouldInstallAddedPackageWithoutVersion -- Time elapsed: 0.366 s <<< ERROR!
java.lang.IllegalStateException: Failed to upload package: 500
	at com.artipie.composer.test.HttpUrlUpload.upload(HttpUrlUpload.java:76)
	at com.artipie.composer.http.RepositoryHttpIT.shouldInstallAddedPackageWithoutVersion(RepositoryHttpIT.java:154)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

[INFO] 
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    RepositoryHttpIT.shouldInstallAddedPackageWithoutVersion:154 » IllegalState Failed to upload package: 500
[INFO] 
Error:  Tests run: 13, Failures: 0, Errors: 1, Skipped: 0
[INFO] 

```
