### PR TITLE
Maintainer info is required for publishing

### DIFF
--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -36,6 +36,19 @@ SOFTWARE.
         <docker.ubuntu.image.name>artipie/artipie-ubuntu</docker.ubuntu.image.name>
         <header.license>${project.basedir}/../LICENSE.header</header.license>
     </properties>
+    <developers>
+        <!-- Required for publishing to central -->
+        <developer>
+            <id>github.com/dgarus</id>
+            <name>Denis Garus</name>
+            <email>g4s8.public@gmail.com</email>
+            <organization>Artipie</organization>
+            <organizationUrl>https://www.artipie.com</organizationUrl>
+            <roles>
+                <role>maintainer</role>
+            </roles>
+        </developer>
+    </developers>
     <dependencies>
         <dependency>
             <groupId>com.artipie</groupId>


### PR DESCRIPTION
Maintainer info is required for publishing

```
Rule failure while trying to close staging repository with ID "comartipie-1753".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
Error:  Repository "comartipie-1753" failures
Error:    Rule "pom-staging" failures
Error:      * Invalid POM: /com/artipie/artipie/v1.17.11/artipie-v1.17.11.pom: Developer information missing
Error:  
Error:  
```