### PR TITLE
fix for missing dependencies httpcore5/httpcore5-h2 (#1447)

### DIFF
--- a/artipie-main/pom.xml
+++ b/artipie-main/pom.xml
@@ -101,6 +101,16 @@ SOFTWARE.
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${httpcore5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>${httpcore5-h2.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,8 @@ SOFTWARE.
     <s3mock.version>3.4.0</s3mock.version>
     <bouncycastle-lts.version>2.73.5</bouncycastle-lts.version>
     <httpclient.version>5.3.1</httpclient.version>
+    <httpcore5.version>5.2.4</httpcore5.version>
+    <httpcore5-h2.version>5.2.4</httpcore5-h2.version>
   </properties>
   <developers>
     <!-- Required for publishing to central -->


### PR DESCRIPTION
see #1452 