### PR TITLE
fix for branch "jdk17-build" broken 

### DIFF
--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -316,7 +316,7 @@ SOFTWARE.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>21</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
config for the maven-compiler-plugin adjusted (21->17)