### PR TITLE
Intermittent test fail fix: RepoDataTest.removesData

### DIFF
--- a/artipie-main/src/main/java/com/artipie/settings/RepoData.java
+++ b/artipie-main/src/main/java/com/artipie/settings/RepoData.java
@@ -59,7 +59,7 @@ public final class RepoData {
     public CompletionStage<Void> remove(final RepositoryName rname) {
         final String repo = rname.toString();
         return this.repoStorage(rname)
-            .thenAccept(
+            .thenCompose(
                 asto ->
                     asto
                         .deleteAll(new Key.From(repo))


### PR DESCRIPTION
Intermittent test fail fix: RepoDataTest.removesData » Completion java.io.UncheckedIOException: java.nio.file.NoSuchFileException

CompletableFuture was just returned by `thenAccept()`, must be awaited by `thenCompose()`.
Fail example is below.

```
Error:  com.artipie.settings.RepoDataTest.removesData -- Time elapsed: 0.008 s <<< ERROR!
java.util.concurrent.CompletionException: java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /tmp/junit8233760876496059153/my-repo/first.txt
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /tmp/junit8233760876496059153/my-repo/first.txt
	at java.base/java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:87)
	at java.base/java.nio.file.FileTreeIterator.hasNext(FileTreeIterator.java:103)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:132)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.artipie.asto.fs.FileStorage.lambda$list$4(FileStorage.java:110)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 6 more
Caused by: java.nio.file.NoSuchFileException: /tmp/junit8233760876496059153/my-repo/first.txt
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:171)
	at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1853)
	at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:220)
	at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:277)
	at java.base/java.nio.file.FileTreeWalker.next(FileTreeWalker.java:374)
	at java.base/java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:83)
	... 16 more



[INFO] 
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    RepoDataTest.removesData » Completion java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /tmp/junit8233760876496059153/my-repo/first.txt
[INFO] 
Error:  Tests run: 360, Failures: 0, Errors: 1, Skipped: 0
[INFO] 

```