### PR TITLE
fix for missing dependencies httpcore5/httpcore5-h2 (#1447)

### DIFF
--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -102,6 +102,16 @@ SOFTWARE.
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${httpcore5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>${httpcore5-h2.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,8 @@ SOFTWARE.
     <maven.compiler.release>17</maven.compiler.release>
     <header.license>LICENSE.header</header.license>
     <httpclient.version>5.3.1</httpclient.version>
+    <httpcore5.version>5.2.4</httpcore5.version>
+    <httpcore5-h2.version>5.2.4</httpcore5-h2.version>
   </properties>
   <distributionManagement>
     <repository>


### PR DESCRIPTION
I investigated this problem a little bit and I think it's some sort of a maven problem while packaging the uber-jar because it's a transitive dependency (that's the reason while it compiles without an error)
```
[INFO] +- org.apache.httpcomponents.client5:httpclient5:jar:5.3.1:compile
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.2.4:compile
[INFO] |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2.4:compile
```
I decided to put the dependencies into the artipie-main's pom because the jar-packaging is defined here.
Locally I checked the outcome and the "org.apache.hc.core5.*" classes are packaged into the jar now.
The version was set according to:
https://repo1.maven.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.pom
