### PR TITLE
Intermittent test fail fix

### DIFF
--- a/maven-adapter/src/main/java/com/artipie/maven/http/CachedProxySlice.java
+++ b/maven-adapter/src/main/java/com/artipie/maven/http/CachedProxySlice.java
@@ -126,8 +126,8 @@ final class CachedProxySlice implements Slice {
                                                 Flowable.fromPublisher(rsbody)
                                                 .doOnError(term::completeExceptionally)
                                                 .doOnTerminate(() -> term.complete(null));
-                                            promise.complete(Optional.of(new Content.From(res)));
                                             this.addEventToQueue(key);
+                                            promise.complete(Optional.of(new Content.From(res)));
                                         } else {
                                             promise.complete(Optional.empty());
                                         }


### PR DESCRIPTION
Intermittent test fail fix. Event added after completion of the promise.
Log example:
```
Error:  Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.468 s <<< FAILURE! -- in com.artipie.maven.http.MavenProxySliceITCase
Error:  com.artipie.maven.http.MavenProxySliceITCase.downloadsJarFromCentralAndCachesIt -- Time elapsed: 0.049 s <<< FAILURE!
java.lang.AssertionError: Event was added to queue
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:26)
	at com.artipie.maven.http.MavenProxySliceITCase.downloadsJarFromCentralAndCachesIt(MavenProxySliceITCase.java:112)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)


[INFO] 
[INFO] Results:
[INFO] 
Error:  Failures: 
Error:    MavenProxySliceITCase.downloadsJarFromCentralAndCachesIt:112 Event was added to queue
[INFO] 
Error:  Tests run: 18, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
```