### PR TITLE
Fix for intermittent test fails.

### DIFF
--- a/asto/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
+++ b/asto/asto-core/src/main/java/com/artipie/asto/fs/FileStorage.java
@@ -263,7 +263,10 @@ public final class FileStorage implements Storage {
                 if (again) {
                     this.deleteEmptyParts(path.getParent());
                 }
-            } catch (final IOException err) {
+            } catch (final NoSuchFileException ex) {
+                this.deleteEmptyParts(path.getParent());
+            }
+            catch (final IOException err) {
                 throw new ArtipieIOException(err);
             }
         }


### PR DESCRIPTION
Fix for intermittent test fails due to empty dirs simultanious removal. Windows/Linux.
It happens when we use `FileStorage` and we remove common empty subdirectories (`deleteEmptyParts()`) simultaneously for 2+ keys, as part of `key` removal operation. Since those common empty subdirectories doesn't have any extra functionality/meaning, their non-existence should be ignored on removal.
Example of intermittent fail:
```
......
Caused by: com.artipie.asto.ArtipieIOException: java.nio.file.NoSuchFileException: /tmp/junit7472437463326177656/repo/bundle100/0f93eb03-2f5d-42a1-afd0-b2d7dd6df314
	at com.artipie.asto.fs.FileStorage.deleteEmptyParts(FileStorage.java:269)
	at com.artipie.asto.fs.FileStorage.lambda$delete$12(FileStorage.java:179)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718)
	... 6 more
Caused by: java.nio.file.NoSuchFileException: /tmp/junit7472437463326177656/repo/bundle100/0f93eb03-2f5d-42a1-afd0-b2d7dd6df314
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.asIOException(UnixException.java:115)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:477)
	at java.base/java.nio.file.Files.newDirectoryStream(Files.java:481)
	at java.base/java.nio.file.Files.list(Files.java:3772)
	at com.artipie.asto.fs.FileStorage.deleteEmptyParts(FileStorage.java:259)
	... 8 more

```