### PR TITLE
Intermittent test fails fix in FileStorageWhiteboxVerificationTest

### DIFF
--- a/asto/asto-core/src/main/java/com/artipie/asto/test/StorageWhiteboxVerification.java
+++ b/asto/asto-core/src/main/java/com/artipie/asto/test/StorageWhiteboxVerification.java
@@ -442,7 +442,7 @@ public abstract class StorageWhiteboxVerification {
                 final Storage storage = pair.getValue();
                 final Key key = new Key.From("shouldFailConcurrentExclusivelyForSameKey");
                 final FakeOperation operation = new FakeOperation();
-                storage.exclusively(key, operation);
+                final CompletionStage<Void> exclusively = storage.exclusively(key, operation);
                 operation.started.join();
                 try {
                     final CompletionException completion = Assertions.assertThrows(
@@ -459,6 +459,7 @@ public abstract class StorageWhiteboxVerification {
                     );
                 } finally {
                     operation.finished.complete(null);
+                    exclusively.toCompletableFuture().join();
                 }
             }
         );
@@ -472,7 +473,7 @@ public abstract class StorageWhiteboxVerification {
                 final Key one = new Key.From("shouldRunExclusivelyForDiffKey-1");
                 final Key two = new Key.From("shouldRunExclusivelyForDiffKey-2");
                 final FakeOperation operation = new FakeOperation();
-                storage.exclusively(one, operation);
+                final CompletionStage<Void> exclusively = storage.exclusively(one, operation);
                 operation.started.join();
                 try {
                     Assertions.assertDoesNotThrow(
@@ -483,6 +484,7 @@ public abstract class StorageWhiteboxVerification {
                     );
                 } finally {
                     operation.finished.complete(null);
+                    exclusively.toCompletableFuture().join();
                 }
             }
         );


### PR DESCRIPTION
Intermittent test fails fix in FileStorageWhiteboxVerificationTest.
We should wait for unfinished file operations on temporary files before test ends, or we are getting into race condition with junit.
Log example:
```
Error:  com.artipie.asto.FileStorageWhiteboxVerificationTest.exclusively_shouldFailExclusivelyForSameKey -- Time elapsed: 0.091 s <<< ERROR!
java.io.IOException: Failed to delete temp directory C:\Users\RUNNER~1\AppData\Local\Temp\junit11463551415899198878. The following paths could not be deleted (see suppressed exceptions for details): sub-storage\test-prefix
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:395)
	at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
	at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	Suppressed: java.nio.file.NoSuchFileException: C:\Users\RUNNER~1\AppData\Local\Temp\junit11463551415899198878\sub-storage\test-prefix
		at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85)
		at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
		at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
		at java.base/sun.nio.fs.WindowsDirectoryStream.<init>(WindowsDirectoryStream.java:86)
		at java.base/sun.nio.fs.WindowsFileSystemProvider.newDirectoryStream(WindowsFileSystemProvider.java:541)
		at java.base/java.nio.file.Files.newDirectoryStream(Files.java:481)
		at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:301)
		at java.base/java.nio.file.FileTreeWalker.next(FileTreeWalker.java:374)
		at java.base/java.nio.file.Files.walkFileTree(Files.java:2820)
		at java.base/java.nio.file.Files.walkFileTree(Files.java:2857)
		... 13 more
		Suppressed: java.nio.file.NoSuchFileException: C:\Users\RUNNER~1\AppData\Local\Temp\junit11463551415899198878\sub-storage\test-prefix
			at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85)
			at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
			at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:273)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:104)
			at java.base/java.nio.file.Files.delete(Files.java:1152)
			at java.base/java.nio.file.Files.walkFileTree(Files.java:2788)
			... 14 more


[INFO] 
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    FileStorageWhiteboxVerificationTest.exclusively_shouldFailExclusivelyForSameKey » IO Failed to delete temp directory C:\Users\RUNNER~1\AppData\Local\Temp\junit11463551415899198878. The following paths could not be deleted (see suppressed exceptions for details): sub-storage\test-prefix
[INFO] 
```