### PR TITLE
Optimizing integration test run time in CI by prebuilt docker images.

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-21-maven-
       - run: mvn install -DskipTests
-      - run: mvn -B package -Pdocker-build -DskipTests
+      - run: mvn -B package -Pdocker-tests-build -DskipTests
         working-directory: artipie-main
       - run: examples/run.sh
         working-directory: artipie-main

--- a/artipie-main/Dockerfile
+++ b/artipie-main/Dockerfile
@@ -1,6 +1,5 @@
 FROM openjdk:21-oracle
 ARG JAR_FILE
-ENV JVM_OPTS=""
 
 LABEL description="Artipie binary repository management tool"
 LABEL maintainer="g4s8.public@gmail.com"
@@ -15,8 +14,10 @@ USER 2021:2020
 COPY target/dependency  /usr/lib/artipie/lib
 COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
 
+RUN timeout 10s java -XX:ArchiveClassesAtExit=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086 || :
+
 VOLUME /var/artipie /etc/artipie
 WORKDIR /var/artipie
-EXPOSE 8080 8086
-CMD [ "sh", "-c", "java $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]
 
+EXPOSE 8080 8086
+CMD [ "sh", "-c", "java -XX:SharedArchiveFile=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]

--- a/artipie-main/Dockerfile
+++ b/artipie-main/Dockerfile
@@ -14,10 +14,8 @@ USER 2021:2020
 COPY target/dependency  /usr/lib/artipie/lib
 COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
 
-RUN timeout 10s java -XX:ArchiveClassesAtExit=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086 || :
-
 VOLUME /var/artipie /etc/artipie
 WORKDIR /var/artipie
 
 EXPOSE 8080 8086
-CMD [ "sh", "-c", "java -XX:SharedArchiveFile=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]
+CMD [ "sh", "-c", "java $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]

--- a/artipie-main/Dockerfile-tests
+++ b/artipie-main/Dockerfile-tests
@@ -1,0 +1,22 @@
+FROM openjdk:21-oracle
+ARG JAR_FILE
+
+LABEL description="Artipie binary repository management tool"
+
+RUN groupadd -r -g 2020 artipie && \
+    adduser -M -r -g artipie -u 2021 -s /sbin/nologin artipie && \
+    mkdir -p /etc/artipie /usr/lib/artipie /var/artipie && \
+    chown artipie:artipie -R /etc/artipie /usr/lib/artipie /var/artipie
+USER 2021:2020
+
+COPY target/dependency  /usr/lib/artipie/lib
+COPY target/${JAR_FILE} /usr/lib/artipie/artipie.jar
+
+# Run Artipie server for 10sec. on build-time to prepare JVM AppCDS cache data (artipie-d.jsa), which will be used to speed-up startup of the container
+RUN timeout 10s java -XX:ArchiveClassesAtExit=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086 || :
+
+VOLUME /var/artipie /etc/artipie
+WORKDIR /var/artipie
+
+EXPOSE 8080 8086
+CMD [ "sh", "-c", "java -XX:SharedArchiveFile=/usr/lib/artipie/artipie-d.jsa $JVM_ARGS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED -cp /usr/lib/artipie/artipie.jar:/usr/lib/artipie/lib/* com.artipie.VertxMain --config-file=/etc/artipie/artipie.yml --port=8080 --api-port=8086" ]

--- a/artipie-main/examples/run.sh
+++ b/artipie-main/examples/run.sh
@@ -10,7 +10,7 @@ workdir=$PWD
 #  - DEBUG - show debug messages
 #  - CI - enable CI mode (debug and `set -x`)
 #  - ARTIPIE_IMAGE - docker image name for artipie
-#       (default artipie/artipie:1.0-SNAPSHOT)
+#       (default artipie/artipie-tests:1.0-SNAPSHOT)
 
 # print error message and exist with error code
 function die {
@@ -59,7 +59,7 @@ function start_artipie {
     image=$ARTIPIE_IMAGE
   fi
   if [[ -z "$image" ]]; then
-    image="artipie/artipie:1.0-SNAPSHOT"
+    image="artipie/artipie-tests:1.0-SNAPSHOT"
   fi
   local port="$2"
   if [[ -z "$port" ]]; then

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -123,7 +123,7 @@ SOFTWARE.
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.16.2</version>
+            <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -34,6 +34,7 @@ SOFTWARE.
     <properties>
         <docker.image.name>artipie/artipie</docker.image.name>
         <docker.ubuntu.image.name>artipie/artipie-ubuntu</docker.ubuntu.image.name>
+        <docker.tests.image.name>artipie/artipie-tests</docker.tests.image.name>
         <header.license>${project.basedir}/../LICENSE.header</header.license>
     </properties>
     <dependencies>
@@ -440,6 +441,80 @@ SOFTWARE.
                             <repository>${docker.ubuntu.image.name}</repository>
                             <tag>${project.version}</tag>
                             <dockerfile>Dockerfile-ubuntu</dockerfile>
+                            <buildArgs>
+                                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>21</source>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker-tests-build</id>
+            <activation>
+                <file>
+                    <exists>/var/run/docker.sock</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.artipie.VertxMain</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-dependencies</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.4.13</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>${docker.tests.image.name}</repository>
+                            <tag>${project.version}</tag>
+                            <dockerfile>Dockerfile-tests</dockerfile>
                             <buildArgs>
                                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
                             </buildArgs>

--- a/artipie-main/src/test/java/com/artipie/conda/CondaAuthITCase.java
+++ b/artipie-main/src/test/java/com/artipie/conda/CondaAuthITCase.java
@@ -13,12 +13,10 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
 import org.hamcrest.core.StringContains;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.BindMode;
 
 /**
  * Conda IT case.
@@ -36,28 +34,8 @@ public final class CondaAuthITCase {
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
             .withUser("security/users/alice.yaml", "alice")
             .withRepoConfig("conda/conda-auth.yml", "my-conda"),
-        () -> new TestDeployment.ClientContainer("continuumio/miniconda3:22.11.1")
-            .withWorkingDirectory("/w")
-            .withClasspathResourceMapping(
-                "conda/example-project", "/w/example-project", BindMode.READ_ONLY
-            )
+        () -> new TestDeployment.ClientContainer("artipie/conda-tests:1.0")
     );
-
-    @BeforeEach
-    void init() throws IOException {
-        this.containers.assertExec(
-            "Conda-build install failed", new ContainerResultMatcher(),
-            "conda", "install", "-y", "conda-build"
-        );
-        this.containers.assertExec(
-            "Conda-verify install failed", new ContainerResultMatcher(),
-            "conda", "install", "-y", "conda-verify"
-        );
-        this.containers.assertExec(
-            "Conda-client install failed", new ContainerResultMatcher(),
-            "conda", "install", "-y", "anaconda-client"
-        );
-    }
 
     @Test
     void canUploadToArtipie() throws IOException {

--- a/artipie-main/src/test/java/com/artipie/conda/CondaITCase.java
+++ b/artipie-main/src/test/java/com/artipie/conda/CondaITCase.java
@@ -13,13 +13,11 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
 import org.hamcrest.core.StringContains;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.testcontainers.containers.BindMode;
 
 /**
  * Conda IT case.
@@ -39,20 +37,8 @@ public final class CondaITCase {
             .withRepoConfig("conda/conda.yml", "my-conda")
             .withRepoConfig("conda/conda-port.yml", "my-conda-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("continuumio/miniconda3:4.10.3")
-            .withWorkingDirectory("/w")
-            .withClasspathResourceMapping(
-                "conda/example-project", "/w/example-project", BindMode.READ_ONLY
-            )
+        () -> new TestDeployment.ClientContainer("artipie/conda-tests:1.0")
     );
-
-    @BeforeEach
-    void init() throws IOException {
-        this.containers.assertExec(
-            "Conda dependencies installation failed", new ContainerResultMatcher(),
-            "conda", "install", "-y", "conda-build", "conda-verify", "anaconda-client"
-        );
-    }
 
     @ParameterizedTest
     @CsvSource({

--- a/artipie-main/src/test/java/com/artipie/db/MetadataMavenITCase.java
+++ b/artipie-main/src/test/java/com/artipie/db/MetadataMavenITCase.java
@@ -39,7 +39,7 @@ public final class MetadataMavenITCase {
         () -> new TestDeployment.ArtipieContainer().withConfig("artipie-db.yaml")
             .withRepoConfig("maven/maven.yml", "my-maven")
             .withRepoConfig("maven/maven-proxy.yml", "my-maven-proxy"),
-        () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
+        () -> new TestDeployment.ClientContainer("artipie/maven-tests:1.0")
             .withWorkingDirectory("/w")
     );
 
@@ -75,6 +75,7 @@ public final class MetadataMavenITCase {
         this.containers.putBinaryToClient(
             new TestResource("maven/pom-with-deps/pom.xml").asBytes(), "/w/pom.xml"
         );
+        this.containers.exec("rm", "-rf", "/root/.m2");
         this.containers.assertExec(
             "Uploading dependencies failed",
             new ContainerResultMatcher(ContainerResultMatcher.SUCCESS),

--- a/artipie-main/src/test/java/com/artipie/debian/DebianGpgITCase.java
+++ b/artipie-main/src/test/java/com/artipie/debian/DebianGpgITCase.java
@@ -39,7 +39,7 @@ public final class DebianGpgITCase {
             .withClasspathResourceMapping(
                 "debian/secret-keys.gpg", "/var/artipie/repo/secret-keys.gpg", BindMode.READ_ONLY
             ),
-        () -> new TestDeployment.ClientContainer("debian:10.8")
+        () -> new TestDeployment.ClientContainer("artipie/deb-tests:1.0")
             .withWorkingDirectory("/w")
             .withClasspathResourceMapping(
                 "debian/aglfn_1.7-3_amd64.deb", "/w/aglfn_1.7-3_amd64.deb", BindMode.READ_ONLY
@@ -51,21 +51,6 @@ public final class DebianGpgITCase {
 
     @BeforeEach
     void setUp() throws IOException {
-        this.containers.assertExec(
-            "Apt-get update failed",
-            new ContainerResultMatcher(),
-            "apt-get", "update"
-        );
-        this.containers.assertExec(
-            "Failed to install curl",
-            new ContainerResultMatcher(),
-            "apt-get", "install", "-y", "curl"
-        );
-        this.containers.assertExec(
-            "Failed to install gnupg",
-            new ContainerResultMatcher(),
-            "apt-get", "install", "-y", "gnupg"
-        );
         this.containers.assertExec(
             "Failed to add public key to apt-get",
             new ContainerResultMatcher(),

--- a/artipie-main/src/test/java/com/artipie/debian/DebianITCase.java
+++ b/artipie-main/src/test/java/com/artipie/debian/DebianITCase.java
@@ -6,11 +6,9 @@ package com.artipie.debian;
 
 import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
-import java.io.IOException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.text.StringContainsInOrder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -35,26 +33,12 @@ public final class DebianITCase {
             .withRepoConfig("debian/debian.yml", "my-debian")
             .withRepoConfig("debian/debian-port.yml", "my-debian-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("debian:10.8-slim")
+        () -> new TestDeployment.ClientContainer("artipie/deb-tests:1.0")
             .withWorkingDirectory("/w")
             .withClasspathResourceMapping(
                 "debian/aglfn_1.7-3_amd64.deb", "/w/aglfn_1.7-3_amd64.deb", BindMode.READ_ONLY
             )
     );
-
-    @BeforeEach
-    void setUp() throws IOException {
-        this.containers.assertExec(
-            "Apt-get update failed",
-            new ContainerResultMatcher(),
-            "apt-get", "update"
-        );
-        this.containers.assertExec(
-            "Failed to install curl",
-            new ContainerResultMatcher(),
-            "apt-get", "install", "-y", "curl"
-        );
-    }
 
     @ParameterizedTest
     @CsvSource({

--- a/artipie-main/src/test/java/com/artipie/docker/DockerLocalAuthIT.java
+++ b/artipie-main/src/test/java/com/artipie/docker/DockerLocalAuthIT.java
@@ -76,7 +76,7 @@ final class DockerLocalAuthIT {
         client.login("bob", "qwerty")
                 .pull("alpine:3.11")
                 .tag("alpine:3.11", image)
-                .executeAssertFail("docker", "push", image);
+                .executeAssertFail("timeout", "20s", "docker", "push", image);
     }
 
     @Test

--- a/artipie-main/src/test/java/com/artipie/docker/DockerProxyCacheIT.java
+++ b/artipie-main/src/test/java/com/artipie/docker/DockerProxyCacheIT.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
  */
 public class DockerProxyCacheIT {
 
-    private static final String IMAGE = "alpine:3.19";
+    private static final String IMAGE = "alpine:3.19.1";
 
     @TempDir
     Path temp;

--- a/artipie-main/src/test/java/com/artipie/file/FileITCase.java
+++ b/artipie-main/src/test/java/com/artipie/file/FileITCase.java
@@ -33,18 +33,9 @@ final class FileITCase {
             .withRepoConfig("binary/bin.yml", "bin")
             .withRepoConfig("binary/bin-port.yml", "bin-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("alpine:3.11")
+        () -> new TestDeployment.ClientContainer("artipie/file-tests:1.0")
             .withWorkingDirectory("/w")
     );
-
-    @BeforeEach
-    void setUp() throws Exception {
-        this.deployment.assertExec(
-            "Failed to install deps",
-            new ContainerResultMatcher(),
-            "apk", "add", "--no-cache", "curl"
-        );
-    }
 
     @ParameterizedTest
     @CsvSource({

--- a/artipie-main/src/test/java/com/artipie/file/FileProxyAuthIT.java
+++ b/artipie-main/src/test/java/com/artipie/file/FileProxyAuthIT.java
@@ -49,18 +49,9 @@ final class FileProxyAuthIT {
                     .withExposedPorts(8081)
             )
         ),
-        () -> new TestDeployment.ClientContainer("alpine:3.11")
+        () -> new TestDeployment.ClientContainer("artipie/file-tests:1.0")
             .withWorkingDirectory("/w")
     );
-
-    @BeforeEach
-    void setUp() throws Exception {
-        this.containers.assertExec(
-            "Failed to install deps",
-            new ContainerResultMatcher(),
-            "apk", "add", "--no-cache", "curl"
-        );
-    }
 
     @ParameterizedTest
     @ValueSource(strings = {"8080/my-bin-proxy", "8081/my-bin-proxy-port"})

--- a/artipie-main/src/test/java/com/artipie/file/RolesITCase.java
+++ b/artipie-main/src/test/java/com/artipie/file/RolesITCase.java
@@ -30,18 +30,9 @@ public final class RolesITCase {
             .withUser("security/users/john.yaml", "john")
             .withRole("security/roles/admin.yaml", "admin")
             .withRole("security/roles/readers.yaml", "readers"),
-        () -> new TestDeployment.ClientContainer("alpine:3.11")
+        () -> new TestDeployment.ClientContainer("artipie/file-tests:1.0")
             .withWorkingDirectory("/w")
     );
-
-    @BeforeEach
-    void setUp() throws Exception {
-        this.deployment.assertExec(
-            "Failed to install deps",
-            new ContainerResultMatcher(),
-            "apk", "add", "--no-cache", "curl"
-        );
-    }
 
     @Test
     void readersAndAdminsCanDownload() throws Exception {

--- a/artipie-main/src/test/java/com/artipie/helm/HelmITCase.java
+++ b/artipie-main/src/test/java/com/artipie/helm/HelmITCase.java
@@ -42,7 +42,7 @@ final class HelmITCase {
             .withRepoConfig("helm/my-helm.yml", "my-helm")
             .withRepoConfig("helm/my-helm-port.yml", "my-helm-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("alpine/helm:2.16.9")
+        () -> new TestDeployment.ClientContainer("artipie/helm-tests:1.0")
             .withWorkingDirectory("/w")
             .withCreateContainerCmdModifier(
                 cmd -> cmd.withEntrypoint("/bin/sh")
@@ -53,11 +53,6 @@ final class HelmITCase {
                 BindMode.READ_ONLY
             )
     );
-
-    @BeforeEach
-    void setUp() throws Exception {
-        this.containers.clientExec("apk", "add", "--no-cache", "curl");
-    }
 
     @ParameterizedTest
     @ValueSource(strings = {"http://artipie:8080/my-helm", "http://artipie:8081/my-helm-port"})

--- a/artipie-main/src/test/java/com/artipie/http/HealthSliceTest.java
+++ b/artipie-main/src/test/java/com/artipie/http/HealthSliceTest.java
@@ -38,16 +38,6 @@ final class HealthSliceTest {
             ).join(),
             RsStatus.OK, "[{\"storage\":\"ok\"}]".getBytes()
         );
-        /*MatcherAssert.assertThat(
-            new HealthSlice(new TestSettings()),
-            new SliceHasResponse(
-                Matchers.allOf(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasBody("[{\"storage\":\"ok\"}]", StandardCharsets.UTF_8)
-                ),
-                HealthSliceTest.REQ_LINE
-            )
-        );*/
     }
 
     @Test
@@ -58,16 +48,6 @@ final class HealthSliceTest {
             ).join(),
             RsStatus.SERVICE_UNAVAILABLE, "[{\"storage\":\"failure\"}]".getBytes()
         );
-        /*MatcherAssert.assertThat(
-            new HealthSlice(new TestSettings(new FakeStorage())),
-            new SliceHasResponse(
-                Matchers.allOf(
-                    new RsHasStatus(RsStatus.SERVICE_UNAVAILABLE),
-                    new RsHasBody("[{\"storage\":\"failure\"}]", StandardCharsets.UTF_8)
-                ),
-                HealthSliceTest.REQ_LINE
-            )
-        );*/
     }
 
     /**

--- a/artipie-main/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/artipie-main/src/test/java/com/artipie/maven/MavenITCase.java
@@ -39,7 +39,7 @@ public final class MavenITCase {
             .withRepoConfig("maven/maven.yml", "my-maven")
             .withRepoConfig("maven/maven-port.yml", "my-maven-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
+        () -> new TestDeployment.ClientContainer("artipie/maven-tests:1.0")
             .withWorkingDirectory("/w")
             .withClasspathResourceMapping(
                 "maven/maven-settings.xml", "/w/settings.xml", BindMode.READ_ONLY
@@ -135,5 +135,4 @@ public final class MavenITCase {
             )
         );
     }
-
 }

--- a/artipie-main/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
+++ b/artipie-main/src/test/java/com/artipie/maven/MavenMultiProxyIT.java
@@ -49,7 +49,7 @@ final class MavenMultiProxyIT {
                     .withRepoConfig("maven/maven.yml", "origin-maven")
             )
         ),
-        () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
+        () -> new TestDeployment.ClientContainer("artipie/maven-tests:1.0")
             .withWorkingDirectory("/w")
     );
 

--- a/artipie-main/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
+++ b/artipie-main/src/test/java/com/artipie/maven/MavenProxyAuthIT.java
@@ -44,7 +44,7 @@ final class MavenProxyAuthIT {
                     .withRepoConfig("maven/maven-proxy-artipie.yml", "my-maven-proxy")
             )
         ),
-        () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
+        () -> new TestDeployment.ClientContainer("artipie/maven-tests:1.0")
             .withWorkingDirectory("/w")
             .withClasspathResourceMapping(
                 "maven/maven-settings-proxy.xml", "/w/settings.xml", BindMode.READ_ONLY

--- a/artipie-main/src/test/java/com/artipie/maven/MavenProxyIT.java
+++ b/artipie-main/src/test/java/com/artipie/maven/MavenProxyIT.java
@@ -33,7 +33,7 @@ final class MavenProxyIT {
             .withRepoConfig("maven/maven-proxy.yml", "my-maven")
             .withRepoConfig("maven/maven-proxy-port.yml", "my-maven-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("maven:3.6.3-jdk-11")
+        () -> new TestDeployment.ClientContainer("artipie/maven-tests:1.0")
             .withWorkingDirectory("/w")
     );
 

--- a/artipie-main/src/test/java/com/artipie/pypi/PypiITCase.java
+++ b/artipie-main/src/test/java/com/artipie/pypi/PypiITCase.java
@@ -10,13 +10,11 @@ import java.io.IOException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.Matchers;
 import org.hamcrest.text.StringContainsInOrder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.testcontainers.containers.BindMode;
 
 /**
  * Integration tests for Pypi repository.
@@ -39,33 +37,9 @@ final class PypiITCase {
             .withRole("security/roles/readers.yaml", "readers")
             .withExposedPorts(8081),
 
-        () -> new TestDeployment.ClientContainer("python:3.7")
+        () -> new TestDeployment.ClientContainer("artipie/pypi-tests:1.0")
             .withWorkingDirectory("/var/artipie")
-            .withClasspathResourceMapping(
-                "pypi-repo/example-pckg",
-                "/var/artipie/data/artipie/pypi/example-pckg",
-                BindMode.READ_ONLY
-            )
     );
-
-    @BeforeEach
-    void setUp() throws IOException {
-        this.containers.assertExec(
-            "Apt-get update failed",
-            new ContainerResultMatcher(),
-            "apt-get", "update"
-        );
-        this.containers.assertExec(
-            "Failed to install twine",
-            new ContainerResultMatcher(),
-            "python", "-m", "pip", "install", "twine"
-        );
-        this.containers.assertExec(
-            "Failed to upgrade pip",
-            new ContainerResultMatcher(),
-            "python", "-m", "pip", "install", "--upgrade", "pip"
-        );
-    }
 
     @ParameterizedTest
     @CsvSource("8080,my-python")
@@ -123,7 +97,7 @@ final class PypiITCase {
             "python3", "-m", "twine", "upload", "--repository-url",
             String.format("http://artipie:%s/%s/", port, repo),
             "-u", "alice", "-p", "123",
-            "/var/artipie/data/artipie/pypi/example-pckg/dist/artipietestpkg-0.0.3.tar.gz"
+            "/w/example-pckg/dist/artipietestpkg-0.0.3.tar.gz"
         );
         this.containers.assertArtipieContent(
             "Bad content after upload",

--- a/artipie-main/src/test/java/com/artipie/pypi/PypiProxyITCase.java
+++ b/artipie-main/src/test/java/com/artipie/pypi/PypiProxyITCase.java
@@ -44,7 +44,7 @@ public final class PypiProxyITCase {
                     .withRepoConfig("pypi-proxy/pypi-proxy.yml", "my-pypi-proxy")
             )
         ),
-        () -> new TestDeployment.ClientContainer("python:3")
+        () -> new TestDeployment.ClientContainer("artipie/pypi-tests:1.0")
             .withWorkingDirectory("/w")
     );
 

--- a/artipie-main/src/test/java/com/artipie/pypi/PypiS3ITCase.java
+++ b/artipie-main/src/test/java/com/artipie/pypi/PypiS3ITCase.java
@@ -16,9 +16,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.images.builder.ImageFromDockerfile;
 import java.io.IOException;
 
 /**
@@ -46,38 +44,10 @@ final class PypiS3ITCase {
             .withUser("security/users/alice.yaml", "alice")
             .withRole("security/roles/readers.yaml", "readers")
             .withExposedPorts(8080),
-        () -> new TestDeployment.ClientContainer(
-            new ImageFromDockerfile(
-                "local/artipie-main/pypi_s3_itcase", false
-            ).withDockerfileFromBuilder(
-                builder -> builder
-                    .from("python:3.7")
-                    .run("apt update -y -o APT::Update::Error-Mode=any")
-                    .run("apt dist-upgrade -y && apt install -y curl xz-utils netcat-traditional")
-                    .run("apt autoremove -y && apt clean -y && rm -rfv /var/lib/apt/lists")
-                    .run("pip install -U pip setuptools")
-                    .run("pip install -U twine")
-                    .copy("minio-bin-20231120.txz", "/w/minio-bin-20231120.txz")
-                    .run("tar xf /w/minio-bin-20231120.txz -C /root")
-                    .run(
-                        String.join(
-                            ";",
-                            "sh -c '/root/bin/minio server /var/minio > /tmp/minio.log 2>&1 &'",
-                            "timeout 30 sh -c 'until nc -z localhost 9000; do sleep 0.1; done'",
-                            "/root/bin/mc alias set srv1 http://localhost:9000 minioadmin minioadmin 2>&1 |tee /tmp/mc.log",
-                            "/root/bin/mc mb srv1/buck1 --region s3test 2>&1|tee -a /tmp/mc.log",
-                            "/root/bin/mc anonymous set public srv1/buck1 2>&1|tee -a /tmp/mc.log"
-                        )
-                    )
-                    .run("rm -fv /w/minio-bin-20231120.txz /tmp/*.log")
-            ).withFileFromClasspath("minio-bin-20231120.txz", "minio-bin-20231120.txz")
-        )
+        () -> new TestDeployment.ClientContainer("artipie/pypi-tests:1.0")
             .withWorkingDirectory("/w")
             .withNetworkAliases("minioc")
             .withExposedPorts(9000)
-            .withClasspathResourceMapping(
-                "pypi-repo/example-pckg", "/w/example-pckg", BindMode.READ_ONLY
-            )
             .waitingFor(
                 new AbstractWaitStrategy() {
                     @Override

--- a/artipie-main/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/artipie-main/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -6,11 +6,9 @@ package com.artipie.rpm;
 
 import com.artipie.test.ContainerResultMatcher;
 import com.artipie.test.TestDeployment;
-import java.io.IOException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.text.StringContainsInOrder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -35,19 +33,12 @@ public final class RpmITCase {
             .withRepoConfig("rpm/my-rpm.yml", "my-rpm")
             .withRepoConfig("rpm/my-rpm-port.yml", "my-rpm-port")
             .withExposedPorts(8081),
-        () -> new TestDeployment.ClientContainer("fedora:35")
+        () -> new TestDeployment.ClientContainer("artipie/rpm-tests-fedora:1.0")
             .withClasspathResourceMapping(
                 "rpm/time-1.7-45.el7.x86_64.rpm", "/w/time-1.7-45.el7.x86_64.rpm",
                 BindMode.READ_ONLY
             )
     );
-
-    @BeforeEach
-    void setUp() throws IOException {
-        this.containers.assertExec(
-            "Dnf install curl failed", new ContainerResultMatcher(), "dnf", "-y", "install", "curl"
-        );
-    }
 
     @ParameterizedTest
     @CsvSource({
@@ -82,5 +73,4 @@ public final class RpmITCase {
             "dnf", "-y", "repository-packages", "example", "install"
         );
     }
-
 }

--- a/artipie-main/src/test/java/com/artipie/rpm/RpmS3ITCase.java
+++ b/artipie-main/src/test/java/com/artipie/rpm/RpmS3ITCase.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+
 import java.io.IOException;
 
 /**
@@ -41,28 +41,7 @@ public final class RpmS3ITCase {
         () -> TestDeployment.ArtipieContainer.defaultDefinition()
             .withRepoConfig("rpm/my-rpm-s3.yml", "my-rpm")
             .withExposedPorts(8080),
-        () -> new TestDeployment.ClientContainer(
-            new ImageFromDockerfile(
-                "local/artipie-main/rpm_s3_itcase", false
-            ).withDockerfileFromBuilder(
-                builder -> builder
-                    .from("fedora:35")
-                    .run("dnf -y install curl xz netcat")
-                    .copy("minio-bin-20231120.txz", "/w/minio-bin-20231120.txz")
-                    .run("tar xf /w/minio-bin-20231120.txz -C /root")
-                    .run(
-                        String.join(
-                            ";",
-                            "sh -c '/root/bin/minio server /var/minio > /tmp/minio.log 2>&1 &'",
-                            "timeout 30 sh -c 'until nc -z localhost 9000; do sleep 0.1; done'",
-                            "/root/bin/mc alias set srv1 http://localhost:9000 minioadmin minioadmin 2>&1 |tee /tmp/mc.log",
-                            "/root/bin/mc mb srv1/buck1 --region s3test 2>&1|tee -a /tmp/mc.log",
-                            "/root/bin/mc anonymous set public srv1/buck1 2>&1|tee -a /tmp/mc.log"
-                        )
-                    )
-                    .run("rm -fv /w/minio-bin-20231120.txz /tmp/*.log")
-            ).withFileFromClasspath("minio-bin-20231120.txz", "minio-bin-20231120.txz")
-        )
+        () -> new TestDeployment.ClientContainer("artipie/rpm-tests-fedora:1.0")
         .withWorkingDirectory("/w")
         .withNetworkAliases("minioc")
         .withExposedPorts(9000)

--- a/artipie-main/src/test/java/com/artipie/test/TestDeployment.java
+++ b/artipie-main/src/test/java/com/artipie/test/TestDeployment.java
@@ -376,7 +376,7 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
          * New default artipie container.
          */
         public ArtipieContainer() {
-            this(DockerImageName.parse("artipie/artipie:1.0-SNAPSHOT"));
+            this(DockerImageName.parse("artipie/artipie-tests:1.0-SNAPSHOT"));
         }
 
         /**

--- a/artipie-main/src/test/java/com/artipie/test/TestDeployment.java
+++ b/artipie-main/src/test/java/com/artipie/test/TestDeployment.java
@@ -139,9 +139,9 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
             .withCommand("tail", "-f", "/dev/null");
         this.artipie.values().forEach(GenericContainer::start);
         this.client.start();
-        this.client.execInContainer("sleep", "3");
+        this.client.execInContainer("sleep", "1");
         this.artipie.values().forEach(
-            new UncheckedConsumer<>(cnt -> cnt.execInContainer("sleep", "3"))
+            new UncheckedConsumer<>(cnt -> cnt.execInContainer("sleep", "1"))
         );
     }
 
@@ -381,11 +381,13 @@ public final class TestDeployment implements BeforeEachCallback, AfterEachCallba
 
         /**
          * New artipie container with image name.
+         * TieredStopAtLevel=1 reduces startup time, which is important for tests.
          *
          * @param name Image name
          */
         public ArtipieContainer(final DockerImageName name) {
             super(name);
+            this.withEnv("JVM_ARGS", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1");
         }
 
         /**

--- a/artipie-main/src/test/java/com/artipie/test/TestDockerClient.java
+++ b/artipie-main/src/test/java/com/artipie/test/TestDockerClient.java
@@ -7,6 +7,7 @@ package com.artipie.test;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AnyOf;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ public class TestDockerClient {
     /**
      * Built from {@link src/test/resources/docker/Dockerfile}.
      */
-    protected static final DockerImageName DOCKER_CLIENT = DockerImageName.parse("artipie/test-docker-client:1.0");
+    protected static final DockerImageName DOCKER_CLIENT = DockerImageName.parse("artipie/docker-tests:1.0");
 
     private final int port;
     private final GenericContainer<?> client;
@@ -89,8 +90,11 @@ public class TestDockerClient {
 
     public TestDockerClient pull(String image) throws IOException {
         return executeAssert(
+            new AnyOf<>(
                 new StringContains("Status: Downloaded newer image for " + image),
-                "docker", "pull", image
+                new StringContains("Status: Image is up to date for " + image)
+            ),
+            "docker", "pull", image
         );
     }
 
@@ -116,8 +120,13 @@ public class TestDockerClient {
         return executeAssert("docker", "tag", source, target);
     }
 
-    public int getMappedPort(int port) {
-        return this.client.getMappedPort(port);
+    /**
+     * Get the actual mapped client port for a given port exposed by the container.
+     * @param originalPort Originally exposed port number
+     * @return The port that the exposed port is mapped to
+     */
+    public int getMappedPort(int originalPort) {
+        return this.client.getMappedPort(originalPort);
     }
 
     public TestDockerClient executeAssert(String... cmd) throws IOException {

--- a/artipie-main/src/test/resources/log4j.properties
+++ b/artipie-main/src/test/resources/log4j.properties
@@ -8,3 +8,5 @@ log4j.logger.com.artipie=DEBUG
 log4j.logger.security=DEBUG
 
 log4j2.formatMsgNoLookups=True
+# For debugging
+org.slf4j.simpleLogger.log.com.github.dockerjava.api.command.BuildImageResultCallback=debug

--- a/conan-adapter/pom.xml
+++ b/conan-adapter/pom.xml
@@ -80,6 +80,26 @@ SOFTWARE.
       <version>0.46</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>asto-s3</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- s3 mocks deps -->
+    <dependency>
+      <groupId>com.adobe.testing</groupId>
+      <artifactId>s3mock</artifactId>
+      <version>${s3mock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.adobe.testing</groupId>
+      <artifactId>s3mock-junit5</artifactId>
+      <version>${s3mock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/conda-adapter/pom.xml
+++ b/conda-adapter/pom.xml
@@ -65,7 +65,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.2</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -75,7 +75,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.2</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -88,6 +88,19 @@ SOFTWARE.
       <version>1.5.0-2</version>
     </dependency>
     <!-- Test scope -->
+    <!-- s3 mocks deps -->
+    <dependency>
+      <groupId>com.adobe.testing</groupId>
+      <artifactId>s3mock</artifactId>
+      <version>${s3mock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.adobe.testing</groupId>
+      <artifactId>s3mock-junit5</artifactId>
+      <version>${s3mock.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>

--- a/conda-adapter/src/test/java/com/artipie/conda/CondaSliceAuthITCase.java
+++ b/conda-adapter/src/test/java/com/artipie/conda/CondaSliceAuthITCase.java
@@ -19,7 +19,6 @@ import com.artipie.security.policy.PolicyByUsername;
 import com.artipie.vertx.VertxSliceServer;
 import com.jcabi.log.Logger;
 import io.vertx.reactivex.core.Vertx;
-import org.apache.commons.io.FileUtils;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.text.StringContainsInOrder;
@@ -137,18 +136,11 @@ public final class CondaSliceAuthITCase {
             this.tmp.resolve(CondaSliceAuthITCase.ANONIM),
             String.format("channels:\n  - %s", url).getBytes()
         );
-        FileUtils.copyFile(
-            new TestResource("CondaSliceITCase/snappy-1.1.3-0.tar.bz2").asPath().toFile(),
-            this.tmp.resolve("snappy-1.1.3-0.tar.bz2").toFile()
-        );
-        this.cntn = new GenericContainer<>("continuumio/miniconda3:22.11.1")
+        this.cntn = new GenericContainer<>("artipie/conda-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");
         this.cntn.start();
-        this.exec("conda", "install", "-y", "conda-build");
-        this.exec("conda", "install", "-y", "conda-verify");
-        this.exec("conda", "install", "-y", "anaconda-client");
     }
 
     @Test
@@ -172,7 +164,7 @@ public final class CondaSliceAuthITCase {
         MatcherAssert.assertThat(
             "Anaconda upload was not successful",
             this.exec(
-                "anaconda", "upload", "./snappy-1.1.3-0.tar.bz2"
+                "anaconda", "upload", "/w/snappy-1.1.3-0.tar.bz2"
             ),
             new StringContainsInOrder(
                 new ListOf<>(

--- a/conda-adapter/src/test/java/com/artipie/conda/CondaSliceITCase.java
+++ b/conda-adapter/src/test/java/com/artipie/conda/CondaSliceITCase.java
@@ -108,18 +108,11 @@ public final class CondaSliceITCase {
         Files.write(
             this.tmp.resolve(".condarc"), String.format("channels:\n  - %s", url).getBytes()
         );
-        FileUtils.copyDirectory(
-            new TestResource("example-project").asPath().toFile(),
-            this.tmp.toFile()
-        );
-        this.cntn = new GenericContainer<>("continuumio/miniconda3:4.10.3-alpine")
+        this.cntn = new GenericContainer<>("artipie/conda-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
-            .withWorkingDirectory("/home/")
+            .withWorkingDirectory("/w/adapter/example-project")
             .withFileSystemBind(this.tmp.toString(), "/home");
         this.cntn.start();
-        this.exec("conda", "install", "-y", "conda-build");
-        this.exec("conda", "install", "-y", "conda-verify");
-        this.exec("conda", "install", "-y", "anaconda-client");
     }
 
     @Test

--- a/debian-adapter/src/test/java/com/artipie/debian/DebianAuthSliceITCase.java
+++ b/debian-adapter/src/test/java/com/artipie/debian/DebianAuthSliceITCase.java
@@ -210,7 +210,7 @@ public final class DebianAuthSliceITCase {
                 DebianAuthSliceITCase.AUTH, this.port
             ).getBytes()
         );
-        this.cntn = new GenericContainer<>("debian:11")
+        this.cntn = new GenericContainer<>("artipie/deb-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");

--- a/debian-adapter/src/test/java/com/artipie/debian/DebianGpgSliceITCase.java
+++ b/debian-adapter/src/test/java/com/artipie/debian/DebianGpgSliceITCase.java
@@ -116,13 +116,11 @@ public final class DebianGpgSliceITCase {
                 "deb http://host.testcontainers.internal:%d/ artipie main", this.port
             ).getBytes()
         );
-        this.cntn = new GenericContainer<>("debian:11")
+        this.cntn = new GenericContainer<>("artipie/deb-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");
         this.cntn.start();
-        this.exec("apt-get", "update");
-        this.exec("apt-get", "install", "-y", "gnupg");
         this.exec("apt-key", "add", "/home/public-key.asc");
         this.exec("mv", "/home/sources.list", "/etc/apt/");
     }

--- a/debian-adapter/src/test/java/com/artipie/debian/DebianSliceITCase.java
+++ b/debian-adapter/src/test/java/com/artipie/debian/DebianSliceITCase.java
@@ -120,7 +120,7 @@ public final class DebianSliceITCase {
                 "deb [trusted=yes] http://host.testcontainers.internal:%d/ artipie main", this.port
             ).getBytes()
         );
-        this.cntn = new GenericContainer<>("debian:11")
+        this.cntn = new GenericContainer<>("artipie/deb-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");

--- a/debian-adapter/src/test/java/com/artipie/debian/DebianSliceS3ITCase.java
+++ b/debian-adapter/src/test/java/com/artipie/debian/DebianSliceS3ITCase.java
@@ -153,7 +153,7 @@ public final class DebianSliceS3ITCase {
                 "deb [trusted=yes] http://host.testcontainers.internal:%d/ artipie main", this.port
             ).getBytes()
         );
-        this.cntn = new GenericContainer<>("debian:11")
+        this.cntn = new GenericContainer<>("artipie/deb-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");

--- a/helm-adapter/src/test/java/com/artipie/helm/http/DownloadIndexSliceTest.java
+++ b/helm-adapter/src/test/java/com/artipie/helm/http/DownloadIndexSliceTest.java
@@ -50,8 +50,6 @@ final class DownloadIndexSliceTest {
     @ParameterizedTest
     @ValueSource(strings = {"http://central.artipie.com/", "http://central.artipie.com"})
     void returnsOkAndUpdateEntriesUrlsForBaseWithOrWithoutTrailingSlash(final String base) {
-//        final AtomicReference<String> cbody = new AtomicReference<>();
-//        final AtomicReference<RsStatus> cstatus = new AtomicReference<>();
         new TestResource("index.yaml").saveTo(this.storage);
 
         Response resp = new DownloadIndexSlice(base, this.storage)

--- a/maven-adapter/src/test/java/com/artipie/maven/MavenITCase.java
+++ b/maven-adapter/src/test/java/com/artipie/maven/MavenITCase.java
@@ -236,7 +236,7 @@ public final class MavenITCase {
         );
         this.port = this.server.start();
         Testcontainers.exposeHostPorts(this.port);
-        this.cntn = new GenericContainer<>("maven:3.6.3-jdk-11")
+        this.cntn = new GenericContainer<>("artipie/maven-tests:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");

--- a/nuget-adapter/pom.xml
+++ b/nuget-adapter/pom.xml
@@ -70,7 +70,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.2</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,14 @@ SOFTWARE.
     <maven.compiler.release>21</maven.compiler.release>
     <header.license>LICENSE.header</header.license>
     <junit-platform.version>5.10.0</junit-platform.version>
-    <vertx.version>4.5.4</vertx.version>
+    <vertx.version>4.5.6</vertx.version>
     <guava.version>33.0.0-jre</guava.version>
     <javax.json.version>1.1.4</javax.json.version>
     <jetty.version>12.0.6</jetty.version>
-    <s3mock.version>3.4.0</s3mock.version>
+    <s3mock.version>3.5.2</s3mock.version>
     <bouncycastle-lts.version>2.73.5</bouncycastle-lts.version>
     <httpclient.version>5.3.1</httpclient.version>
+    <fasterxml.jackson.version>2.16.2</fasterxml.jackson.version>
   </properties>
   <developers>
     <!-- Required for publishing to central -->
@@ -269,7 +270,7 @@ SOFTWARE.
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <release>21</release>
+          <release>${maven.compiler.release}</release>
         </configuration>
         <executions>
           <execution>
@@ -279,7 +280,7 @@ SOFTWARE.
               <goal>testCompile</goal>
             </goals>
             <configuration>
-              <release>21</release>
+              <release>${maven.compiler.release}</release>
             </configuration>
           </execution>
         </executions>

--- a/pypi-adapter/src/test/java/com/artipie/pypi/PypiDeployment.java
+++ b/pypi-adapter/src/test/java/com/artipie/pypi/PypiDeployment.java
@@ -85,7 +85,6 @@ public final class PypiDeployment implements BeforeEachCallback, AfterEachCallba
             .withCommand("tail", "-f", "/dev/null")
             .setWorkingDirectory("/home/");
         this.container.start();
-        this.bash("python3 -m pip install --user --upgrade twine");
     }
 
     @Override
@@ -111,7 +110,7 @@ public final class PypiDeployment implements BeforeEachCallback, AfterEachCallba
          * New client container with name.
          */
         public PypiContainer() {
-            super(DockerImageName.parse("python:3.7"));
+            super(DockerImageName.parse("artipie/pypi-tests:1.0"));
         }
     }
 }

--- a/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceDownloadITCase.java
+++ b/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceDownloadITCase.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -143,6 +144,7 @@ final class RpmSliceDownloadITCase {
             )
         );
         this.cntn.execInContainer("mv", "/home/example.repo", "/etc/yum.repos.d/");
+        final Container.ExecResult res = this.cntn.execInContainer("dnf", "-y", "update");
         MatcherAssert.assertThat(
             this.cntn.execInContainer(
                 "dnf", "-y", "repository-packages", "example", "install"
@@ -180,7 +182,7 @@ final class RpmSliceDownloadITCase {
         );
         this.port = this.server.start();
         Testcontainers.exposeHostPorts(this.port);
-        this.cntn = new GenericContainer<>("fedora:36")
+        this.cntn = new GenericContainer<>("artipie/rpm-tests-fedora:1.0")
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/home/")
             .withFileSystemBind(this.tmp.toString(), "/home");

--- a/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceITCase.java
+++ b/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceITCase.java
@@ -81,8 +81,8 @@ public final class RpmSliceITCase {
 
     @ParameterizedTest
     @CsvSource({
-        "redhat/ubi9:9.0.0,yum,repo-pkgs",
-        "fedora:36,dnf,repository-packages"
+        "artipie/rpm-tests-ubi:1.0,yum,repo-pkgs",
+        "artipie/rpm-tests-fedora:1.0,dnf,repository-packages"
     })
     void canListAndInstallFromArtipieRepo(final String linux,
         final String mngr, final String rey) throws Exception {
@@ -101,8 +101,8 @@ public final class RpmSliceITCase {
 
     @ParameterizedTest
     @CsvSource({
-        "redhat/ubi9:9.0.0,yum,repo-pkgs",
-        "fedora:36,dnf,repository-packages"
+        "artipie/rpm-tests-ubi:1.0,yum,repo-pkgs",
+        "artipie/rpm-tests-fedora:1.0,dnf,repository-packages"
     })
     void canListAndInstallFromArtipieRepoWithAuth(final String linux,
         final String mngr, final String key) throws Exception {

--- a/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceS3ITCase.java
+++ b/rpm-adapter/src/test/java/com/artipie/rpm/http/RpmSliceS3ITCase.java
@@ -128,8 +128,8 @@ public final class RpmSliceS3ITCase {
 
     @ParameterizedTest
     @CsvSource({
-        "redhat/ubi9:9.0.0,yum,repo-pkgs",
-        "fedora:36,dnf,repository-packages"
+        "artipie/rpm-tests-ubi:1.0,yum,repo-pkgs",
+        "artipie/rpm-tests-fedora:1.0,dnf,repository-packages"
     })
     void canListAndInstallFromArtipieRepo(final String linux,
         final String mngr, final String rey) throws Exception {
@@ -148,8 +148,8 @@ public final class RpmSliceS3ITCase {
 
     @ParameterizedTest
     @CsvSource({
-        "redhat/ubi9:9.0.0,yum,repo-pkgs",
-        "fedora:36,dnf,repository-packages"
+        "artipie/rpm-tests-ubi:1.0,yum,repo-pkgs",
+        "artipie/rpm-tests-fedora:1.0,dnf,repository-packages"
     })
     void canListAndInstallFromArtipieRepoWithAuth(final String linux,
         final String mngr, final String key) throws Exception {

--- a/test_images/Dockerfile.conan
+++ b/test_images/Dockerfile.conan
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+ENV REV=1
+ENV CONAN_TRACE_FILE /tmp/conan_trace.log
+ENV DEBIAN_FRONTEND noninteractive
+ENV CONAN_VERBOSE_TRACEBACK 1
+ENV CONAN_NON_INTERACTIVE 1
+ENV CONAN_LOGIN_USERNAME demo_login
+ENV CONAN_PASSWORD demo_pass
+ENV no_proxy host.docker.internal,host.testcontainers.internal,localhost,127.0.0.1
+RUN apt update -y -o APT::Update::Error-Mode=any && apt dist-upgrade -y
+RUN apt install --no-install-recommends -y python3-pip curl g++ git make cmake curl xz-utils netcat
+RUN pip3 install -U pip setuptools
+RUN pip3 install -U conan==1.60.2
+RUN conan profile new --detect default
+RUN conan profile update settings.compiler.libcxx=libstdc++11 default
+RUN conan remote add conancenter https://center.conan.io False --force
+RUN conan remote add conan-center https://conan.bintray.com False --force
+RUN conan remote add conan-test http://host.testcontainers.internal:9300 False --force
+RUN conan install zlib/1.2.13@ -r conancenter
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+WORKDIR "/w"
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN apt -y autoremove -y --purge && apt clean -y && rm -rf /var/cache/apt/archives /var/lib/apt/lists
+RUN du -hs /w/*

--- a/test_images/Dockerfile.conda
+++ b/test_images/Dockerfile.conda
@@ -1,0 +1,24 @@
+FROM continuumio/miniconda3:22.11.1
+ENV REV=1
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update -y -o APT::Update::Error-Mode=any && apt dist-upgrade -y
+RUN apt install -y curl xz-utils netcat
+COPY conda/example-project /w/example-project
+COPY adapter /w/adapter
+COPY conda/condarc /w/condarc
+COPY conda/snappy-1.1.3-0.tar.bz2 /w/snappy-1.1.3-0.tar.bz2
+COPY conda/noarch_glom-22.1.0.tar.bz2 /w/noarch_glom-22.1.0.tar.bz2
+COPY conda/linux-64_nng-1.4.0.tar.bz2 /w/linux-64_nng-1.4.0.tar.bz2
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+RUN conda install -vv -y conda-build==3.27.0 conda-verify==3.4.2 anaconda-client==1.10.0 2>&1|tee /tmp/conda.log
+RUN conda clean -ay
+WORKDIR "/w"
+
+RUN mv -fv /w/condarc /root/.condarc
+RUN anaconda config --set url http://artipie:8080/my-conda/ -s
+RUN conda config --set anaconda_upload yes
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN apt -y autoremove -y --purge && apt clean -y && rm -rf /var/cache/apt/archives /var/lib/apt/lists
+RUN du -hs /w/example-project

--- a/test_images/Dockerfile.debian
+++ b/test_images/Dockerfile.debian
@@ -1,0 +1,16 @@
+FROM debian:11
+ENV REV=0
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update -y -o APT::Update::Error-Mode=any && apt dist-upgrade -y
+RUN apt install -y curl xz-utils netcat gnupg
+
+COPY adapter /w/adapter
+
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+WORKDIR "/w"
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN apt -y autoremove -y --purge && apt clean -y
+RUN du -hs /w/

--- a/test_images/Dockerfile.docker
+++ b/test_images/Dockerfile.docker
@@ -1,0 +1,14 @@
+FROM alpine:3.19
+# See ../artipie-main/src/test/resources/docker/Dockerfile
+
+RUN apk add --update --no-cache openrc docker xz curl
+RUN rc-status
+RUN touch /run/openrc/softlevel
+# Insecure registry ports 52001, 52002, 52003
+RUN sed -i \
+    s/DOCKER_OPTS=/"DOCKER_OPTS=\"--insecure-registry=host.testcontainers.internal:52001 --insecure-registry=host.testcontainers.internal:52002 --insecure-registry=host.testcontainers.internal:52003 \""/g  \
+    /etc/conf.d/docker
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+RUN rm -rf /w/minio-bin-20231120.txz

--- a/test_images/Dockerfile.file
+++ b/test_images/Dockerfile.file
@@ -1,0 +1,3 @@
+FROM alpine:3.19
+RUN apk add --no-cache curl
+WORKDIR /w

--- a/test_images/Dockerfile.helm
+++ b/test_images/Dockerfile.helm
@@ -1,0 +1,3 @@
+FROM alpine/helm:2.16.9
+RUN apk add --no-cache curl
+WORKDIR /w

--- a/test_images/Dockerfile.maven
+++ b/test_images/Dockerfile.maven
@@ -1,0 +1,40 @@
+FROM maven:3.6.3-jdk-11
+ENV REV=19
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update -y -o APT::Update::Error-Mode=any && apt dist-upgrade -y
+RUN apt install -y libxml2-utils # for xmllint
+
+# install artpie test dependencies to maven cache
+COPY artipie /opt/artipie
+RUN find /opt/artipie -name "*.jar" -type f|xargs -n1 sh -c \
+   'mvn install:install-file -Dfile="$0" -DpomFile="${0%.jar}.pom"'
+RUN ls -lah $HOME/.m2/repository/com/artipie
+
+# prefetch all dependencies
+COPY projects /opt/projects
+COPY fetchPomDeps.sh /opt/
+RUN ls -lah /opt/projects/
+RUN find /opt/projects -name pom.xml -type f|xargs -n1 /opt/fetchPomDeps.sh
+RUN find /opt/projects -name pom.xml -type f|xargs -n1 ls -lah
+RUN ls -lah /opt $HOME/.m2/repository/
+
+# generate AppCDS cache for maven
+RUN sh -c ' \
+    echo "<settings></settings>" > /opt/settings.xml ;\
+    find /opt/projects -name pom.xml -type f|head -n1|xargs -i -n1 cp -fv {} /opt/pom.xml ;\
+    MAVEN_OPTS="-Xshare:off -XX:DumpLoadedClassList=/opt/mvn.classlist -XX:+TieredCompilation -XX:TieredStopAtLevel=1" timeout 5s mvn -B -q -s /opt/settings.xml -f /opt/pom.xml dependency:go-offline || : ;\
+    MAVEN_OPTS="-Xshare:dump -XX:SharedArchiveFile=/opt/mvn-s.jsa -XX:SharedClassListFile=/opt/mvn.classlist -XX:+TieredCompilation -XX:TieredStopAtLevel=1" timeout 5s mvn -B -q -s /opt/settings.xml -f /opt/pom.xml dependency:go-offline || : ;\
+    '
+
+RUN ls -lah /opt/mvn-s.jsa
+RUN rm -fv /opt/mvn.classlist /opt/*.xml
+ENV MAVEN_OPTS="-XX:SharedArchiveFile=/opt/mvn-s.jsa -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+WORKDIR "/w"
+
+# ensure that artipie test deps were in cache but remove before finishing
+RUN ls -lah $HOME/.m2/repository/com/artipie
+RUN rm -rf  $HOME/.m2/repository/com/artipie
+
+RUN rm -rf /opt/artipie /opt/projects /opt/target /opt/fetchPomDeps.sh
+RUN apt purge -y libxml2-utils && apt -y autoremove -y --purge && apt clean -y && rm -rf /var/cache/apt/archives /var/lib/apt/lists
+RUN du -hs /root/.m2

--- a/test_images/Dockerfile.pypi
+++ b/test_images/Dockerfile.pypi
@@ -1,0 +1,18 @@
+FROM python:3.7
+ENV REV=0
+ENV DEBIAN_FRONTEND noninteractive
+ENV no_proxy host.docker.internal,host.testcontainers.internal,localhost,127.0.0.1
+RUN apt update -y -o APT::Update::Error-Mode=any && apt dist-upgrade -y
+RUN apt install --no-install-recommends -y curl xz-utils netcat-traditional
+RUN pip3 install -U pip setuptools
+RUN pip3 install -U twine
+COPY pypi-repo/ /w/
+
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+WORKDIR "/w"
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN apt -y autoremove -y --purge && apt clean -y && rm -rf /var/cache/apt/archives /var/lib/apt/lists
+RUN du -hs /w/*

--- a/test_images/Dockerfile.rpm_fedora
+++ b/test_images/Dockerfile.rpm_fedora
@@ -1,0 +1,13 @@
+FROM fedora:36
+ENV REV=1
+RUN dnf -y upgrade
+RUN dnf -y install curl xz netcat
+
+COPY adapter /w/adapter
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+WORKDIR "/w"
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN du -hs /w/

--- a/test_images/Dockerfile.rpm_ubi
+++ b/test_images/Dockerfile.rpm_ubi
@@ -1,0 +1,13 @@
+FROM redhat/ubi9:9.0.0
+ENV REV=2
+RUN yum -y upgrade
+RUN yum --allowerasing -y install curl xz nc
+
+COPY adapter /w/adapter
+COPY prepMinio.sh minio-bin-20231120.txz /w/
+RUN /w/prepMinio.sh
+
+WORKDIR "/w"
+
+RUN rm -rf /w/minio-bin-20231120.txz
+RUN du -hs /w/

--- a/test_images/README.md
+++ b/test_images/README.md
@@ -1,0 +1,26 @@
+## Artipie test images
+
+Here's base images dockerfiles, mostly one image for every adapter type in the project.
+Small changes in similar images often produce very different resulting docker image. 
+Using single test image per adapter type greatly reduces total amount of network and disk usage by docker images.
+It reduces time to fetch and start docker test images during CI runs too.
+Also, test images prefetch and preinstall third-party packages required for test runs.
+It reduces CI times even further, also reducing potential internet-related fails.
+For maven client, AppCDS JVM cache is generated inside dockerfiles + tier 1 JVM JIT mode is enforced to reduce startup time of every related test.
+
+Usage:
+```
+./build.sh
+# test code locally...
+./upload.sh
+```
+
+## Updating images
+
+1. Update dockerfile locally for the target adapter.
+2. Update corresponding image version in `build.sh`.
+3. Build image locally via `./build.sh`
+4. Test your artipie code locally
+5. Update image version in `upload.sh`
+6. Push to the artipie DockerHub via `upload.sh`.
+7. Push your working branch for PR

--- a/test_images/build.sh
+++ b/test_images/build.sh
@@ -1,0 +1,106 @@
+#!/bin/bash -e
+baseDir="$(dirname $0)"
+cd "$baseDir"
+
+rm -rf ./_context
+
+mkdir -p ./_context/projects
+cp -rfv ../artipie-main/src/test/resources/helloworld-src  ../artipie-main/src/test/resources/snapshot-src _context/projects
+cp -rfv ../maven-adapter/src/test/resources-binary/helloworld-src _context/projects/helloworld-adapter
+sed -i 's/host.testcontainers.internal:%d/localhost:8080/' _context/projects/helloworld-adapter/pom.xml.template
+mv -v _context/projects/helloworld-adapter/pom.xml.template _context/projects/helloworld-adapter/pom.xml
+cp -rfv ../artipie-main/src/test/resources/com/artipie ../artipie-main/src/test/resources/maven _context
+cp -fv ./fetchPomDeps.sh _context/
+echo '<settings></settings>' > _context/settings.xml
+MAVER_VER="1.0"
+docker build --progress=plain --build-arg MAVER_VER="$MAVER_VER" -t "artipie/maven-tests:$MAVER_VER" _context -f ./Dockerfile.maven
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/conda ./_context/ # example-project; *.bz2; etc.
+cp -rfv ../conda-adapter/src/test/resources-binary/example-project ./_context/adapter/
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+CONDA_VER="1.0"
+docker build --progress=plain --build-arg CONDA_VER="$CONDA_VER" -t "artipie/conda-tests:$CONDA_VER" _context -f ./Dockerfile.conda
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/rpm ./_context/
+cp -rfv ../rpm-adapter/src/test/resources-binary/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+RPM_FVER="1.0"
+docker build --progress=plain --build-arg RPM_FVER="$RPM_FVER" -t "artipie/rpm-tests-fedora:$RPM_FVER" _context -f ./Dockerfile.rpm_fedora
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/rpm ./_context/
+cp -rfv ../rpm-adapter/src/test/resources-binary/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+RPM_UVER="1.0"
+docker build --progress=plain --build-arg RPM_UVER="$RPM_UVER" -t "artipie/rpm-tests-ubi:$RPM_UVER" _context -f ./Dockerfile.rpm_fedora
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/debian ./_context/
+cp -rfv ../debian-adapter/src/test/resources/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+DEB_VER="1.0"
+docker build --progress=plain --build-arg DEB_VER="$DEB_VER" -t "artipie/deb-tests:$DEB_VER" _context -f ./Dockerfile.debian
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/conan ./_context/
+cp -rfv ../conan-adapter/src/test/resources/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+CONAN_VER="1.0"
+docker build --progress=plain --build-arg CONAN_VER="$CONAN_VER" -t "artipie/conan-tests:$CONAN_VER" _context -f ./Dockerfile.conan
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/pypi-repo ./_context/
+cp -rfv ../pypi-adapter/src/test/resources/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+PYPI_VER="1.0"
+docker build --progress=plain --build-arg PYPI_VER="$PYPI_VER" -t "artipie/pypi-tests:$PYPI_VER" _context -f ./Dockerfile.pypi
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/docker ./_context/
+cp -rfv ../docker-adapter/src/test/resources/ ./_context/adapter
+cp -rfv ./prepMinio.sh ../artipie-main/src/test/resources/minio-bin-20231120.txz ./_context/
+DOCKER_VER="1.0"
+docker build --progress=plain --build-arg DOCKER_VER="$DOCKER_VER" -t "artipie/docker-tests:$DOCKER_VER" _context -f ./Dockerfile.docker
+# Caching test images. Needs privileged mode.
+TMP_CONT="local-artipie-docker-test-cache"
+docker stop "$TMP_CONT" || :
+docker container rm "$TMP_CONT" || :
+docker run --name "$TMP_CONT" --privileged artipie/docker-tests:1.0 sh -c 'rc-service docker start;sleep 0.5;docker pull alpine:3.11;docker pull alpine:3.19.1;docker pull debian:stable-slim;rc-service docker stop;sleep 0.5;'
+hash=$(docker commit "$TMP_CONT")
+docker tag "$hash" "artipie/docker-tests:$DOCKER_VER"
+docker stop "$TMP_CONT"
+docker container rm "$TMP_CONT"
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/file-repo ./_context/
+cp -rfv ../pypi-adapter/src/test/resources/ ./_context/adapter
+FILE_VER="1.0"
+docker build --progress=plain --build-arg FILE_VER="$FILE_VER" -t "artipie/file-tests:$FILE_VER" _context -f ./Dockerfile.file
+
+rm -rf ./_context
+
+mkdir -p ./_context/adapter
+cp -rfv ../artipie-main/src/test/resources/helm ./_context/
+cp -rfv ../helm-adapter/src/test/resources/ ./_context/adapter
+HELM_VER="1.0"
+docker build --progress=plain --build-arg FILE_VER="$HELM_VER" -t "artipie/helm-tests:$HELM_VER" _context -f ./Dockerfile.helm
+
+rm -rf ./_context

--- a/test_images/fetchPomDeps.sh
+++ b/test_images/fetchPomDeps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 path" && exit 1
+fi
+
+pom="$1"
+groupId=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='groupId']/text()" "$pom")
+artifactId=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='artifactId']/text()" "$pom")
+version=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" "$pom")
+artifact="${groupId}:${artifactId}:${version}"
+mvn -B -e -f "$pom" dependency:go-offline
+mvn -B -e -f "$pom" dependency:go-offline deploy -Dmaven.deploy.skip=true -Dartifact="$artifact"
+mvn -B -e -f "$pom" versions:set -DnewVersion=1.0-SNAPSHOT

--- a/test_images/prepMinio.sh
+++ b/test_images/prepMinio.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -ex
+baseDir="$(dirname $0)"
+cd "$baseDir"
+tar xf /w/minio-bin-20231120.txz -C /root
+/root/bin/minio server /var/minio > /tmp/minio.log 2>&1 &
+timeout 30 sh -c "until nc -z localhost 9000; do sleep 0.1; done;"
+/root/bin/mc alias set srv1 http://localhost:9000 minioadmin minioadmin 2>&1 |tee /tmp/mc.log
+/root/bin/mc mb srv1/buck1 --region s3test 2>&1|tee -a /tmp/mc.log
+/root/bin/mc anonymous set public srv1/buck1 2>&1|tee -a /tmp/mc.log
+rm -f /tmp/mc.log /tmp/minio.log

--- a/test_images/upload.sh
+++ b/test_images/upload.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+docker push artipie/conan-tests:1.0
+docker push artipie/conda-tests:1.0
+docker push artipie/deb-tests:1.0
+docker push artipie/docker-tests:1.0
+docker push artipie/file-tests:1.0
+docker push artipie/helm-tests:1.0
+docker push artipie/maven-tests:1.0
+docker push artipie/pypi-tests:1.0
+docker push artipie/rpm-tests-fedora:1.0
+docker push artipie/rpm-tests-ubi:1.0


### PR DESCRIPTION
Optimizing integration test run time in CI by prebuilt docker images. Part of https://github.com/artipie/artipie/issues/1352
Implementation details:
1. Use single integration test client image per test(adapter) type, whenever possible. It reduces total download time and size, plus provides smaller total docker cache footprint. This is important optimization for both, local test runs and GitHub CI test runs.
2. Tests-related docker images are built by script from the set of Dockerfiles. Images are pushed to artipie Docker account by another script. IT tests reference target base image by its name and version, e.g. `artipie/maven-tests:1.0`.
3. Since base images for tests rarely change, they must be rebuilt and pushed manually. After making changes, new version for the test image must be assigned, for example `artipie/maven-tests:1.0` -> `artipie/maven-tests:1.1`.
4. Third-party packages are fetched and installed when test docker images are built, not on test start. It also reduces run time of every test, plus reduces probability of spurious test fails due to internet issues.
5. For Artipie server and maven client, AppCDS JVM cache is generated inside docker containers + Tier 1 JVM JIT mode is enforced to reduce startup time of every related test. Since our tests mostly run for short periods of time fast startup much more important than performance in the long term.